### PR TITLE
fix: OAuth default client ID not being used in setup_github_auth

### DIFF
--- a/docs/development/SESSION_NOTES_2025_08_25_OAUTH_DEFAULT_FIX_PR741.md
+++ b/docs/development/SESSION_NOTES_2025_08_25_OAUTH_DEFAULT_FIX_PR741.md
@@ -1,0 +1,200 @@
+# Session Notes - August 25, 2025 - Critical OAuth Default Fix (PR #741)
+
+**Time**: ~4:30 PM - 5:30 PM  
+**Branch**: `fix/oauth-default-not-working`  
+**PR**: #741  
+**Context**: Emergency fix for v1.6.1 OAuth authentication failure  
+**Status**: PR created, awaiting merge for v1.6.2 hotfix  
+
+## Critical Issue Discovered
+
+### User Report
+After releasing v1.6.1 with the "default OAuth client ID" feature, users still couldn't authenticate. The `setup_github_auth` tool failed with:
+
+```
+❌ Authentication Setup Failed
+Unable to start GitHub authentication: Failed to start GitHub authentication. 
+Please check your internet connection.
+```
+
+### Expected Behavior (v1.6.1)
+- Users should be able to run `setup_github_auth` immediately after NPM installation
+- No configuration should be required
+- Default OAuth client ID (`Ov23liXGGP9jNrBhBNfO`) should be used automatically
+
+### Actual Behavior
+- Authentication failed for users without explicit OAuth configuration
+- Error message was misleading (suggested network issues)
+- Default client ID was NOT being used despite being in the code
+
+## Root Cause Analysis
+
+### The Bug Location
+**File**: `src/index.ts`  
+**Method**: `setupGitHubAuth()` (line ~2689)  
+
+### The Problem Code
+```typescript
+// WRONG - This bypasses the default fallback!
+const configManager = ConfigManager.getInstance();
+const clientId = await configManager.getGitHubClientId();
+
+if (!clientId) {
+  // Error: "OAuth Not Configured"
+}
+```
+
+### Why This Failed
+1. `ConfigManager.getGitHubClientId()` only checks:
+   - Stored configuration
+   - Returns `null` if nothing configured
+
+2. `GitHubAuthManager.getClientId()` checks (correct fallback):
+   - Environment variable (`DOLLHOUSE_GITHUB_CLIENT_ID`)
+   - ConfigManager stored value
+   - **DEFAULT CLIENT ID** ← This was being skipped!
+
+3. The OAuth helper process (`oauth-helper.mjs`) was receiving `undefined` as the client ID
+
+## The Fix (PR #741)
+
+### Changes Made
+
+#### 1. Made `getClientId()` Public
+**File**: `src/auth/GitHubAuthManager.ts` (line 57)
+```typescript
+// Changed from:
+private static async getClientId(): Promise<string | null> {
+
+// To:
+public static async getClientId(): Promise<string | null> {
+```
+
+#### 2. Fixed `setupGitHubAuth()` Method
+**File**: `src/index.ts` (line 2689)
+```typescript
+// Changed from:
+const configManager = ConfigManager.getInstance();
+const clientId = await configManager.getGitHubClientId();
+
+// To:
+const clientId = await GitHubAuthManager.getClientId();
+```
+
+### Why This Works
+Now `setupGitHubAuth()` uses the same method with proper fallback hierarchy:
+1. Check environment variable
+2. Check ConfigManager
+3. **Use default client ID** ✅
+
+## Important Context
+
+### Version History
+- **v1.6.0**: Released without default OAuth
+- **v1.6.1**: Added default OAuth client ID (PR #731) - BUT had this bug
+- **v1.6.2**: Will contain this fix (PR #741)
+
+### Testing Notes
+- In development/testing, we often use PATs (Personal Access Tokens)
+- PATs bypass OAuth flow entirely
+- This bug only affects production users using OAuth device flow
+- That's why it wasn't caught in testing
+
+### The OAuth Flow
+1. User runs `setup_github_auth`
+2. Server calls `setupGitHubAuth()` 
+3. Gets client ID (now properly uses default)
+4. Spawns `oauth-helper.mjs` process with client ID
+5. Helper process handles device flow polling
+6. User authenticates via browser
+7. Token stored securely
+
+## Files Modified
+
+1. **src/auth/GitHubAuthManager.ts**
+   - Made `getClientId()` public instead of private
+
+2. **src/index.ts**
+   - Updated `setupGitHubAuth()` to use `GitHubAuthManager.getClientId()`
+
+## Testing Performed
+
+```javascript
+// Verified the fix works:
+const clientId = await GitHubAuthManager.getClientId();
+// Returns: 'Ov23liXGGP9jNrBhBNfO' (default) when no config
+
+// OAuth flow tested successfully:
+const response = await authManager.initiateDeviceFlow();
+// Returns valid device code and user code
+```
+
+## Release Plan
+
+1. **Merge PR #741** to develop
+2. **Create hotfix release v1.6.2** immediately
+3. **Merge to main** and tag
+4. **NPM publish** as emergency fix
+
+### Version Impact
+- v1.6.1 is broken for new users (requires manual OAuth setup)
+- v1.6.2 will fix this critical issue
+- Users on v1.6.1 should upgrade immediately
+
+## Related Issues & PRs
+
+- **PR #731**: Original implementation of default OAuth client ID (v1.6.1)
+- **PR #734**: Release v1.6.1 (contains the bug)
+- **PR #741**: This fix (for v1.6.2)
+- **Issues #735-740**: Enhancement issues created from PR #734 review
+
+## Key Takeaways
+
+### What Went Wrong
+1. Two different methods for getting client ID existed
+2. `setupGitHubAuth()` used the wrong one (without default fallback)
+3. Testing with PATs masked the issue
+4. The feature worked in `initiateDeviceFlow()` but not in `setupGitHubAuth()`
+
+### Lessons Learned
+1. **Consistency**: Always use the same method for getting configuration
+2. **Testing**: Test OAuth flow without PATs in production-like environment
+3. **Code Review**: Check all places where configuration is accessed
+4. **Integration**: When adding defaults, ensure ALL code paths use them
+
+## Commands for Next Session
+
+```bash
+# Check PR status
+gh pr view 741
+
+# After merge, create hotfix
+git checkout main
+git pull
+git checkout -b hotfix/v1.6.2
+git merge develop
+git push -u origin hotfix/v1.6.2
+
+# Create release PR
+gh pr create --base main --title "Hotfix v1.6.2 - Critical OAuth fix"
+
+# After merge, tag release
+git tag -a v1.6.2 -m "Hotfix: OAuth default client ID actually works now"
+git push origin v1.6.2
+```
+
+## Success Criteria
+
+When v1.6.2 is released, users should be able to:
+1. Install: `npm install -g @dollhousemcp/mcp-server@1.6.2`
+2. Run: `setup_github_auth` (no configuration needed!)
+3. See device flow start with 8-character code
+4. Complete authentication successfully
+
+## Critical Note for Future
+
+**The promise of v1.6.1** was "just works" OAuth authentication. Due to this bug, that promise was broken. v1.6.2 is a **critical hotfix** that actually delivers on that promise. Any user on v1.6.1 will have authentication problems and should upgrade immediately.
+
+---
+
+**Session ended at 3% context remaining - This fix is critical for user experience!**

--- a/src/auth/GitHubAuthManager.ts
+++ b/src/auth/GitHubAuthManager.ts
@@ -54,7 +54,7 @@ export class GitHubAuthManager {
    * 
    * @returns The OAuth Client ID to use for authentication
    */
-  private static async getClientId(): Promise<string | null> {
+  public static async getClientId(): Promise<string | null> {
     // Check environment variable first (for backward compatibility)
     const envClientId = process.env.DOLLHOUSE_GITHUB_CLIENT_ID;
     if (envClientId) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2684,21 +2684,22 @@ export class DollhouseMCPServer implements IToolHandler {
       // MCP servers are stateless and terminate after returning response
       // The helper process survives MCP termination and can complete OAuth polling
       
-      // Get the OAuth client ID
-      const configManager = ConfigManager.getInstance();
-      const clientId = await configManager.getGitHubClientId();
+      // Get the OAuth client ID - use the same method that has the default fallback
+      // This ensures we get the default client ID if no env/config is set
+      const clientId = await GitHubAuthManager.getClientId();
       
+      // This should never happen now since getClientId() always returns a value
+      // (env, config, or default), but keeping for safety
       if (!clientId) {
         return {
           content: [{
             type: "text",
-            text: `${this.getPersonaIndicator()}❌ **GitHub OAuth Not Configured**\n\n` +
-                  `The server administrator needs to configure GitHub OAuth.\n\n` +
-                  `**Administrator Setup:**\n` +
-                  `1. Create OAuth app at: https://github.com/settings/applications/new\n` +
-                  `2. Set environment variable: DOLLHOUSE_GITHUB_CLIENT_ID\n` +
-                  `3. Restart the MCP server\n\n` +
-                  `For details, see: /docs/setup/OAUTH_SETUP.md`
+            text: `${this.getPersonaIndicator()}❌ **GitHub OAuth Configuration Error**\n\n` +
+                  `Unable to obtain GitHub OAuth client ID.\n\n` +
+                  `This is unexpected - please report this issue.\n\n` +
+                  `**Workaround:**\n` +
+                  `• Set environment variable: DOLLHOUSE_GITHUB_CLIENT_ID\n` +
+                  `• Or use GitHub CLI: gh auth login --web`
           }]
         };
       }


### PR DESCRIPTION
## Critical Bug Fix for v1.6.1

This fixes a critical bug where the default OAuth client ID introduced in v1.6.1 was not actually being used by the `setup_github_auth` tool, causing authentication to fail for users.

## The Problem

Users on v1.6.1 were getting this error:
```
❌ Authentication Setup Failed
Unable to start GitHub authentication: Failed to start GitHub authentication. 
Please check your internet connection.
```

The issue was that `setupGitHubAuth()` was bypassing the default client ID fallback logic.

## Root Cause

In `src/index.ts`, the `setupGitHubAuth()` method was calling:
```typescript
const clientId = await configManager.getGitHubClientId();
```

This only checks ConfigManager, skipping the fallback logic in `GitHubAuthManager.getClientId()` that includes the default client ID.

## The Fix

1. **Made `getClientId()` public** in GitHubAuthManager (was private)
2. **Updated `setupGitHubAuth()`** to use `GitHubAuthManager.getClientId()` instead of going directly to ConfigManager

Now the fallback hierarchy works correctly:
1. Environment variable (`DOLLHOUSE_GITHUB_CLIENT_ID`)
2. ConfigManager stored value
3. **Default client ID** ✅

## Testing

- ✅ OAuth device flow tested and working
- ✅ Default client ID properly used when no env/config exists
- ✅ Build successful with no TypeScript errors
- ✅ Fallback hierarchy preserved

## Impact

This restores the "just works" experience promised in v1.6.1 where users can authenticate immediately after NPM installation without any configuration.

## Release Plan

This should be released as v1.6.2 hotfix since v1.6.1 is broken for new users without OAuth configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)