### PR TITLE
fix: PortfolioElementAdapter now serializes to markdown instead of JSON

### DIFF
--- a/security-audit-report.md
+++ b/security-audit-report.md
@@ -1,7 +1,7 @@
 # Security Audit Report
 
-Generated: 2025-08-10T22:47:34.493Z
-Duration: 2ms
+Generated: 2025-08-10T23:15:40.345Z
+Duration: 6ms
 
 ## Summary
 
@@ -22,7 +22,7 @@ Duration: 2ms
 
 #### DMCP-SEC-006: Security operation without audit logging
 
-- **File**: `/var/folders/kj/45kjdq714853c8nlnsv7l0_r0000gn/T/security-audit-test-FPnYfN/auth-handler.js`
+- **File**: `/var/folders/kj/45kjdq714853c8nlnsv7l0_r0000gn/T/security-audit-test-WqFVG9/auth-handler.js`
 - **Confidence**: medium
 - **Remediation**: Add SecurityMonitor.logSecurityEvent() for audit trail
 

--- a/src/tools/portfolio/PortfolioElementAdapter.ts
+++ b/src/tools/portfolio/PortfolioElementAdapter.ts
@@ -22,6 +22,7 @@ import { PortfolioElement } from './submitToPortfolioTool.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
 import { logger } from '../../utils/logger.js';
+import * as yaml from 'js-yaml';
 
 /**
  * Adapter class that wraps a simple PortfolioElement and implements IElement
@@ -127,16 +128,30 @@ export class PortfolioElementAdapter implements IElement {
   }
 
   /**
-   * Serialize the element to string
+   * Serialize the element to markdown with YAML frontmatter
+   * FIX: Changed from JSON to markdown format for GitHub portfolio compatibility
    */
   serialize(): string {
-    return JSON.stringify({
+    // If the content already has frontmatter, return it as-is
+    if (this.portfolioElement.content.startsWith('---\n')) {
+      return this.portfolioElement.content;
+    }
+    
+    // Otherwise, create markdown with YAML frontmatter
+    // Build frontmatter from metadata
+    const frontmatter = yaml.dump({
+      ...this.metadata,
       id: this.id,
       type: this.type,
-      version: this.version,
-      metadata: this.metadata,
-      content: this.portfolioElement.content
-    }, null, 2);
+      version: this.version
+    }, {
+      noRefs: true,
+      sortKeys: false,
+      lineWidth: -1
+    });
+    
+    // Return markdown with frontmatter
+    return `---\n${frontmatter}---\n\n${this.portfolioElement.content}`;
   }
 
   /**


### PR DESCRIPTION
## Problem
When submitting elements to GitHub portfolios using the `submit_to_portfolio` tool, the files were still being saved as JSON instead of readable markdown with YAML frontmatter.

## Root Cause
The `PortfolioElementAdapter` class was still using JSON serialization in its `serialize()` method, even though we had updated all other element types to use markdown.

## Solution
Updated `PortfolioElementAdapter.serialize()` to output markdown with YAML frontmatter, matching the behavior of other element types.

## Changes
- Modified `serialize()` method to generate YAML frontmatter using js-yaml
- Added logic to preserve content that already has frontmatter
- Added js-yaml import

## Testing
- ✅ Build successful
- ✅ All 1577 tests passing
- ✅ Ready for user testing

## Impact
Elements submitted to GitHub portfolios will now appear as readable markdown files instead of JSON blobs, making them much more useful for showcasing work on GitHub.

Fixes the remaining issue from #535