### PR TITLE
Fix personas directory path resolution for production environments

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -125,13 +125,13 @@ echo
 echo "🔄 After updating the configuration:"
 echo "   1. Save the configuration file"
 echo "   2. Restart Claude Desktop completely"
-echo "   3. All 17 DollhouseMCP tools will be available in your next conversation"
+echo "   3. All 23 DollhouseMCP tools will be available in your next conversation"
 echo
 echo "🎯 Quick Test:"
 echo "   Try using 'list_personas' tool in Claude to verify the installation works"
 echo
 echo "📚 Documentation:"
-echo "   Repository: https://github.com/mickdarling/DollhouseMCP"
-echo "   Marketplace: https://github.com/mickdarling/DollhouseMCP-Personas"
+echo "   Repository: https://github.com/DollhouseMCP/mcp-server"
+echo "   Marketplace: https://github.com/DollhouseMCP/personas"
 echo
 echo "🎭 Happy persona management!"

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import * as fs from "fs/promises";
 import * as path from "path";
+import { fileURLToPath } from "url";
 import matter from "gray-matter";
 import { loadIndicatorConfig, formatIndicator, validateCustomFormat, type IndicatorConfig } from './config/indicator-config.js';
 import { SecureYamlParser } from './security/secureYamlParser.js';
@@ -64,8 +65,12 @@ export class DollhouseMCPServer implements IToolHandler {
       }
     );
 
-    // Use environment variable if set, otherwise default to personas subdirectory relative to current working directory
-    this.personasDir = process.env.PERSONAS_DIR || path.join(process.cwd(), "personas");
+    // Get the directory of this file for proper path resolution
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = path.dirname(__filename);
+    
+    // Use environment variable if set, otherwise default to personas subdirectory relative to the project root
+    this.personasDir = process.env.PERSONAS_DIR || path.join(__dirname, "..", "personas");
     
     // Load user identity from environment variables
     this.currentUser = process.env.DOLLHOUSE_USER || null;


### PR DESCRIPTION
## Summary
Fixes the critical error where the MCP server tries to create `/personas` at the filesystem root, causing permission errors on startup.

## Problem
The server was failing with:
```
Error: ENOENT: no such file or directory, mkdir '/personas'
```

This happens because the code was using `process.cwd()` which could return `/` if the server was started from the root directory.

## Solution
Changed the personas directory path resolution from:
```typescript
path.join(process.cwd(), "personas")
```

To:
```typescript
path.join(__dirname, "..", "personas")
```

This ensures the personas directory is created relative to the project root, not the current working directory.

## Changes
- Added ES module `__dirname` equivalent using `fileURLToPath` and `import.meta.url`
- Updated personas path to be relative to the compiled file location
- Ensures consistent behavior regardless of where the server is executed from

## Testing
The server should now:
1. Create the personas directory in the project root
2. Work correctly regardless of the current working directory
3. Not require administrator/root privileges

🤖 Generated with [Claude Code](https://claude.ai/code)