### PR TITLE
docs: Update README version references from 1.5.2 to 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A comprehensive Model Context Protocol (MCP) server that enables dynamic AI pers
 # Install globally
 npm install -g @dollhousemcp/mcp-server
 
-# ✅ v1.5.2 enables anonymous usage - no GitHub auth required!
+# ✅ v1.6.0 enables anonymous usage - no GitHub auth required!
 # Browse and submit to collection without authentication:
 # npm install -g @dollhousemcp/mcp-server@latest
 
@@ -735,7 +735,7 @@ get_collection_cache_health
 
 ### GitHub Authentication (v1.5.0+)
 
-DollhouseMCP supports GitHub OAuth device flow authentication for enhanced features. **NEW in v1.5.2**: Authentication is now optional - browse and submit anonymously!
+DollhouseMCP supports GitHub OAuth device flow authentication for enhanced features. **NEW in v1.6.0**: Authentication is now optional - browse and submit anonymously!
 
 #### OAuth Setup (For Self-Hosting)
 


### PR DESCRIPTION
## Summary
Updates version references in the README from v1.5.2 to v1.6.0 to reflect the current release.

## Changes Made
1. **Quick Start Guide** (line 45)
   - Updated comment: `# ✅ v1.5.2 enables anonymous usage` → `# ✅ v1.6.0 enables anonymous usage`

2. **GitHub Authentication Section** (line 738)  
   - Updated: `**NEW in v1.5.2**: Authentication is now optional` → `**NEW in v1.6.0**: Authentication is now optional`

## Rationale
These version references should reflect the current release to ensure users have accurate information about:
- When anonymous usage features were introduced
- Current version capabilities
- Installation instructions accuracy

## Files Changed
- `README.md` - Updated 2 version references

## Notes
- Historical changelog entries remain unchanged (as they should)
- The "v1.5.0+" reference in GitHub Authentication header remains unchanged (means "1.5.0 and later")
- No functional changes, only documentation updates

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>