### PR TITLE
fix: Add CodeQL suppressions for intentional test patterns

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,25 @@
+name: "CodeQL config"
+
+# Paths to ignore during analysis
+paths-ignore:
+  - test/__tests__/security/regexValidator.test.ts
+
+# Query filters to exclude specific alerts
+query-filters:
+  - exclude:
+      id: js/polynomial-redos
+      paths:
+        - test/**/*.test.ts
+  - exclude:
+      id: js/redos
+      paths:
+        - test/**/*.test.ts
+  - exclude:
+      problem.severity: error
+      tags contain: "redos"
+      paths:
+        - "test/__tests__/security/**"
+
+# Additional documentation
+# These test files intentionally contain vulnerable regex patterns
+# to test our security validation mechanisms

--- a/test/__tests__/security/.codeql-supress
+++ b/test/__tests__/security/.codeql-supress
@@ -1,0 +1,12 @@
+# CodeQL Suppression File for Security Tests
+
+# This directory contains security test files that intentionally use vulnerable patterns
+# to test our security validation mechanisms. All ReDoS warnings should be suppressed.
+
+# Suppress all ReDoS warnings in regexValidator.test.ts
+query-id: js/polynomial-redos
+query-id: js/redos
+query-id: js/inefficient-regular-expression
+
+# These patterns are essential for testing our RegexValidator's ability to detect
+# and prevent Regular Expression Denial of Service (ReDoS) attacks.

--- a/test/__tests__/security/regexValidator.test.ts
+++ b/test/__tests__/security/regexValidator.test.ts
@@ -7,7 +7,13 @@
  * such dangerous patterns from being executed.
  * 
  * CodeQL warnings in this file are expected and should be suppressed.
+ * 
+ * @security-severity none
  */
+
+/* eslint-disable security/detect-unsafe-regex */
+// codeql[javascript/ql/src/Security/CWE-730/PolynomialReDoS.ql] = false
+// codeql[javascript/ql/src/Security/CWE-1333/ReDoS.ql] = false
 
 // codeql[js/redos]: This entire file tests ReDoS detection with intentionally vulnerable patterns
 


### PR DESCRIPTION
## Summary

This PR addresses CodeQL security alerts #82-92, which are all false positives in our security test files.

**Note**: This is a clean PR created from the develop branch after closing #430 which had conflicts.

## Problem

CodeQL is flagging 11 'Inefficient regular expression' errors in `regexValidator.test.ts`. These alerts are false positives because:
- The regex patterns are intentionally vulnerable
- They're used to test our RegexValidator's ability to detect ReDoS attacks
- They exist only in test files, not production code

## Solution

Added multiple layers of suppression:
1. **File-level documentation** - Enhanced header comments explaining the purpose
2. **ESLint directives** - Added `eslint-disable` for security rules
3. **CodeQL configuration** - Created `.github/codeql/codeql-config.yml` to exclude test patterns
4. **Local suppression** - Added `.codeql-suppress` file in test directory

## Verification

The test file already had clear documentation:
```javascript
/**
 * NOTE: This test file intentionally contains regex patterns that would cause
 * Regular Expression Denial of Service (ReDoS) attacks. These patterns are
 * used to verify that our RegexValidator correctly identifies and prevents
 * such dangerous patterns from being executed.
 */
```

## Impact

- Reduces noise in security scanning
- Preserves important security tests
- Makes real security issues more visible

## Related Issues

Addresses security alerts #82 through #92 (all 11 alerts)

🤖 Generated with [Claude Code](https://claude.ai/code)