### PR TITLE
feat: implement collection index filtering for MCP compatibility

### DIFF
--- a/src/collection/CollectionBrowser.ts
+++ b/src/collection/CollectionBrowser.ts
@@ -6,6 +6,16 @@ import { GitHubClient } from './GitHubClient.js';
 import { CollectionCache, CollectionItem } from '../cache/CollectionCache.js';
 import { CollectionSeeder } from './CollectionSeeder.js';
 import { logger } from '../utils/logger.js';
+import { ElementType } from '../portfolio/types.js';
+
+// Content types supported by MCP server (Issue #144)
+// Hide: tools, memories, ensembles, prompts from MCP queries
+const MCP_SUPPORTED_TYPES = [
+  ElementType.PERSONA,    // personas - supported by PersonaTools and ElementTools
+  ElementType.SKILL,      // skills - supported by ElementTools
+  ElementType.AGENT,      // agents - supported by ElementTools  
+  ElementType.TEMPLATE    // templates - supported by ElementTools
+];
 
 export class CollectionBrowser {
   private githubClient: GitHubClient;
@@ -56,8 +66,9 @@ export class CollectionBrowser {
       
       // In the library section, we have content type directories
       if (section === 'library' && !type) {
+        // Filter to only show MCP-supported content types
         const contentTypes = data.filter((item: any) => 
-          item.type === 'dir' && ['personas', 'skills', 'agents', 'prompts', 'templates', 'tools', 'ensembles', 'memories'].includes(item.name)
+          item.type === 'dir' && MCP_SUPPORTED_TYPES.includes(item.name as ElementType)
         );
         return { items: [], categories: contentTypes };
       }
@@ -150,7 +161,10 @@ export class CollectionBrowser {
     items.forEach(item => {
       const pathParts = item.path.split('/');
       if (pathParts.length >= 2 && pathParts[0] === 'library') {
-        types.add(pathParts[1]);
+        // Only include MCP-supported types in cache browsing
+        if (MCP_SUPPORTED_TYPES.includes(pathParts[1] as ElementType)) {
+          types.add(pathParts[1]);
+        }
       }
     });
     
@@ -211,7 +225,7 @@ export class CollectionBrowser {
         const icon = sectionIcons[sec.name] || '📁';
         const descriptions: { [key: string]: string } = {
           'library': 'Free community content',
-          'showcase': 'Featured high-quality content',
+          'showcase': 'Featured high-quality content (coming soon)',
           'catalog': 'Premium content (coming soon)'
         };
         textParts.push(


### PR DESCRIPTION
## Summary

This PR implements Issue #144 - Collection Index Filtering to hide unsupported content types from MCP collection queries while maintaining them in the repository for future use.

## Problem

When users browse the DollhouseMCP collection through MCP tools, they see content types that are not yet supported by the MCP server, causing confusion when they try to use unsupported features.

## Solution

Implemented filtering at the collection browsing level to only show MCP-supported content types while hiding:
- **tools** - not yet supported by MCP
- **memories** - patent-pending, not public
- **ensembles** - patent-pending, not public  
- **prompts** - different from personas/elements

## Changes

1. **Added MCP_SUPPORTED_TYPES constant** - Defines which element types are compatible with MCP
2. **Updated GitHub API filtering** - Filters responses to only show supported types
3. **Updated cache filtering** - Ensures consistency between API and cached responses
4. **Enhanced Showcase messaging** - Added 'coming soon' for empty sections

## Content Type Visibility

✅ **Visible** (MCP-supported):
- personas - Supported by PersonaTools and ElementTools
- skills - Supported by ElementTools
- agents - Supported by ElementTools
- templates - Supported by ElementTools

🚫 **Hidden** (Not MCP-supported):
- tools - Not yet supported
- memories - Patent-pending
- ensembles - Patent-pending
- prompts - Different from personas/elements

## Benefits

1. **Improved User Experience** - Users only see content they can actually install and use
2. **Patent Protection** - Hides patent-pending features from public queries
3. **Clean API Surface** - Reduces confusion about supported functionality
4. **Future-Proof** - Easy to add types back when they become supported

## Testing

- ✅ TypeScript compilation successful
- ✅ Build completes without errors
- ✅ Filtering logic implemented consistently

## Related Issues

Resolves #144