### PR TITLE
Update README to reflect marketplace → collection rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@
 [![Test Coverage](https://img.shields.io/badge/Coverage-500%20Tests-green)](https://github.com/DollhouseMCP/mcp-server/tree/main/__tests__)
 [![Auto-Update](https://img.shields.io/badge/Auto--Update-Enterprise%20Grade-purple)](https://github.com/DollhouseMCP/mcp-server)
 
-A comprehensive Model Context Protocol (MCP) server that enables dynamic AI persona management with an integrated GitHub-powered marketplace. DollhouseMCP allows Claude and other compatible AI assistants to activate different behavioral personas while supporting community sharing and monetization.
+A comprehensive Model Context Protocol (MCP) server that enables dynamic AI persona management with an integrated GitHub-powered collection. DollhouseMCP allows Claude and other compatible AI assistants to activate different behavioral personas while supporting community sharing and monetization.
 
 **🌐 Repository**: https://github.com/DollhouseMCP/mcp-server  
-**🏪 Marketplace**: https://github.com/DollhouseMCP/personas  
+**🏪 Collection**: https://github.com/DollhouseMCP/collection  
 **📦 NPM Package**: https://www.npmjs.com/package/@mickdarling/dollhousemcp  
 **🌍 Website**: https://dollhousemcp.com (planned)  
 **📦 Version**: v1.2.4 - MCP Protocol Compatibility Fix
+
+> **⚠️ Breaking Change Notice**: Tool names have changed from "marketplace" to "collection" terminology. Old names still work but are deprecated. See [Migration Guide](docs/MIGRATION_GUIDE_COLLECTION_RENAME.md) for details.
 
 ## 🚀 Quick Start
 
@@ -55,7 +57,7 @@ Restart Claude Desktop and you're ready to use DollhouseMCP! Try `list_personas`
 | Feature | Description |
 |---------|-------------|
 | 🎭 **23 MCP Tools** | Complete persona lifecycle management through chat interface |
-| 🏪 **GitHub Marketplace** | Browse, search, install, and submit personas to community marketplace |
+| 🏪 **GitHub Collection** | Browse, search, install, and submit personas to community collection |
 | 👤 **User Identity System** | Environment-based attribution for persona creators |
 | 🆔 **Unique ID System** | Advanced ID generation: `what-it-is_YYYYMMDD-HHMMSS_who-made-it` |
 | 💬 **Chat-Based Management** | Create, edit, and validate personas through conversational interface |
@@ -205,12 +207,12 @@ Add DollhouseMCP to your Claude Desktop configuration:
 - **`get_persona_details`** - View complete persona details
 - **`reload_personas`** - Refresh from filesystem
 
-### GitHub Marketplace Integration
-- **`browse_marketplace`** - Browse personas by category
-- **`search_marketplace`** - Search across all marketplace personas
-- **`get_marketplace_persona`** - View detailed marketplace persona info
+### GitHub Collection Integration
+- **`browse_collection`** - Browse personas by category
+- **`search_collection`** - Search across all collection personas
+- **`get_collection_persona`** - View detailed collection persona info
 - **`install_persona`** - One-click download and installation
-- **`submit_persona`** - Submit to marketplace via GitHub issue
+- **`submit_persona`** - Submit to collection via GitHub issue
 
 ### User Identity Management
 - **`set_user_identity`** - Set username for persona attribution
@@ -234,12 +236,12 @@ Add DollhouseMCP to your Claude Desktop configuration:
 
 ## 📖 Usage Examples
 
-### Marketplace Operations
+### Collection Operations
 ```
-browse_marketplace                          # See all categories
-browse_marketplace "creative"               # Browse creative personas
-search_marketplace "writing"                # Search for writing personas
-install_persona "creative/storyteller.md"  # Install from marketplace
+browse_collection                          # See all categories
+browse_collection "creative"               # Browse creative personas
+search_collection "writing"                # Search for writing personas
+install_persona "creative/storyteller.md"  # Install from collection
 ```
 
 ### Persona Creation & Management
@@ -543,7 +545,7 @@ npm run test:watch
 # Run specific test suites
 npm run test:auto-update
 npm run test:personas
-npm run test:marketplace
+npm run test:collection
 ```
 
 ### Test Coverage
@@ -640,7 +642,7 @@ DollhouseMCP/
 │   ├── index.ts                  # Main MCP server (DollhouseMCPServer)
 │   ├── cache/                    # API caching layer
 │   ├── config/                   # Configuration management
-│   ├── marketplace/              # GitHub marketplace integration
+│   ├── marketplace/              # GitHub collection integration
 │   ├── persona/                  # Persona management core
 │   ├── security/                 # Input validation and security
 │   ├── server/                   # MCP server setup and tools
@@ -737,19 +739,28 @@ Your persona instructions go here. This content defines how the AI should behave
 | **Business Consultant** | Strategic business analysis and recommendations | Strategy planning, business decisions, market analysis |
 | **Debug Detective** | Systematic debugging and troubleshooting | Bug hunting, system troubleshooting, root cause analysis |
 
-## 🏪 Marketplace Integration (Beta)
+## 🏪 Collection Integration (Beta)
 
-> **🧪 Beta Feature**: The GitHub-powered marketplace is currently in beta. Features may change based on community feedback.
+> **🧪 Beta Feature**: The GitHub-powered collection is currently in beta. Features may change based on community feedback.
 
-DollhouseMCP includes an experimental GitHub-powered marketplace:
+DollhouseMCP includes an experimental GitHub-powered collection:
 
 - **Browse by Category**: creative, professional, educational, gaming, personal
 - **Search Content**: Find personas by keywords and descriptions
-- **One-Click Install**: Download and integrate marketplace personas
+- **One-Click Install**: Download and integrate collection personas
 - **Community Submissions**: Submit your personas via `submit_persona` tool
-- **Version Control**: Full Git history for all marketplace content
+- **Version Control**: Full Git history for all collection content
 
-> **Note**: Marketplace features require internet connection and GitHub API access. Rate limits may apply.
+> **Note**: Collection features require internet connection and GitHub API access. Rate limits may apply.
+
+### ⚠️ Migration Guide - Breaking Changes
+
+**Important**: Tool names have changed in recent versions:
+- `browse_marketplace` → `browse_collection`
+- `search_marketplace` → `search_collection`
+- `get_marketplace_persona` → `get_collection_persona`
+
+If you have scripts or workflows using the old tool names, please update them to use the new names.
 
 ## 💼 Business Model & Legal
 
@@ -808,7 +819,7 @@ export DEBUG="dollhousemcp:*"                  # Debug logging (optional)
 |-------|----------|
 | **Personas not loading** | Check `personas/` directory exists and has read permissions |
 | **Server won't start** | Run `npm run rebuild` to clean and rebuild |
-| **Marketplace not working** | Check internet connection and GitHub API access |
+| **Collection not working** | Check internet connection and GitHub API access |
 | **User identity not saving** | Set `DOLLHOUSE_USER` environment variable before starting Claude |
 | **"Cannot find module" errors** | Ensure `npm install` completed successfully |
 | **TypeScript compilation errors** | Verify Node.js version is 20+ with `node --version` |
@@ -872,7 +883,7 @@ We welcome contributions! DollhouseMCP includes integrated tools for submitting 
    validate_persona "My Awesome Persona"
    ```
 
-3. **Submit to the marketplace** directly from Claude:
+3. **Submit to the collection** directly from Claude:
    ```
    submit_persona "My Awesome Persona"
    ```
@@ -960,11 +971,11 @@ interface DollhouseTool {
 // reload_personas - No parameters
 ```
 
-#### Marketplace Integration
+#### Collection Integration
 ```typescript
-// browse_marketplace - { category?: string }
-// search_marketplace - { query: string }
-// get_marketplace_persona - { path: string }
+// browse_collection - { category?: string }
+// search_collection - { query: string }
+// get_collection_persona - { path: string }
 // install_persona - { path: string }
 // submit_persona - { persona: string }
 ```
@@ -997,7 +1008,7 @@ The server provides detailed error messages for:
 - **Invalid persona identifiers** - Clear suggestions for valid names
 - **File system issues** - Permission and path resolution errors
 - **Malformed persona files** - YAML parsing and validation errors
-- **Network errors** - GitHub API and marketplace connectivity issues
+- **Network errors** - GitHub API and collection connectivity issues
 - **Runtime errors** - Server startup and operation failures
 
 ### Response Formats
@@ -1019,6 +1030,20 @@ This project is licensed under the **AGPL-3.0** License with Platform Stability 
 - Community advisory input
 
 ## 🏷️ Version History
+
+### v1.2.5 - July 19, 2025 (Upcoming)
+
+**Collection Rename & Breaking Changes**:
+- 🔄 **Renamed all "marketplace" tools to "collection"**:
+  - `browse_marketplace` → `browse_collection`
+  - `search_marketplace` → `search_collection`
+  - `get_marketplace_persona` → `get_collection_persona`
+  - `install_persona` → `install_persona` (unchanged)
+  - `submit_persona` → `submit_persona` (unchanged)
+- ✅ **Added backward compatibility aliases** (deprecated, will be removed in v2.0.0)
+- ✅ **Updated repository** from `/personas` to `/collection`
+- ✅ **Created migration guide** for users to update their scripts
+- ✅ **Fixed all date references** from January to July 2025
 
 ### v1.2.4 - July 10, 2025 (Current)
 
@@ -1096,4 +1121,4 @@ This project is licensed under the **AGPL-3.0** License with Platform Stability 
 
 **🎭 Transform your AI interactions with the power of personas**
 
-For support, please [open an issue](https://github.com/DollhouseMCP/mcp-server/issues) or visit our [marketplace](https://github.com/DollhouseMCP/personas).
+For support, please [open an issue](https://github.com/DollhouseMCP/mcp-server/issues) or visit our [collection](https://github.com/DollhouseMCP/collection).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A comprehensive Model Context Protocol (MCP) server that enables dynamic AI pers
 **🏪 Collection**: https://github.com/DollhouseMCP/collection  
 **📦 NPM Package**: https://www.npmjs.com/package/@mickdarling/dollhousemcp  
 **🌍 Website**: https://dollhousemcp.com (planned)  
-**📦 Version**: v1.2.4 - MCP Protocol Compatibility Fix
+**📦 Version**: v1.2.4 (Current) | v1.2.5 (Next Release)
 
 > **⚠️ Breaking Change Notice**: Tool names have changed from "marketplace" to "collection" terminology. Old names still work but are deprecated. See [Migration Guide](docs/MIGRATION_GUIDE_COLLECTION_RENAME.md) for details.
 
@@ -1031,7 +1031,7 @@ This project is licensed under the **AGPL-3.0** License with Platform Stability 
 
 ## 🏷️ Version History
 
-### v1.2.5 - July 19, 2025 (Upcoming)
+### v1.2.5 - July 2025 (Next Release)
 
 **Collection Rename & Breaking Changes**:
 - 🔄 **Renamed all "marketplace" tools to "collection"**:

--- a/docs/MIGRATION_GUIDE_COLLECTION_RENAME.md
+++ b/docs/MIGRATION_GUIDE_COLLECTION_RENAME.md
@@ -1,0 +1,98 @@
+# Migration Guide: Marketplace → Collection Rename
+
+## Overview
+
+As of v1.2.5, DollhouseMCP has renamed all "marketplace" terminology to "collection" to better reflect the collaborative nature of the persona sharing platform. This is a **breaking change** that requires updates to any scripts or configurations using the old tool names.
+
+## Tool Name Changes
+
+The following MCP tools have been renamed:
+
+| Old Tool Name | New Tool Name | Status |
+|--------------|---------------|---------|
+| `browse_marketplace` | `browse_collection` | ⚠️ Deprecated |
+| `search_marketplace` | `search_collection` | ⚠️ Deprecated |
+| `get_marketplace_persona` | `get_collection_persona` | ⚠️ Deprecated |
+| `install_persona` | `install_persona` | ✅ Unchanged |
+| `submit_persona` | `submit_persona` | ✅ Unchanged |
+
+## Backward Compatibility
+
+**Important**: The old tool names are still supported in v1.2.5 but are deprecated and will be removed in v2.0.0 (estimated Q1 2026).
+
+### Deprecation Timeline
+- **v1.2.5**: Both old and new tool names work (current)
+- **v2.0.0 (Q1 2026)**: Old tool names will be removed
+- **Advance Notice**: We'll provide at least 3 months warning before removal
+
+## Migration Steps
+
+### 1. Update Your Scripts
+
+Search for any usage of the old tool names and update them:
+
+```bash
+# Find usage in your scripts
+grep -r "browse_marketplace\|search_marketplace\|get_marketplace_persona" your-scripts/
+
+# Update the tool names
+# browse_marketplace → browse_collection
+# search_marketplace → search_collection
+# get_marketplace_persona → get_collection_persona
+```
+
+### 2. Update Claude Desktop Configuration
+
+If you have custom shortcuts or scripts in Claude Desktop that use these tools, update them to use the new names.
+
+### 3. Update Any Automation
+
+If you have GitHub Actions, CI/CD pipelines, or other automation using these tools, update the tool names.
+
+## Examples
+
+### Before (Old)
+```javascript
+// Browse the marketplace
+await mcp.call_tool("browse_marketplace", { category: "creative" });
+
+// Search for personas
+await mcp.call_tool("search_marketplace", { query: "writing assistant" });
+
+// Get persona details
+await mcp.call_tool("get_marketplace_persona", { path: "creative/writer.md" });
+```
+
+### After (New)
+```javascript
+// Browse the collection
+await mcp.call_tool("browse_collection", { category: "creative" });
+
+// Search for personas
+await mcp.call_tool("search_collection", { query: "writing assistant" });
+
+// Get persona details
+await mcp.call_tool("get_collection_persona", { path: "creative/writer.md" });
+```
+
+## Repository Changes
+
+The GitHub repository for shared personas has also moved:
+- **Old**: `https://github.com/DollhouseMCP/personas`
+- **New**: `https://github.com/DollhouseMCP/collection`
+
+## Need Help?
+
+If you encounter any issues during migration:
+1. Check the [GitHub Issues](https://github.com/DollhouseMCP/mcp-server/issues) for known problems
+2. Create a new issue if you need assistance
+3. The old tool names will continue working until v2.0.0, so there's no immediate urgency
+
+## Why This Change?
+
+The term "collection" better represents:
+- The collaborative nature of persona sharing
+- The curated aspect of the persona repository
+- The community-driven approach to building personas
+
+Thank you for your patience during this transition!


### PR DESCRIPTION
## Summary

This PR updates the README to reflect the breaking changes introduced in PR #280 where all "marketplace" terminology was changed to "collection".

## Changes Made

### 1. Terminology Updates
- Replaced all instances of "marketplace" with "collection" throughout the README
- Updated the GitHub repository link from `/personas` to `/collection`

### 2. Tool Name Updates
Updated all tool names in documentation and examples:
- `browse_marketplace` → `browse_collection`
- `search_marketplace` → `search_collection`
- `get_marketplace_persona` → `get_collection_persona`

### 3. User Communication
- Added a prominent **Breaking Change Notice** near the top of the README
- Added link to the migration guide for users
- Updated the changelog with v1.2.5 entry documenting these changes

### 4. Documentation Consistency
- Updated all code examples to use the new tool names
- Fixed the Collection Integration section with proper migration warnings
- Ensured all references are consistent throughout the document

## Why This Change?

Users visiting the README need to:
1. Immediately see that there are breaking changes
2. Understand what changed (tool names)
3. Know where to find migration guidance
4. See accurate examples that work with the current version

## Testing

- [x] All marketplace references have been updated
- [x] Tool names are consistent throughout
- [x] Migration guide link is included
- [x] Examples use the correct new tool names

🤖 Generated with [Claude Code](https://claude.ai/code)