### PR TITLE
Fix PathValidator CI failure by ensuring directory creation before atomic write

### DIFF
--- a/src/security/pathValidator.ts
+++ b/src/security/pathValidator.ts
@@ -107,6 +107,10 @@ export class PathValidator {
       throw new Error('Content too large');
     }
     
+    // Ensure directory exists before atomic write
+    const dirPath = path.dirname(validatedPath);
+    await fs.mkdir(dirPath, { recursive: true });
+    
     // Write to temp file first (atomic write)
     const tempPath = `${validatedPath}.tmp`;
     await fs.writeFile(tempPath, content, 'utf-8');


### PR DESCRIPTION
## Summary
This PR fixes the PathValidator atomic write test failure that was occurring in CI environments (Ubuntu, Windows, macOS) by ensuring the target directory exists before attempting atomic file operations.

## Problem
The security test suite was failing in CI with:
```
ENOENT: no such file or directory, open '/tmp/test-personas/test-file.md.tmp'
```

This was the single remaining test failure (695/696 passing) preventing 100% CI success after the security infrastructure deployment.

## Root Cause Analysis
The `PathValidator.safeWriteFile()` method performs atomic writes by:
1. Creating a temporary file (`/path/to/file.md.tmp`)
2. Renaming it to the final path (`/path/to/file.md`)

However, in CI environments, the directory `/tmp/test-personas/` doesn't exist, causing step 1 to fail with ENOENT.

## Solution
Added directory creation before the atomic write operation:
```typescript
// Ensure directory exists before atomic write
const dirPath = path.dirname(validatedPath);
await fs.mkdir(dirPath, { recursive: true });
```

This approach:
- ✅ **Safe**: Path is already validated by `validatePersonaPath()`
- ✅ **Minimal**: Only creates the necessary directory structure
- ✅ **Atomic**: Preserves existing atomic write behavior
- ✅ **Cross-platform**: Works on all CI environments

## Changes Made
**File**: `src/security/pathValidator.ts`
- **Lines 111-112**: Added directory creation before atomic write
- **Method**: `fs.mkdir(dirPath, { recursive: true })`
- **Impact**: Ensures parent directories exist without changing security validation

## Testing Results
### Local Testing ✅
```bash
npm test  # 696/696 tests passing
npm test -- __tests__/security/tests/security-validators.test.ts  # Specific test passing
```

### Expected CI Results
- ✅ **Ubuntu, Windows, macOS**: Should now pass PathValidator test
- ✅ **696/696 tests**: Full CI success expected
- ✅ **Security framework**: No impact on 53/53 security tests

## Security Considerations
- **No security regression**: Directory creation only occurs after path validation
- **Path traversal protection**: Maintained through existing `validatePersonaPath()`
- **Atomic writes preserved**: File operations remain atomic and safe
- **Minimal permissions**: Only creates necessary directories

## Related Issues
- **Fixes**: Issue #226 - Fix CI PathValidator Test  
- **Part of**: Three-phase deployment plan after PR #225 (Security Infrastructure)
- **Enables**: Phase 3 - Issue #227 (Post-Integration Validation)

## Impact Assessment
This is a **targeted CI fix** with:
- **Low risk**: Minimal change to well-tested path validation logic
- **High value**: Achieves 100% CI test success rate
- **Clean scope**: Isolated to single test failure issue
- **Fast execution**: No performance impact

## Review Checklist
- [ ] Verify directory creation logic is correct
- [ ] Confirm atomic write behavior is preserved  
- [ ] Check that security validation remains intact
- [ ] Validate CI environments will pass

## Follow-up Work
After this PR merges:
1. **Verify 696/696 CI success** across all platforms
2. **Begin Issue #227**: Post-integration validation
3. **Complete three-phase deployment** of security infrastructure

This fix completes **Phase 2** of our strategic deployment plan and enables comprehensive system validation in **Phase 3**.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>