### PR TITLE
Fix MCP protocol compatibility by replacing console output

### DIFF
--- a/src/marketplace/GitHubClient.ts
+++ b/src/marketplace/GitHubClient.ts
@@ -6,6 +6,7 @@ import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { APICache } from '../cache/APICache.js';
 import { SECURITY_LIMITS } from '../security/constants.js';
 import { SecureTokenManager, TokenScope } from '../security/tokenManager.js';
+import { logger } from '../utils/logger.js';
 
 export class GitHubClient {
   private apiCache: APICache;
@@ -61,7 +62,7 @@ export class GitHubClient {
           headers['Authorization'] = `Bearer ${token}`;
         } catch (tokenError) {
           // Log error but continue without token
-          console.log('GitHub token validation failed, proceeding without authentication');
+          logger.info('GitHub token validation failed, proceeding without authentication');
         }
       }
       

--- a/src/persona/PersonaLoader.ts
+++ b/src/persona/PersonaLoader.ts
@@ -9,6 +9,7 @@ import { Persona, PersonaMetadata } from '../types/persona.js';
 import { ensureDirectory, generateUniqueId } from '../utils/filesystem.js';
 import { SecureYamlParser } from '../security/secureYamlParser.js';
 import { SecurityError } from '../errors/SecurityError.js';
+import { logger } from '../utils/logger.js';
 
 export class PersonaLoader {
   private personasDir: string;
@@ -35,14 +36,14 @@ export class PersonaLoader {
           const persona = await this.loadPersona(file, getCurrentUser);
           if (persona) {
             personas.set(file, persona);
-            console.error(`Loaded persona: ${persona.metadata.name} (${persona.unique_id})`);
+            logger.error(`Loaded persona: ${persona.metadata.name} (${persona.unique_id})`);
           }
         } catch (error) {
-          console.error(`Error loading persona ${file}: ${error}`);
+          logger.error(`Error loading persona ${file}: ${error}`);
         }
       }
     } catch (error) {
-      console.error(`Error reading personas directory: ${error}`);
+      logger.error(`Error reading personas directory: ${error}`);
     }
     
     return personas;
@@ -62,7 +63,7 @@ export class PersonaLoader {
         parsed = SecureYamlParser.safeMatter(fileContent);
       } catch (error) {
         if (error instanceof SecurityError) {
-          console.error(`Security threat detected in persona ${filename}: ${error.message}`);
+          logger.error(`Security threat detected in persona ${filename}: ${error.message}`);
           return null;
         }
         throw error;
@@ -80,7 +81,7 @@ export class PersonaLoader {
       if (!uniqueId) {
         const authorForId = metadata.author || getCurrentUser() || undefined;
         uniqueId = generateUniqueId(metadata.name, authorForId);
-        console.error(`Generated unique ID for ${metadata.name}: ${uniqueId}`);
+        logger.error(`Generated unique ID for ${metadata.name}: ${uniqueId}`);
       }
       
       // Set default values for metadata fields
@@ -95,7 +96,7 @@ export class PersonaLoader {
       
       return persona;
     } catch (error) {
-      console.error(`Error loading persona ${filename}: ${error}`);
+      logger.error(`Error loading persona ${filename}: ${error}`);
       return null;
     }
   }

--- a/src/tools/debug.ts
+++ b/src/tools/debug.ts
@@ -1,0 +1,49 @@
+/**
+ * Debug tools for retrieving server logs
+ */
+
+import { logger } from '../utils/logger.js';
+
+export interface GetLogsArgs {
+  count?: number;
+  level?: 'debug' | 'info' | 'warn' | 'error';
+}
+
+export async function getServerLogs(args: GetLogsArgs) {
+  const { count = 100, level } = args;
+  
+  const logs = logger.getLogs(count, level);
+  
+  // Format logs for display
+  const formattedLogs = logs.map(log => {
+    const timestamp = log.timestamp.toISOString();
+    const logLevel = log.level.toUpperCase().padEnd(5);
+    const message = log.data 
+      ? `${log.message} ${JSON.stringify(log.data, null, 2)}`
+      : log.message;
+    
+    return `[${timestamp}] [${logLevel}] ${message}`;
+  }).join('\n');
+  
+  return {
+    content: [
+      {
+        type: "text",
+        text: formattedLogs || "No logs found matching the criteria",
+      },
+    ],
+  };
+}
+
+export async function clearServerLogs() {
+  logger.clearLogs();
+  
+  return {
+    content: [
+      {
+        type: "text",
+        text: "Server logs cleared successfully",
+      },
+    ],
+  };
+}

--- a/src/update/BackupManager.ts
+++ b/src/update/BackupManager.ts
@@ -6,6 +6,7 @@ import * as fs from 'fs/promises';
 import * as fsSync from 'fs';
 import * as path from 'path';
 import { safeExec } from '../utils/git.js';
+import { logger } from '../utils/logger.js';
 
 export interface BackupInfo {
   path: string;
@@ -175,7 +176,7 @@ export class BackupManager {
       }
     } catch (error) {
       // Log warning but don't fail the backup
-      console.error('Warning: Could not backup all personas:', error);
+      logger.warn('Could not backup all personas:', error);
     }
     
     // Save backup metadata
@@ -296,7 +297,7 @@ export class BackupManager {
           await fs.rm(backup.path, { recursive: true, force: true });
           deletedCount++;
         } catch (error) {
-          console.error(`Failed to delete backup ${backup.path}:`, error);
+          logger.error(`Failed to delete backup ${backup.path}:`, error);
         }
       }
     }

--- a/src/update/SignatureVerifier.ts
+++ b/src/update/SignatureVerifier.ts
@@ -13,6 +13,7 @@ import * as crypto from 'crypto';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { randomBytes } from 'crypto';
+import { logger } from '../utils/logger.js';
 
 export interface SignatureVerificationResult {
   verified: boolean;
@@ -253,7 +254,7 @@ export class SignatureVerifier {
       }
       
     } catch (error) {
-      console.error('Failed to import GPG key:', error);
+      logger.error('Failed to import GPG key:', error);
       return false;
     }
   }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,104 @@
+/**
+ * MCP-safe logger that avoids writing to stdout/stderr during protocol communication
+ * 
+ * In MCP servers, stdout and stderr are reserved for JSON-RPC protocol messages.
+ * Any non-protocol output will cause "Unexpected token" errors in the MCP client.
+ * 
+ * This logger:
+ * - Writes to stderr ONLY during server initialization (before MCP connection)
+ * - Stores all logs in memory during runtime
+ * - Provides methods to retrieve logs via MCP tools if needed
+ */
+
+interface LogEntry {
+  timestamp: Date;
+  level: 'debug' | 'info' | 'warn' | 'error';
+  message: string;
+  data?: any;
+}
+
+class MCPLogger {
+  private logs: LogEntry[] = [];
+  private maxLogs = 1000;
+  private isMCPConnected = false;
+  
+  /**
+   * Call this after MCP connection is established to stop console output
+   */
+  public setMCPConnected(): void {
+    this.isMCPConnected = true;
+  }
+  
+  /**
+   * Internal logging method
+   */
+  private log(level: LogEntry['level'], message: string, data?: any): void {
+    const entry: LogEntry = {
+      timestamp: new Date(),
+      level,
+      message,
+      data
+    };
+    
+    // Store in memory
+    this.logs.push(entry);
+    if (this.logs.length > this.maxLogs) {
+      this.logs.shift();
+    }
+    
+    // Only write to console during initialization
+    if (!this.isMCPConnected) {
+      const prefix = `[${entry.timestamp.toISOString()}] [${level.toUpperCase()}]`;
+      const fullMessage = data 
+        ? `${prefix} ${message} ${JSON.stringify(data)}`
+        : `${prefix} ${message}`;
+      
+      // During initialization, we can use console
+      if (level === 'error') {
+        console.error(fullMessage);
+      } else if (level === 'warn') {
+        console.warn(fullMessage);
+      } else {
+        // For MCP, even during init, avoid stdout for info/debug
+        console.error(fullMessage);
+      }
+    }
+  }
+  
+  public debug(message: string, data?: any): void {
+    this.log('debug', message, data);
+  }
+  
+  public info(message: string, data?: any): void {
+    this.log('info', message, data);
+  }
+  
+  public warn(message: string, data?: any): void {
+    this.log('warn', message, data);
+  }
+  
+  public error(message: string, data?: any): void {
+    this.log('error', message, data);
+  }
+  
+  /**
+   * Get recent logs (for MCP tools to retrieve)
+   */
+  public getLogs(count = 100, level?: LogEntry['level']): LogEntry[] {
+    let filtered = this.logs;
+    if (level) {
+      filtered = this.logs.filter(log => log.level === level);
+    }
+    return filtered.slice(-count);
+  }
+  
+  /**
+   * Clear logs
+   */
+  public clearLogs(): void {
+    this.logs = [];
+  }
+}
+
+// Singleton instance
+export const logger = new MCPLogger();


### PR DESCRIPTION
## Summary
Fixes critical issue where console output was breaking the MCP JSON-RPC protocol, causing "Unexpected token" errors and connection failures in Claude Desktop.

## Problem
The MCP (Model Context Protocol) uses stdout and stderr for JSON-RPC communication. Any non-JSON output (like console.error, console.log) breaks the protocol and causes parsing errors:
```
Unexpected token 'S', "[SECURITY] "... is not valid JSON
```

## Solution
Created an MCP-safe logger that:
1. Only writes to stderr during server initialization (before MCP connection)
2. Stores all logs in memory during protocol communication
3. Prevents any non-JSON output that would break the protocol

## Changes
- Created `src/utils/logger.ts` - MCP-safe logging utility
- Replaced all console.error/warn/log calls across the codebase:
  - `src/index.ts` - Main server file
  - `src/security/securityMonitor.ts` - Security monitoring
  - `src/update/BackupManager.ts` - Backup operations
  - `src/update/SignatureVerifier.ts` - GPG signature verification
  - `src/marketplace/GitHubClient.ts` - GitHub API client
  - `src/persona/PersonaLoader.ts` - Persona loading
- Added `src/tools/debug.ts` - Future enhancement for log retrieval via MCP

## Technical Details
The logger:
- Uses a circular buffer (1000 entries max) to store logs in memory
- Has a `setMCPConnected()` method called after protocol handshake
- Provides `debug()`, `info()`, `warn()`, `error()` methods
- Includes `getLogs()` and `clearLogs()` for future MCP tools

## Testing
- Built successfully with TypeScript
- All console calls have been replaced
- Logger only outputs during initialization phase

## Impact
This fix is critical for v1.2.4 release as it resolves connection failures reported by multiple users.

🤖 Generated with [Claude Code](https://claude.ai/code)