### PR TITLE
Fix: Update unique ID format documentation to match Collection standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Restart Claude Desktop and you're ready to use DollhouseMCP! Try `list_personas`
 | 🎭 **23 MCP Tools** | Complete persona lifecycle management through chat interface |
 | 🏪 **GitHub Collection** | Browse, search, install, and submit personas to community collection |
 | 👤 **User Identity System** | Environment-based attribution for persona creators |
-| 🆔 **Unique ID System** | Advanced ID generation: `what-it-is_YYYYMMDD-HHMMSS_who-made-it` |
+| 🆔 **Unique ID System** | Advanced ID generation: `{type}_{name}_{author}_{YYYYMMDD}-{HHMMSS}` |
 | 💬 **Chat-Based Management** | Create, edit, and validate personas through conversational interface |
 | 🔄 **Real-time Operations** | Live editing with automatic version bumping and validation |
 | 🚀 **Auto-Update System** | Enterprise-grade auto-update with backup/rollback and dependency validation |

--- a/docs/project/PROJECT_SUMMARY.md
+++ b/docs/project/PROJECT_SUMMARY.md
@@ -16,7 +16,7 @@ DollhouseMCP is a comprehensive Model Context Protocol (MCP) server that provide
 ### ✅ Phase 1: Foundation (Complete)
 - **Fresh Repository Setup**: Clean AGPL-3.0 licensed codebase
 - **Complete Rebranding**: From persona-mcp-server to DollhouseMCP
-- **Unique ID System**: `what-it-is_YYYYMMDD-HHMMSS_who-made-it` format
+- **Unique ID System**: `{type}_{name}_{author}_{YYYYMMDD}-{HHMMSS}` format
 - **Enhanced Metadata Schema**: Categories, pricing, AI flags, age ratings
 - **Anonymous User Support**: Auto-generated contributor IDs
 - **Backwards Compatibility**: Automatic ID generation for existing personas


### PR DESCRIPTION
## Summary
This PR updates all unique ID format documentation in the MCP server to match the format used in the Collection repository.

## Changes
Updates documentation from the old format:
```
what-it-is_YYYYMMDD-HHMMSS_who-made-it
```

To the Collection's format:
```
{type}_{name}_{author}_{YYYYMMDD}-{HHMMSS}
```

## Files Updated
- **README.md**: Updated unique ID system documentation
- **CLAUDE.md**: Updated both the summary and detailed unique ID sections with corrected examples
- **docs/project/PROJECT_SUMMARY.md**: Updated format reference

## Context
This change was requested to ensure consistency between the MCP server and Collection repositories. The Collection repository already uses the new format, so this brings the MCP server documentation in line.

## Examples of the new format
- `persona_creative-writer_dollhousemcp_20250701-150000`
- `persona_debug-detective_mick_20250701-154234`
- `persona_custom-persona_anon-clever-fox-x7k2_20250701-160000`

## Review Request
Please verify that all references to the unique ID format have been updated consistently across the documentation.