### PR TITLE
docs: Update version references to v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.2] - 2025-08-25
+
+### Fixed
+- **Critical OAuth Bug** - Fixed default client ID not being used in `setup_github_auth`
+  - The v1.6.1 release had a bug where `setupGitHubAuth()` bypassed the default fallback
+  - Made `GitHubAuthManager.getClientId()` public instead of private
+  - Updated `setupGitHubAuth()` to use proper fallback chain
+  - Now correctly uses default OAuth client ID when no configuration exists
+  - Restores the "just works" authentication experience promised in v1.6.1
+
 ## [1.6.1] - 2025-08-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ A comprehensive Model Context Protocol (MCP) server that enables dynamic AI pers
 **🏪 Collection**: https://github.com/DollhouseMCP/collection  
 **📦 NPM Package**: https://www.npmjs.com/package/@dollhousemcp/mcp-server  
 **🌍 Website**: https://dollhousemcp.com (planned)  
-**📦 Version**: v1.6.1
+**📦 Version**: v1.6.2
 
-> **🎉 New in v1.6.1**: Default OAuth client ID for seamless GitHub authentication! Users can now authenticate without any configuration. The portfolio management system, GitHub integration, and 42 MCP tools from v1.6.0 are also included.
+> **🎉 New in v1.6.2**: Critical OAuth fix - the default client ID now actually works! The v1.6.1 release had a bug where the default OAuth wasn't being used. This hotfix restores the "just works" authentication experience. Includes all features from v1.6.0.
 
 > **⚠️ Breaking Change**: PersonaTools have been streamlined in v1.6.0. 9 redundant tools were removed in favor of ElementTools. See [PersonaTools Migration Guide](docs/PERSONATOOLS_MIGRATION_GUIDE.md) for migration instructions.
 
@@ -42,7 +42,7 @@ A comprehensive Model Context Protocol (MCP) server that enables dynamic AI pers
 # Install globally
 npm install -g @dollhousemcp/mcp-server
 
-# ✅ v1.6.1 includes default OAuth - authentication just works!
+# ✅ v1.6.2 fixes OAuth - authentication truly just works now!
 # Browse and submit to collection with or without authentication:
 # npm install -g @dollhousemcp/mcp-server@latest
 
@@ -735,7 +735,7 @@ get_collection_cache_health
 
 ### GitHub Authentication (v1.5.0+)
 
-DollhouseMCP supports GitHub OAuth device flow authentication for enhanced features. **NEW in v1.6.1**: Default OAuth client ID built-in - no configuration needed!
+DollhouseMCP supports GitHub OAuth device flow authentication for enhanced features. **FIXED in v1.6.2**: Default OAuth client ID now works correctly - no configuration needed!
 
 #### OAuth Setup (For Self-Hosting)
 
@@ -1547,7 +1547,22 @@ This project is licensed under the **AGPL-3.0** License with Platform Stability 
 
 ## 🏷️ Version History
 
-### v1.6.1 - August 25, 2025 (Current - Develop Branch)
+### v1.6.2 - August 25, 2025 (Current - Develop Branch)
+
+**Critical Hotfix**: Fixed OAuth default client ID not being used in `setup_github_auth` tool
+
+#### 🔧 Bug Fixes
+- **OAuth Authentication**: Fixed critical bug where default OAuth client ID wasn't used in `setupGitHubAuth()` method
+- **Configuration Fallback**: Now correctly uses `GitHubAuthManager.getClientId()` with proper fallback hierarchy
+
+#### 📚 Technical Details
+- Made `GitHubAuthManager.getClientId()` public (was private)
+- Updated `setupGitHubAuth()` to use proper fallback chain
+- Restored "just works" authentication experience promised in v1.6.1
+
+---
+
+### v1.6.1 - August 25, 2025
 
 **⚠️ Breaking Changes**:
 - 🔄 **Serialization Format Change** - `BaseElement.serialize()` now returns markdown with YAML frontmatter instead of JSON

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
-# DollhouseMCP Architecture v1.6.1
+# DollhouseMCP Architecture v1.6.2
 
-This document describes the comprehensive architecture of DollhouseMCP v1.6.1, including core systems, design patterns, and architectural components that create a complete AI persona management ecosystem.
+This document describes the comprehensive architecture of DollhouseMCP v1.6.2, including core systems, design patterns, and architectural components that create a complete AI persona management ecosystem.
 
 ## Table of Contents
 
@@ -24,7 +24,7 @@ This document describes the comprehensive architecture of DollhouseMCP v1.6.1, i
                       │ MCP Protocol
                       ▼
 ┌─────────────────────────────────────────────────────────────┐
-│                    MCP Server (Core v1.6.1)                 │
+│                    MCP Server (Core v1.6.2)                 │
 │  • Portfolio System (PortfolioManager)                       │
 │  • Unified Indexing (UnifiedIndexManager)                    │
 │  • Tool Registry (23+ tools)                                 │
@@ -549,8 +549,8 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed guidelines on:
 
 ---
 
-**Architecture Version**: v1.6.1  
-**Last Updated**: August 19, 2025  
+**Architecture Version**: v1.6.2  
+**Last Updated**: August 25, 2025  
 **Next Review**: September 2025
 
 *This architecture is designed for scalability, security, and community growth while maintaining simplicity for end users and comprehensive functionality for AI platforms.*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Updates all version references from v1.6.1 to v1.6.2 following the critical OAuth fix merged in PR #741.

## Changes Made

- ✅ Updated `package.json` version to 1.6.2
- ✅ Updated `README.md` with v1.6.2 release notes and fixed OAuth messaging
- ✅ Updated `ARCHITECTURE.md` version references and last updated date
- ✅ Added v1.6.2 entry to `CHANGELOG.md` with critical bug fix details

## Context

Version 1.6.2 is a critical hotfix that resolves the OAuth default client ID bug from v1.6.1. The bug prevented the default OAuth client from being used in the `setup_github_auth` tool, breaking the "just works" authentication experience.

### Key Messages Updated
- Changed "New in v1.6.1" to "Fixed in v1.6.2" to reflect the bug fix
- Added detailed v1.6.2 changelog entry explaining the critical fix
- Updated version badge from v1.6.1 to v1.6.2

## Related PRs
- #741 - The critical OAuth fix that this documentation update follows

## Testing
- [x] All version references consistently updated to 1.6.2
- [x] Changelog accurately describes the fix
- [x] README messaging reflects the hotfix nature

🤖 Generated with [Claude Code](https://claude.ai/code)