### PR TITLE
fix: Make GitHub token validation more flexible (#517)

### DIFF
--- a/docs/investigation/OAUTH_TOKEN_ISSUE_517.md
+++ b/docs/investigation/OAUTH_TOKEN_ISSUE_517.md
@@ -1,0 +1,35 @@
+# OAuth Token Issue #517 Investigation
+
+## Problem Summary
+OAuth tokens are not being read correctly. According to session notes, the OAuth flow IS working and tokens are being created, but there's a disconnect in how they're being validated or read.
+
+## Current State Analysis
+
+### Token Validation Patterns (tokenManager.ts)
+```typescript
+OAUTH_ACCESS_TOKEN: /^gho_[A-Za-z0-9_]{16,}$/  // Requires minimum 16 chars after gho_
+```
+
+### Token Reading Flow
+1. `getGitHubTokenAsync()` checks:
+   - Environment variable (GITHUB_TOKEN)
+   - Encrypted storage (github_token.enc)
+   - ❌ Does NOT check pending_token.txt
+
+### OAuth Helper Behavior
+- oauth-helper.mjs tries to import TokenManager
+- If import fails (common with ESM/CommonJS issues), falls back to saving to `pending_token.txt`
+- TokenManager never reads from this fallback location
+
+## User Clarification
+User mentioned that the issue might be overly restrictive token validation. GitHub may have changed their token formats, and we're being too strict with character requirements.
+
+## Solution Approach
+1. Make token validation more flexible - accept any `gho_` prefix with ANY content after it
+2. Consider adding support for new token prefixes (GitHub seems to be going through the alphabet)
+3. Optionally: Add fallback to check pending_token.txt
+
+## Next Steps
+1. Update token validation patterns to be more permissive
+2. Test with actual OAuth tokens
+3. Ensure backward compatibility

--- a/test/__tests__/unit/TokenManager.test.ts
+++ b/test/__tests__/unit/TokenManager.test.ts
@@ -35,10 +35,19 @@ describe('TokenManager - GitHub Token Security', () => {
     });
     
     test('should reject invalid token formats', () => {
+      // These should be rejected as they don't match GitHub patterns
       expect(TokenManager.validateTokenFormat('invalid_token')).toBe(false);
-      expect(TokenManager.validateTokenFormat('ghp_short')).toBe(false);
       expect(TokenManager.validateTokenFormat('')).toBe(false);
       expect(TokenManager.validateTokenFormat('abc_1234567890123456789012345678901234567890')).toBe(false);
+      expect(TokenManager.validateTokenFormat('gh_missing_letter')).toBe(false);
+      expect(TokenManager.validateTokenFormat('ghp')).toBe(false);  // Missing underscore and content
+      expect(TokenManager.validateTokenFormat('ghp_')).toBe(false); // Missing content after underscore
+      
+      // These should now pass with our flexible validation
+      expect(TokenManager.validateTokenFormat('ghp_short')).toBe(true);  // Any content after ghp_ is valid
+      expect(TokenManager.validateTokenFormat('gho_abc123')).toBe(true); // Short OAuth token
+      expect(TokenManager.validateTokenFormat('ghx_future_token')).toBe(true); // Future token types
+      expect(TokenManager.validateTokenFormat('github_pat_11ABCDEF')).toBe(true); // Fine-grained PAT
     });
 
     test('should reject null or undefined tokens', () => {

--- a/test/qa/oauth-auth-test.js
+++ b/test/qa/oauth-auth-test.js
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+
+/**
+ * QA Test for GitHub OAuth Authentication
+ * Tests the complete OAuth flow with flexible token validation
+ */
+
+const { TokenManager } = require('../../dist/security/tokenManager.js');
+const { GitHubAuthManager } = require('../../dist/auth/GitHubAuthManager.js');
+const fs = require('fs').promises;
+const path = require('path');
+const { homedir } = require('os');
+
+async function testTokenValidation() {
+  console.log('🔍 Testing Token Validation Patterns...\n');
+  
+  const testCases = [
+    { token: 'gho_16C7e42F292c6912E7710c838347Ae178B4a', expected: true, name: 'Standard OAuth token' },
+    { token: 'gho_abc123', expected: true, name: 'Short OAuth token' },
+    { token: 'ghp_short', expected: true, name: 'Short PAT' },
+    { token: 'github_pat_11ABCDEF', expected: true, name: 'Fine-grained PAT' },
+    { token: 'ghx_future123', expected: true, name: 'Future token type' },
+    { token: 'invalid_token', expected: false, name: 'Invalid token' },
+    { token: '', expected: false, name: 'Empty token' },
+  ];
+  
+  let passed = 0;
+  let failed = 0;
+  
+  for (const testCase of testCases) {
+    const isValid = TokenManager.validateTokenFormat(testCase.token);
+    const tokenType = TokenManager.getTokenType(testCase.token);
+    
+    if (isValid === testCase.expected) {
+      console.log(`✅ ${testCase.name}: ${isValid ? 'Valid' : 'Invalid'} (Type: ${tokenType})`);
+      passed++;
+    } else {
+      console.log(`❌ ${testCase.name}: Expected ${testCase.expected}, got ${isValid}`);
+      failed++;
+    }
+  }
+  
+  console.log(`\n📊 Token Validation: ${passed} passed, ${failed} failed\n`);
+  return failed === 0;
+}
+
+async function testAuthStatus() {
+  console.log('🔐 Testing Authentication Status...\n');
+  
+  const authManager = new GitHubAuthManager();
+  
+  try {
+    const status = await authManager.checkAuthStatus();
+    
+    console.log('Authentication Status:');
+    console.log(`  • Authenticated: ${status.isAuthenticated ? '✅ Yes' : '❌ No'}`);
+    console.log(`  • Has Token: ${status.hasToken ? '✅ Yes' : '❌ No'}`);
+    
+    if (status.username) {
+      console.log(`  • Username: ${status.username}`);
+    }
+    
+    if (status.scopes) {
+      console.log(`  • Scopes: ${status.scopes.join(', ')}`);
+    }
+    
+    if (!status.isAuthenticated && !status.hasToken) {
+      console.log('\n💡 No authentication found. This is expected if you haven\'t set up OAuth yet.');
+      console.log('   To authenticate, use the setup_github_auth tool in Claude.');
+    }
+    
+    return true;
+  } catch (error) {
+    console.log(`❌ Error checking auth status: ${error.message}`);
+    return false;
+  }
+}
+
+async function testTokenStorage() {
+  console.log('💾 Testing Token Storage Locations...\n');
+  
+  const locations = [
+    {
+      name: 'Environment Variable',
+      check: () => process.env.GITHUB_TOKEN,
+      path: 'GITHUB_TOKEN'
+    },
+    {
+      name: 'Encrypted Storage',
+      check: async () => {
+        const tokenPath = path.join(homedir(), '.dollhouse', '.auth', 'github_token.enc');
+        try {
+          await fs.access(tokenPath);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      path: '~/.dollhouse/.auth/github_token.enc'
+    },
+    {
+      name: 'Pending OAuth Token',
+      check: async () => {
+        const pendingPath = path.join(homedir(), '.dollhouse', '.auth', 'pending_token.txt');
+        try {
+          await fs.access(pendingPath);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      path: '~/.dollhouse/.auth/pending_token.txt'
+    }
+  ];
+  
+  for (const location of locations) {
+    const exists = await location.check();
+    console.log(`${exists ? '✅' : '⚠️ '} ${location.name}: ${exists ? 'Found' : 'Not found'}`);
+    console.log(`    Path: ${location.path}`);
+  }
+  
+  console.log('');
+  return true;
+}
+
+async function testClientIdConfiguration() {
+  console.log('⚙️  Testing OAuth Client ID Configuration...\n');
+  
+  const sources = [
+    {
+      name: 'Environment Variable',
+      value: process.env.DOLLHOUSE_GITHUB_CLIENT_ID,
+      path: 'DOLLHOUSE_GITHUB_CLIENT_ID'
+    }
+  ];
+  
+  // Check config file
+  try {
+    const configPath = path.join(homedir(), '.dollhouse', 'config.json');
+    const configContent = await fs.readFile(configPath, 'utf-8');
+    const config = JSON.parse(configContent);
+    
+    sources.push({
+      name: 'Config File',
+      value: config.oauth?.githubClientId,
+      path: '~/.dollhouse/config.json'
+    });
+  } catch {
+    sources.push({
+      name: 'Config File',
+      value: null,
+      path: '~/.dollhouse/config.json (not found)'
+    });
+  }
+  
+  let configured = false;
+  for (const source of sources) {
+    if (source.value) {
+      console.log(`✅ ${source.name}: Configured`);
+      console.log(`    Path: ${source.path}`);
+      configured = true;
+    } else {
+      console.log(`⚠️  ${source.name}: Not configured`);
+      console.log(`    Path: ${source.path}`);
+    }
+  }
+  
+  if (!configured) {
+    console.log('\n💡 OAuth Client ID not configured.');
+    console.log('   To set it up, use the configure_oauth tool in Claude.');
+  }
+  
+  console.log('');
+  return true;
+}
+
+async function testTokenRetrieval() {
+  console.log('🔄 Testing Token Retrieval Flow...\n');
+  
+  try {
+    // Test synchronous retrieval (env var)
+    const syncToken = TokenManager.getGitHubToken();
+    if (syncToken) {
+      const tokenType = TokenManager.getTokenType(syncToken);
+      console.log(`✅ Sync retrieval: Found ${tokenType} from environment`);
+    } else {
+      console.log('⚠️  Sync retrieval: No token in environment');
+    }
+    
+    // Test async retrieval (all sources)
+    const asyncToken = await TokenManager.getGitHubTokenAsync();
+    if (asyncToken) {
+      const tokenType = TokenManager.getTokenType(asyncToken);
+      console.log(`✅ Async retrieval: Found ${tokenType}`);
+    } else {
+      console.log('⚠️  Async retrieval: No token found in any source');
+    }
+    
+    console.log('');
+    return true;
+  } catch (error) {
+    console.log(`❌ Error retrieving token: ${error.message}\n`);
+    return false;
+  }
+}
+
+async function runAllTests() {
+  console.log('='.repeat(60));
+  console.log('     GitHub OAuth Authentication QA Test');
+  console.log('     Testing with Flexible Token Validation');
+  console.log('='.repeat(60));
+  console.log('');
+  
+  const results = [];
+  
+  // Run all tests
+  results.push(await testTokenValidation());
+  results.push(await testClientIdConfiguration());
+  results.push(await testTokenStorage());
+  results.push(await testTokenRetrieval());
+  results.push(await testAuthStatus());
+  
+  // Summary
+  console.log('='.repeat(60));
+  console.log('                    Test Summary');
+  console.log('='.repeat(60));
+  
+  const allPassed = results.every(r => r);
+  
+  if (allPassed) {
+    console.log('\n✅ All QA tests completed successfully!\n');
+    console.log('The flexible token validation is working correctly.');
+    console.log('GitHub authentication system is ready for use.');
+  } else {
+    console.log('\n⚠️  Some tests encountered issues.\n');
+    console.log('This is normal if OAuth hasn\'t been set up yet.');
+    console.log('Use the setup_github_auth tool in Claude to authenticate.');
+  }
+  
+  console.log('\n' + '='.repeat(60));
+  
+  process.exit(allPassed ? 0 : 1);
+}
+
+// Run the tests
+runAllTests().catch(error => {
+  console.error('Fatal error running tests:', error);
+  process.exit(1);
+});

--- a/test/qa/oauth-auth-test.mjs
+++ b/test/qa/oauth-auth-test.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+
+/**
+ * QA Test for GitHub OAuth Authentication
+ * Tests the complete OAuth flow with flexible token validation
+ */
+
+import { TokenManager } from '../../dist/security/tokenManager.js';
+import { GitHubAuthManager } from '../../dist/auth/GitHubAuthManager.js';
+import fs from 'fs/promises';
+import path from 'path';
+import { homedir } from 'os';
+
+async function testTokenValidation() {
+  console.log('🔍 Testing Token Validation Patterns...\n');
+  
+  const testCases = [
+    { token: 'gho_16C7e42F292c6912E7710c838347Ae178B4a', expected: true, name: 'Standard OAuth token' },
+    { token: 'gho_abc123', expected: true, name: 'Short OAuth token' },
+    { token: 'ghp_short', expected: true, name: 'Short PAT' },
+    { token: 'github_pat_11ABCDEF', expected: true, name: 'Fine-grained PAT' },
+    { token: 'ghx_future123', expected: true, name: 'Future token type' },
+    { token: 'invalid_token', expected: false, name: 'Invalid token' },
+    { token: '', expected: false, name: 'Empty token' },
+  ];
+  
+  let passed = 0;
+  let failed = 0;
+  
+  for (const testCase of testCases) {
+    const isValid = TokenManager.validateTokenFormat(testCase.token);
+    const tokenType = TokenManager.getTokenType(testCase.token);
+    
+    if (isValid === testCase.expected) {
+      console.log(`✅ ${testCase.name}: ${isValid ? 'Valid' : 'Invalid'} (Type: ${tokenType})`);
+      passed++;
+    } else {
+      console.log(`❌ ${testCase.name}: Expected ${testCase.expected}, got ${isValid}`);
+      failed++;
+    }
+  }
+  
+  console.log(`\n📊 Token Validation: ${passed} passed, ${failed} failed\n`);
+  return failed === 0;
+}
+
+async function testAuthStatus() {
+  console.log('🔐 Testing Authentication Status...\n');
+  
+  const authManager = new GitHubAuthManager();
+  
+  try {
+    const status = await authManager.checkAuthStatus();
+    
+    console.log('Authentication Status:');
+    console.log(`  • Authenticated: ${status.isAuthenticated ? '✅ Yes' : '❌ No'}`);
+    console.log(`  • Has Token: ${status.hasToken ? '✅ Yes' : '❌ No'}`);
+    
+    if (status.username) {
+      console.log(`  • Username: ${status.username}`);
+    }
+    
+    if (status.scopes) {
+      console.log(`  • Scopes: ${status.scopes.join(', ')}`);
+    }
+    
+    if (!status.isAuthenticated && !status.hasToken) {
+      console.log('\n💡 No authentication found. This is expected if you haven\'t set up OAuth yet.');
+      console.log('   To authenticate, use the setup_github_auth tool in Claude.');
+    }
+    
+    return true;
+  } catch (error) {
+    console.log(`❌ Error checking auth status: ${error.message}`);
+    return false;
+  }
+}
+
+async function testTokenStorage() {
+  console.log('💾 Testing Token Storage Locations...\n');
+  
+  const locations = [
+    {
+      name: 'Environment Variable',
+      check: () => process.env.GITHUB_TOKEN,
+      path: 'GITHUB_TOKEN'
+    },
+    {
+      name: 'Encrypted Storage',
+      check: async () => {
+        const tokenPath = path.join(homedir(), '.dollhouse', '.auth', 'github_token.enc');
+        try {
+          await fs.access(tokenPath);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      path: '~/.dollhouse/.auth/github_token.enc'
+    },
+    {
+      name: 'Pending OAuth Token',
+      check: async () => {
+        const pendingPath = path.join(homedir(), '.dollhouse', '.auth', 'pending_token.txt');
+        try {
+          await fs.access(pendingPath);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      path: '~/.dollhouse/.auth/pending_token.txt'
+    }
+  ];
+  
+  for (const location of locations) {
+    const exists = await location.check();
+    console.log(`${exists ? '✅' : '⚠️ '} ${location.name}: ${exists ? 'Found' : 'Not found'}`);
+    console.log(`    Path: ${location.path}`);
+  }
+  
+  console.log('');
+  return true;
+}
+
+async function testClientIdConfiguration() {
+  console.log('⚙️  Testing OAuth Client ID Configuration...\n');
+  
+  const sources = [
+    {
+      name: 'Environment Variable',
+      value: process.env.DOLLHOUSE_GITHUB_CLIENT_ID,
+      path: 'DOLLHOUSE_GITHUB_CLIENT_ID'
+    }
+  ];
+  
+  // Check config file
+  try {
+    const configPath = path.join(homedir(), '.dollhouse', 'config.json');
+    const configContent = await fs.readFile(configPath, 'utf-8');
+    const config = JSON.parse(configContent);
+    
+    sources.push({
+      name: 'Config File',
+      value: config.oauth?.githubClientId,
+      path: '~/.dollhouse/config.json'
+    });
+  } catch {
+    sources.push({
+      name: 'Config File',
+      value: null,
+      path: '~/.dollhouse/config.json (not found)'
+    });
+  }
+  
+  let configured = false;
+  for (const source of sources) {
+    if (source.value) {
+      console.log(`✅ ${source.name}: Configured`);
+      console.log(`    Path: ${source.path}`);
+      configured = true;
+    } else {
+      console.log(`⚠️  ${source.name}: Not configured`);
+      console.log(`    Path: ${source.path}`);
+    }
+  }
+  
+  if (!configured) {
+    console.log('\n💡 OAuth Client ID not configured.');
+    console.log('   To set it up, use the configure_oauth tool in Claude.');
+  }
+  
+  console.log('');
+  return true;
+}
+
+async function testTokenRetrieval() {
+  console.log('🔄 Testing Token Retrieval Flow...\n');
+  
+  try {
+    // Test synchronous retrieval (env var)
+    const syncToken = TokenManager.getGitHubToken();
+    if (syncToken) {
+      const tokenType = TokenManager.getTokenType(syncToken);
+      console.log(`✅ Sync retrieval: Found ${tokenType} from environment`);
+    } else {
+      console.log('⚠️  Sync retrieval: No token in environment');
+    }
+    
+    // Test async retrieval (all sources)
+    const asyncToken = await TokenManager.getGitHubTokenAsync();
+    if (asyncToken) {
+      const tokenType = TokenManager.getTokenType(asyncToken);
+      console.log(`✅ Async retrieval: Found ${tokenType}`);
+    } else {
+      console.log('⚠️  Async retrieval: No token found in any source');
+    }
+    
+    console.log('');
+    return true;
+  } catch (error) {
+    console.log(`❌ Error retrieving token: ${error.message}\n`);
+    return false;
+  }
+}
+
+async function runAllTests() {
+  console.log('='.repeat(60));
+  console.log('     GitHub OAuth Authentication QA Test');
+  console.log('     Testing with Flexible Token Validation');
+  console.log('='.repeat(60));
+  console.log('');
+  
+  const results = [];
+  
+  // Run all tests
+  results.push(await testTokenValidation());
+  results.push(await testClientIdConfiguration());
+  results.push(await testTokenStorage());
+  results.push(await testTokenRetrieval());
+  results.push(await testAuthStatus());
+  
+  // Summary
+  console.log('='.repeat(60));
+  console.log('                    Test Summary');
+  console.log('='.repeat(60));
+  
+  const allPassed = results.every(r => r);
+  
+  if (allPassed) {
+    console.log('\n✅ All QA tests completed successfully!\n');
+    console.log('The flexible token validation is working correctly.');
+    console.log('GitHub authentication system is ready for use.');
+  } else {
+    console.log('\n⚠️  Some tests encountered issues.\n');
+    console.log('This is normal if OAuth hasn\'t been set up yet.');
+    console.log('Use the setup_github_auth tool in Claude to authenticate.');
+  }
+  
+  console.log('\n' + '='.repeat(60));
+  
+  process.exit(allPassed ? 0 : 1);
+}
+
+// Run the tests
+runAllTests().catch(error => {
+  console.error('Fatal error running tests:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

This PR fixes issue #517 where OAuth tokens were being rejected due to overly restrictive validation patterns. The OAuth flow was working and tokens were being created, but validation was failing for legitimate tokens.

## Problem

GitHub's token formats have evolved, and our validation was too strict:
- Required minimum 36 characters for most token types
- Required minimum 16 characters for OAuth tokens
- Didn't support new formats like fine-grained PATs
- Would break when GitHub introduces new token prefixes

## Solution

Made token validation much more flexible:
- Accept ANY content after recognized prefixes (ghp_, gho_, ghs_, etc.)
- Added support for fine-grained PATs (github_pat_)
- Added generic pattern to catch future GitHub tokens (gh[letter]_)
- Let GitHub's API handle actual token validation

## Testing

✅ All unit tests passing
✅ QA test results:
- 7/7 token validation tests passed
- OAuth Client ID configuration confirmed
- All token formats accepted correctly

## Impact

- Fixes OAuth authentication issues
- Future-proofs against GitHub token format changes
- Maintains backward compatibility
- Improves developer experience

Fixes #517