### PR TITLE
fix: Configure Dependabot to target develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -24,6 +25,7 @@ updates:
   # Monitor Docker base images and dependencies  
   - package-ecosystem: "docker"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary
Updates Dependabot configuration to create PRs against the `develop` branch instead of `main`, aligning with our GitFlow workflow.

## Problem
Dependabot PRs were failing the "Verify PR Source Branch" check because they were targeting `main` instead of `develop`. Our GitFlow workflow requires all changes to go through `develop` first.

## Solution
Added `target-branch: "develop"` to both npm and docker package ecosystems in `.github/dependabot.yml`.

## Impact
- ✅ Future Dependabot PRs will target develop
- ✅ PRs will pass branch verification checks
- ✅ Aligns with GitFlow best practices

## Next Steps
After merging this:
1. Close the 5 existing Dependabot PRs that target main
2. Dependabot will automatically recreate them against develop
3. The new PRs should pass all checks

## Related
- Fixes issue with PRs #574, #560, #558, #557, #554 failing branch checks

🤖 Generated with [Claude Code](https://claude.ai/code)