### PR TITLE
Fix: Add content size validation to prevent memory exhaustion

### DIFF
--- a/test/__tests__/unit/server/content-size-validation.test.ts
+++ b/test/__tests__/unit/server/content-size-validation.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { DollhouseMCPServer } from '../../../../src/index.js';
+import { SECURITY_LIMITS } from '../../../../src/security/constants.js';
+import path from 'path';
+import fs from 'fs/promises';
+import os from 'os';
+
+describe('Content Size Validation', () => {
+  let server: DollhouseMCPServer;
+  let testDir: string;
+
+  beforeEach(async () => {
+    // Create a temporary test directory
+    testDir = path.join(os.tmpdir(), `content-size-test-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+    
+    // Initialize server with test directory
+    server = new DollhouseMCPServer();
+    (server as any).personasDir = testDir;
+    (server as any).portfolioDir = testDir;
+  });
+
+  afterEach(async () => {
+    // Clean up test directory
+    try {
+      await fs.rm(testDir, { recursive: true, force: true });
+    } catch (error) {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe('createElement with large content', () => {
+    it('should reject content exceeding MAX_CONTENT_LENGTH', async () => {
+      // Create content that exceeds the limit
+      const largeContent = 'x'.repeat(SECURITY_LIMITS.MAX_CONTENT_LENGTH + 1);
+      
+      const result = await server.createElement({
+        name: 'test-skill',
+        type: 'skills',
+        description: 'Test skill',
+        content: largeContent
+      });
+
+      expect(result.content[0].text).toContain('❌ Content too large');
+      expect(result.content[0].text).toContain(`${SECURITY_LIMITS.MAX_CONTENT_LENGTH} characters`);
+      expect(result.content[0].text).toContain(`${Math.floor(SECURITY_LIMITS.MAX_CONTENT_LENGTH / 1024)}KB`);
+    });
+
+    it('should accept content at exactly MAX_CONTENT_LENGTH', async () => {
+      // Create content at exactly the limit
+      const maxContent = 'x'.repeat(SECURITY_LIMITS.MAX_CONTENT_LENGTH);
+      
+      const result = await server.createElement({
+        name: 'test-skill',
+        type: 'skills',
+        description: 'Test skill',
+        content: maxContent
+      });
+
+      // Should not contain error message
+      expect(result.content[0].text).not.toContain('❌ Content too large');
+      // Should successfully create
+      expect(result.content[0].text).toContain('✅ Created skill');
+    });
+
+    it('should accept content below MAX_CONTENT_LENGTH', async () => {
+      // Create normal sized content
+      const normalContent = 'This is a normal sized skill content';
+      
+      const result = await server.createElement({
+        name: 'test-skill',
+        type: 'skills', 
+        description: 'Test skill',
+        content: normalContent
+      });
+
+      expect(result.content[0].text).toContain('✅ Created skill');
+      expect(result.content[0].text).toContain('test-skill');
+    });
+
+    it('should handle missing content gracefully', async () => {
+      const result = await server.createElement({
+        name: 'test-skill',
+        type: 'skills',
+        description: 'Test skill'
+        // No content provided
+      });
+
+      expect(result.content[0].text).toContain('✅ Created skill');
+    });
+
+    it('should prevent memory exhaustion with extremely large content', async () => {
+      // This is the test case that would have caused Claude to hang
+      const hugeContent = 'x'.repeat(1000000); // 1 million characters
+      
+      const result = await server.createElement({
+        name: 'test-skill',
+        type: 'skills',
+        description: 'Test skill',
+        content: hugeContent
+      });
+
+      expect(result.content[0].text).toContain('❌ Content too large');
+      // Should complete quickly without hanging
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This PR fixes a critical bug where createElement would accept arbitrarily large content, causing Claude Desktop to hang when trying to output massive responses.

## Problem
During integration testing, we discovered that calling `create_skill "test" "x".repeat(1000000)` would cause Claude Desktop to hang with a "response paused because Claude reached its max length" error. The server was accepting and trying to return 1 million characters in the response.

## Root Cause
The `createElement` method in `src/index.ts` was not validating content size before processing. While individual element managers (like SkillManager) had size limits, the validation happened AFTER the server tried to return the content in a response.

## Solution
Added content size validation at the earliest possible point in `createElement`:
- Validates content against `SECURITY_LIMITS.MAX_CONTENT_LENGTH` (500KB)
- Returns a clear error message with size limits
- Prevents the content from being processed or returned
- Completes immediately without hanging

## Changes Made
1. **src/index.ts** (lines 1244-1257)
   - Added `validateContentSize` check before element creation
   - Returns user-friendly error with size limits

2. **test/__tests__/unit/server/content-size-validation.test.ts**
   - 5 comprehensive test cases
   - Specifically tests the 1 million character scenario
   - Verifies boundary conditions

## Testing
- ✅ All new tests passing (5/5)
- ✅ Verified fix in Claude Desktop - no more hangs
- ✅ Error message displays correctly with size limits
- ✅ Normal-sized content still works fine

## Impact
- **Security**: Prevents memory exhaustion attacks
- **UX**: Prevents Claude Desktop from hanging
- **Performance**: Fails fast with large content

## Before
```
create_skill "test" "x".repeat(1000000)
// Claude Desktop hangs, shows "response paused" error
```

## After
```
create_skill "test" "x".repeat(1000000)
// Immediately returns: ❌ Content too large: Content exceeds maximum allowed size. Maximum allowed size is 500000 characters (488KB).
```

## Related Issues
- Discovered during integration testing of PR #511 (error codes implementation)

## Review Request
Please verify:
1. The validation placement is optimal (early in the flow)
2. The error message is clear and helpful
3. The size limit is appropriate (500KB)