### PR TITLE
Fix: OAuth helper NPM packaging and performance tests (v1.6.4)

### DIFF
--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -177,12 +177,12 @@ jobs:
 
           if [ "$HAS_PYTHON3" = "true" ]; then
             START_TIME=$(python3 -c "import time; print(int(time.time() * 1000))")
-            npm test > test-perf.log 2>&1
+            npm test -- test/__tests__/performance/ --no-coverage > test-perf.log 2>&1
             END_TIME=$(python3 -c "import time; print(int(time.time() * 1000))")
             TEST_TIME=$((END_TIME - START_TIME))
           else
             START_TIME=$(date +%s)
-            npm test > test-perf.log 2>&1
+            npm test -- test/__tests__/performance/ --no-coverage > test-perf.log 2>&1
             END_TIME=$(date +%s)
             TEST_TIME=$(((END_TIME - START_TIME) * 1000))
           fi

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "data/ensembles/**/*.md",
     "!dist/__tests__/**",
     "!dist/**/*.test.*",
+    "oauth-helper.mjs",
     "README.md",
     "LICENSE",
     "CHANGELOG.md"

--- a/src/index.ts
+++ b/src/index.ts
@@ -2725,7 +2725,8 @@ export class DollhouseMCPServer implements IToolHandler {
         const possiblePaths = [
           path.join(__dirname, '..', 'oauth-helper.mjs'),  // From dist/index.js
           path.join(process.cwd(), 'oauth-helper.mjs'),    // From CWD
-          path.join(__dirname, 'oauth-helper.mjs')         // Same directory
+          path.join(__dirname, 'oauth-helper.mjs'),        // Same directory
+          path.join(__dirname, '..', '..', 'oauth-helper.mjs') // NPM package root
         ];
         
         helperPath = null;


### PR DESCRIPTION
## Summary

This PR fixes two critical issues found in v1.6.3:

1. **OAuth Helper Missing from NPM Package** - Users installing from NPM couldn't authenticate with GitHub
2. **Performance Tests Failing in CI** - Workflow was running all tests instead of just performance tests

## Problems Fixed

### 1. OAuth Helper Not Included in NPM Distribution ❌ → ✅
**Issue**: The `oauth-helper.mjs` file exists in the repository but wasn't being included when publishing to NPM.

**Root Cause**: The `files` field in package.json didn't include `oauth-helper.mjs`

**Fix**: 
- Added `oauth-helper.mjs` to the files array in package.json
- Added additional fallback path in src/index.ts for NPM package installations

### 2. Performance Testing Workflow Failures ❌ → ✅
**Issue**: PR #751 showed performance tests failing with exit code 1 on all platforms

**Root Cause**: The workflow was running `npm test` which executes ALL tests, not just performance tests

**Fix**:
- Changed to `npm test -- test/__tests__/performance/ --no-coverage`
- Now only runs performance-specific tests

## Changes Made

1. **package.json** (line 97)
   - Added `oauth-helper.mjs` to files array

2. **src/index.ts** (line 2729)
   - Added fallback path: `path.join(__dirname, '..', '..', 'oauth-helper.mjs')`

3. **.github/workflows/performance-testing.yml** (lines 180, 185)
   - Changed test command to target only performance tests

## Testing

- ✅ Built locally: `npm run build`
- ✅ Performance tests run correctly: `npm test -- test/__tests__/performance/ --no-coverage`
- ✅ Verified oauth-helper.mjs included: `npm pack --dry-run | grep oauth-helper`
- ✅ All performance tests passing locally

## Impact

- Fixes GitHub authentication for NPM users
- Restores performance testing workflow reliability
- Enables proper CI/CD for performance monitoring

This should be released as v1.6.4 to fix the issues in v1.6.3.

🤖 Generated with [Claude Code](https://claude.ai/code)