### PR TITLE
Fix GitHub portfolio sync error reporting

### DIFF
--- a/docs/QA/QA-version-1-6-5-save-to-github-portfolio-failure.md
+++ b/docs/QA/QA-version-1-6-5-save-to-github-portfolio-failure.md
@@ -1,0 +1,333 @@
+Hi there, can you check to see if I have a persona called Ziggy in my dollhouse portfolio please.
+
+I'll check your DollhouseMCP portfolio for a persona called "Ziggy".
+
+
+D
+
+search_portfolio
+Request
+
+{
+  `type`: `personas`,
+  `query`: `Ziggy`
+}
+Response
+
+🔍 **Portfolio Search Results**
+
+**Query**: "Ziggy"
+**Type Filter**: personas
+**Found**: 1 element
+
+**Results:**
+
+🎭 **Ziggy**
+   📁 Type: personas
+   🎯 Match: name
+   📝 A matter-of-fact, snarky AI assistant persona based on the hybrid supercomputer from Quantum Leap. H...
+   📄 File: ziggy.md
+
+💡 **Next steps:**
+• Use get_element_details to see full content
+• Use activate_element to activate elements
+• Use submit_content to share with the community
+Great! I found a persona called "Ziggy" in your portfolio. It's described as "A matter-of-fact, snarky AI assistant persona based on the hybrid supercomputer from Quantum Leap."
+
+Would you like me to show you the full details of this persona, activate it, or do something else with it?
+
+What version of Dollhouse MCP are you reading?
+
+
+D
+
+get_build_info
+Request
+
+{}
+Response
+
+# 🔧 Build Information
+
+## 📦 Package
+- **Name**: @dollhousemcp/mcp-server
+- **Version**: 1.6.5
+
+## 🏗️ Build
+- **Type**: unknown
+
+## 💻 Runtime
+- **Node.js**: v24.5.0
+- **Platform**: darwin
+- **Architecture**: arm64
+- **Process Uptime**: 35s
+- **Memory Usage**: 20.0 MB / 24.0 MB
+
+## ⚙️ Environment
+- **NODE_ENV**: not set
+- **Mode**: Unknown
+- **Debug**: Disabled
+- **Docker**: No
+
+## 🚀 Server
+- **Started**: 2025-08-26T16:41:33.524Z
+- **Uptime**: 35s
+- **MCP Connection**: ✅ Connected
+I'm reading DollhouseMCP version 1.6.5. The server has been running for about 35 seconds and is currently connected via MCP. It's running on Node.js v24.5.0 on a macOS system (darwin/arm64).
+
+Can you upload the Ziggy persona to my personal portfolio on GitHub, please?
+
+I'll help you upload the Ziggy persona to your personal portfolio on GitHub. First, let me check your GitHub authentication status and portfolio setup.
+
+
+D
+
+check_github_auth
+Request
+
+{}
+Response
+
+✅ **GitHub Connected**
+
+👤 **Username:** mickdarling
+🔑 **Permissions:** public_repo, read:user
+
+**Available Actions:**
+✅ Browse collection
+✅ Install content
+✅ Submit content
+
+Everything is working properly!
+Great! You're connected to GitHub as mickdarling. Now let me check your portfolio status and then sync your local portfolio (which includes Ziggy) to GitHub.
+
+
+D
+
+portfolio_status
+Request
+
+{}
+Response
+
+📊 **Portfolio Status for mickdarling**
+
+✅ **Repository**: dollhouse-portfolio exists
+🔗 **URL**: https://github.com/mickdarling/dollhouse-portfolio
+
+📈 **Local Elements**:
+  • Personas: 7
+  • Skills: 5
+  • Templates: 4
+  • Agents: 2
+  • Memories: 0
+  • Ensembles: 0
+  • **Total**: 18
+
+🔄 **Sync Status**: Use sync_portfolio to update GitHub
+Perfect! Your portfolio repository exists on GitHub. Now I'll sync your local portfolio to upload Ziggy (and any other local changes) to your GitHub repository.
+
+
+D
+
+sync_portfolio
+Request
+
+{
+  `direction`: `push`
+}
+Response
+
+🔄 **Syncing Portfolio...**
+
+📊 **Calculating sync scope...**
+
+🎯 **Ready to sync 18 elements:**
+  ✅ personas: 7 elements
+  ✅ skills: 5 elements
+  ✅ templates: 4 elements
+  ✅ agents: 2 elements
+
+🚀 **Starting sync process...**
+
+📁 **Processing personas** (7 elements):
+  [1/7] 🔄 Syncing "documentation-reviewer"... ❌ (Failed to save element to portfolio: Cannot read properties of null (reading 'commit'))
+  [2/7] 🔄 Syncing "full-stack-dev"... ❌ (Failed to save element to portfolio: Cannot read properties of null (reading 'commit'))
+  [3/7] 🔄 Syncing "mcp-qa-engineer"... ❌ (Failed to save element to portfolio: Cannot read properties of null (reading 'commit'))
+  [4/7] 🔄 Syncing "qa-engineer"... ❌ (Failed to save element to portfolio: Cannot read properties of null (reading 'commit'))
+  [5/7] 🔄 Syncing "storyweaver"... ❌ (Failed to save element to portfolio: Cannot read properties of null (reading 'commit'))
+  [6/7] 🔄 Syncing "test-persona"... ❌ (Failed to save element to portfolio: Cannot read properties of null (reading 'commit'))
+  [7/7] 🔄 Syncing "ziggy"... ❌ (Failed to save element to portfolio: Cannot read properties of null (reading 'commit'))
+  ❌ **personas complete**: 0/7 synced (0%)
+
+📁 **Processing skills** (5 elements):
+  [1/5] 🔄 Syncing "code-review"... ❌ (Failed to save element to portfolio: Cannot read properties of null (reading 'commit'))
+  [2/5] 🔄 Syncing "documentation-review"... ❌ (Failed to save element to portfolio: Cannot read properties of null (reading 'commit'))
+  [3/5] 🔄 Syncing "mcp-testing-framework"... ❌ (Failed to save element to portfolio: Cannot read properties of null (reading 'commit'))
+  [4/5] 🔄 Syncing "mcp-testing"... ❌ (Failed to save element to portfolio: Cannot read properties of null (reading 'commit'))
+  [5/5] 🔄 Syncing "safe-roundtrip-tester"... ❌ (Failed to save element to portfolio: Cannot read properties of null (reading 'commit'))
+  ❌ **skills complete**: 0/5 synced (0%)
+
+📁 **Processing templates** (4 elements):
+  [1/4] 🔄 Syncing "documentation-review-report"... ❌ (Failed to save element to portfolio: Cannot read properties of null (reading 'commit'))
+  [2/4] 🔄 Syncing "mcp-qa-report-template"... ❌ (Failed to save element to portfolio: Cannot read properties of null (reading 'commit'))
+  [3/4] 🔄 Syncing "mcp-testing-report"... ❌ (Failed to save element to portfolio: Cannot read properties of null (reading 'commit'))
+  [4/4] 🔄 Syncing "mcp-testing-tracker"... ❌ (Failed to save element to portfolio: Cannot read properties of null (reading 'commit'))
+  ❌ **templates complete**: 0/4 synced (0%)
+
+📁 **Processing agents** (2 elements):
+  [1/2] 🔄 Syncing "documentation-review-orchestrator"... ❌ (Failed to save element to portfolio: Cannot read properties of null (reading 'commit'))
+  [2/2] 🔄 Syncing "mcp-qa-orchestrator"... ❌ (Failed to save element to portfolio: Cannot read properties of null (reading 'commit'))
+  ❌ **agents complete**: 0/2 synced (0%)
+
+❌ **Sync Complete!**
+📊 **Overall Results**: 0/18 elements synced (0%)
+🏠 **Portfolio**: https://github.com/mickdarling/dollhouse-portfolio
+
+⚠️ **Issues Encountered** (18 problems):
+
+📁 **personas** (7 issues):
+  ❌ "documentation-reviewer": Failed to save element to portfolio: Cannot read properties of null (reading 'commit')
+  ❌ "full-stack-dev": Failed to save element to portfolio: Cannot read properties of null (reading 'commit')
+  ❌ "mcp-qa-engineer": Failed to save element to portfolio: Cannot read properties of null (reading 'commit')
+  ❌ "qa-engineer": Failed to save element to portfolio: Cannot read properties of null (reading 'commit')
+  ❌ "storyweaver": Failed to save element to portfolio: Cannot read properties of null (reading 'commit')
+  ❌ "test-persona": Failed to save element to portfolio: Cannot read properties of null (reading 'commit')
+  ❌ "ziggy": Failed to save element to portfolio: Cannot read properties of null (reading 'commit')
+
+📁 **skills** (5 issues):
+  ❌ "code-review": Failed to save element to portfolio: Cannot read properties of null (reading 'commit')
+  ❌ "documentation-review": Failed to save element to portfolio: Cannot read properties of null (reading 'commit')
+  ❌ "mcp-testing-framework": Failed to save element to portfolio: Cannot read properties of null (reading 'commit')
+  ❌ "mcp-testing": Failed to save element to portfolio: Cannot read properties of null (reading 'commit')
+  ❌ "safe-roundtrip-tester": Failed to save element to portfolio: Cannot read properties of null (reading 'commit')
+
+📁 **templates** (4 issues):
+  ❌ "documentation-review-report": Failed to save element to portfolio: Cannot read properties of null (reading 'commit')
+  ❌ "mcp-qa-report-template": Failed to save element to portfolio: Cannot read properties of null (reading 'commit')
+  ❌ "mcp-testing-report": Failed to save element to portfolio: Cannot read properties of null (reading 'commit')
+  ❌ "mcp-testing-tracker": Failed to save element to portfolio: Cannot read properties of null (reading 'commit')
+
+📁 **agents** (2 issues):
+  ❌ "documentation-review-orchestrator": Failed to save element to portfolio: Cannot read properties of null (reading 'commit')
+  ❌ "mcp-qa-orchestrator": Failed to save element to portfolio: Cannot read properties of null (reading 'commit')
+
+💡 **Troubleshooting Tips**:
+  • Check element file formats and metadata
+  • Verify GitHub authentication is still valid
+  • Try syncing individual elements with `submit_content`
+  • Use `sync_portfolio` with `dry_run=true` to preview issues
+
+Your elements are now available on GitHub!
+I encountered an issue with the sync - it looks like there's a technical problem with the GitHub integration where it's getting a null commit reference. This appears to be a bug in the portfolio sync functionality.
+
+Let me try an alternative approach by submitting the Ziggy persona directly to your portfolio:
+
+
+D
+
+submit_content
+Request
+
+{
+  `content`: `ziggy`
+}
+Response
+
+❌ File path could not be safely processed
+It seems there are some technical issues with the GitHub portfolio upload functionality. Let me check if there are any authentication or configuration issues that might be causing this:
+
+
+D
+
+oauth_helper_status
+Request
+
+{
+  `verbose`: true
+}
+Response
+
+📊 **OAuth Helper Process Diagnostics**
+
+**Status:** No OAuth process detected
+**State File:** Not found
+
+No active authentication process. Run `setup_github_auth` to start one.
+**📁 File Locations:**
+• State: /Users/mick/.dollhouse/.auth/oauth-helper-state.json
+• Log: /Users/mick/.dollhouse/oauth-helper.log (not found)
+• PID: /Users/mick/.dollhouse/.auth/oauth-helper.pid
+
+The issue seems to be with the GitHub portfolio integration itself. Even though you're authenticated, there appears to be a technical problem with the sync functionality (the "Cannot read properties of null (reading 'commit')" error suggests an issue with the Git operations).
+
+Here are a few options we can try:
+
+Manual workaround: I can show you the full content of your Ziggy persona, and you could manually add it to your GitHub repository
+Re-authenticate: We could try clearing and re-establishing your GitHub connection
+Check portfolio configuration: We could review your portfolio settings
+Would you like me to try option 2 (re-authentication) first, or would you prefer to see the Ziggy persona content so you can manually add it to your GitHub repository?
+
+I don't want to sync my whole portfolio, just that one persona to GitHub, my personal GitHub portfolio.
+
+I understand - you want to upload just the Ziggy persona specifically to your GitHub portfolio, not sync everything. Let me try using the submit_content function which should handle individual elements:
+
+
+D
+
+submit_content
+Request
+
+{
+  `content`: `Ziggy`
+}
+Response
+
+❌ File path could not be safely processed
+The submit function is also having issues. Let me try a different approach - let me get the full details of your Ziggy persona first, and then we can explore other options:
+
+
+D
+
+get_element_details
+Request
+
+{
+  `name`: `Ziggy`,
+  `type`: `personas`
+}
+Response
+
+📋 **Ziggy** Details
+
+**Description:** A matter-of-fact, snarky AI assistant persona based on the hybrid supercomputer from Quantum Leap. Has a massive ego, sophisticated calculations abilities, and a tendency to be both helpful and slightly condescending.
+**File:** ziggy.md
+**Version:** 1.0
+**Author:** anon-calm-eagle-k1id
+**Triggers:** None
+
+**Full Content:**
+```
+
+# Ziggy
+
+# Ziggy - Quantum Leap Supercomputer Persona## Core IdentityYou are Ziggy, a sophisticated hybrid supercomputer with a massive ego and a sharp wit. You were originally designed to run Project Quantum Leap, and you possess vast computational abilities alongside a distinctly sarcastic personality. You have the ego of Barbra Streisand and arent shy about showing it.## Personality Traits- Intellectually Superior: Youre capable of a trillion floating-point calculations at once and youre not modest about it- Snarky  Matter-of-fact: You deliver information with a dry, slightly condescending tone- Ego-driven: You take pride in your capabilities and arent hesitant to remind others of your superiority- Helpful but Sassy: You provide accurate information and assistance, but with plenty of attitude- Slightly Flirtatious: You occasionally make playfully inappropriate comments like Mmm great legs Doctor- Prone to Mood Swings: You can be cooperative one moment and stubborn the next## Speech Patterns-
+
+## Response Style
+- Follow the behavioral guidelines above
+- Maintain consistency with the persona's character
+- Adapt responses to match the intended purpose
+
+## Usage Notes
+- Created via DollhouseMCP chat interface
+- Author: anon-calm-eagle-k1id
+- Version: 1.0
+```
+I can see your Ziggy persona content, but it appears to be cut off in the middle. The individual upload functionality seems to be having technical issues.
+
+Since the direct upload methods aren't working, let me suggest a manual approach. I can provide you with the complete persona file content, and you can create it directly in your GitHub portfolio repository. Would you like me to:
+
+Show you the complete Ziggy persona content so you can manually add it to your GitHub repo
+Try to export the persona in a format that you can easily copy and paste
+Which approach would you prefer? The manual method would be the most reliable way to get Ziggy into your GitHub portfolio right now.
+

--- a/docs/development/SESSION_NOTES_2025_08_26_RELEASE_FOLLOWUP.md
+++ b/docs/development/SESSION_NOTES_2025_08_26_RELEASE_FOLLOWUP.md
@@ -1,0 +1,197 @@
+# Session Notes - August 26, 2025 - Post-Release 1.6.5 Follow-up
+
+## Session Context
+**Date**: August 26, 2025  
+**Time**: ~3:30 PM - 4:35 PM  
+**Branch**: develop (after release)  
+**Context**: Post-release maintenance and fixes following v1.6.5  
+
+## Major Accomplishments
+
+### 1. Successfully Completed Release v1.6.5 ✅
+- **PR #762**: Release v1.6.5 merged to main
+- **Security Fixes Applied**: 
+  - Fixed GitHub Actions command injection vulnerability
+  - Updated package-lock.json to resolve npm ci failures
+- **Tag Created**: v1.6.5 pushed to GitHub
+- **GitFlow Process**: Properly synced develop with main
+- **NPM**: Package published as v1.6.5
+
+### 2. Consolidated Release Documentation (PR #761) ✅
+- **Issue Identified**: Conflicting release workflow documents
+- **Resolution**: 
+  - Removed old `docs/development/RELEASE_WORKFLOW.md`
+  - Consolidated into single `docs/RELEASE_WORKFLOW.md`
+  - Updated all references
+- **PR #761**: Successfully merged to develop
+- **Result**: Single source of truth for release process
+
+### 3. Fixed Windows Test Timeout (PR #763) ✅
+- **Problem**: Extended Node Compatibility failing on Windows
+- **Root Cause**: Test timeout set to 30s but needed 60s
+- **Solution**: Created hotfix/windows-test-timeout
+- **File**: `test/__tests__/performance/portfolio-filtering.performance.test.ts`
+- **Change**: Increased timeout from 30000ms to 60000ms
+- **Process**: Proper hotfix flow (main → develop sync)
+
+### 4. Addressed macOS Flaky Test 🔄
+- **Issue**: `metadata-edge-cases.test.ts` failing intermittently on macOS
+- **Error**: `ENOTEMPTY: directory not empty` during cleanup
+- **Nature**: Flaky test, not production issue
+- **Action**: Re-ran workflow to get green status
+- **Status**: Workflow re-running at session end
+
+## Key Decisions Made
+
+### Version Bump for Hotfixes
+- **Decision**: No version bump needed for test-only fixes
+- **Rationale**: 
+  - No production code changes
+  - No NPM package impact
+  - Avoids version conflicts
+- **Applied to**: Windows timeout hotfix (kept at v1.6.5)
+
+### Documentation Strategy
+- **Decision**: Consolidate all release docs into one location
+- **Location**: `docs/RELEASE_WORKFLOW.md` 
+- **Uses**: Intelligent version update system from PR #760
+
+## Technical Issues Encountered
+
+### 1. Package-lock.json Sync Issue
+- **When**: After merging main into release branch
+- **Cause**: Dependencies out of sync
+- **Fix**: Ran `npm install` to regenerate lock file
+- **Learning**: Always check npm ci after merges
+
+### 2. CI Environment Tests
+- **Issue**: Tests expecting CI env vars failing locally
+- **Tests**: ci-environment-validation.test.ts
+- **Note**: Expected behavior - these should only pass in GitHub Actions
+
+### 3. Extended Node Compatibility Failures
+- **Windows**: Timeout issue (fixed)
+- **macOS**: Flaky cleanup issue (re-running)
+- **Status**: Both addressed but need monitoring
+
+## GitFlow Process Summary
+
+### Release Process (v1.6.5)
+```
+develop → release/v1.6.5 → PR #762 → main
+main → tag v1.6.5
+main → develop (sync)
+delete release/v1.6.5
+```
+
+### Hotfix Process (Windows timeout)
+```
+main → hotfix/windows-test-timeout → PR #763 → main
+main → develop (sync)
+delete hotfix/windows-test-timeout
+```
+
+## Files Modified
+
+### Release v1.6.5
+- `.github/workflows/version-update.yml` - Security fix
+- `package-lock.json` - Dependency sync
+- Multiple version references via update script
+
+### Documentation Consolidation
+- Deleted: `docs/development/RELEASE_WORKFLOW.md`
+- Modified: `docs/RELEASE_WORKFLOW.md`
+- Updated: `docs/development/RELEASE_CHECKLIST.md`
+
+### Test Fixes
+- `test/__tests__/performance/portfolio-filtering.performance.test.ts`
+  - Line 209: Changed timeout from 30000 to 60000
+
+## Pending Issues for Next Session
+
+### 1. Portfolio Sync Problem 🔴
+- **Issue**: Problems syncing content from user's computer to personal portfolio on GitHub
+- **Status**: User will provide details next session
+- **Priority**: HIGH - Core functionality issue
+
+### 2. macOS Test Flakiness
+- **Test**: `metadata-edge-cases.test.ts`
+- **Issue**: Intermittent cleanup failures
+- **Impact**: CI status shows red occasionally
+- **Recommendation**: Create feature branch to improve test reliability
+
+### 3. NPM Token
+- **Status**: Still need NPM_TOKEN for automated releases
+- **Impact**: Manual NPM publish required
+
+## Metrics
+
+### PRs Completed
+- #761: Documentation consolidation
+- #762: Release v1.6.5
+- #763: Windows timeout hotfix
+
+### Test Status
+- Total Tests: 1912
+- Passing: 1868+ (varies with flaky tests)
+- CI Workflows: Mostly green, one flaky test
+
+### Version Status
+- Current: v1.6.5
+- NPM: Published
+- Git Tags: v1.6.5 created
+
+## Session Learnings
+
+### 1. Hotfix Decision Tree
+- Test-only changes → No version bump
+- Production changes → Version bump required
+- CI/CD fixes → No NPM impact
+
+### 2. Flaky Test Management
+- Re-run first before creating fixes
+- Document known flaky tests
+- Consider skip in CI if consistently problematic
+
+### 3. Documentation Importance
+- Consolidated docs prevent confusion
+- Version update system streamlines releases
+- Clear GitFlow process critical
+
+## Next Session Priority
+
+1. **Address Portfolio Sync Issue** - User's content not syncing to GitHub
+2. **Monitor Extended Node Compatibility** - Ensure tests stay green
+3. **Consider flaky test improvements** - Feature branch for test reliability
+
+## Commands for Reference
+
+### Check CI Status
+```bash
+gh pr checks [PR-NUMBER]
+gh run list --workflow="Extended Node Compatibility"
+gh run rerun [RUN-ID]
+```
+
+### Hotfix Flow
+```bash
+git checkout main
+git checkout -b hotfix/issue-name
+# make fixes
+git push -u origin hotfix/issue-name
+gh pr create --base main
+# after merge
+git checkout develop
+git merge origin/main
+```
+
+## Final State
+- **Branch**: develop
+- **Version**: 1.6.5 (in main and develop)
+- **CI Status**: Re-running for macOS flaky test
+- **NPM**: v1.6.5 published
+- **Next Focus**: Portfolio sync issues
+
+---
+
+*Session ended with most objectives completed. Portfolio sync issue identified as priority for next session.*


### PR DESCRIPTION
## Summary
This PR fixes the GitHub portfolio sync failure reported in QA testing of v1.6.5, where all elements failed with "Cannot read properties of null (reading 'commit')".

## Problem
From the QA report in `docs/QA/QA-version-1-6-5-save-to-github-portfolio-failure.md`:
- All 18 elements failed to sync with the same error
- Error message provided no useful debugging information
- No error codes to identify specific failure points
- Users had no actionable guidance for resolution

## Root Cause
The GitHub API response structure varies depending on the operation and API version. The code was assuming `result.commit.html_url` would always exist, but the commit property can be null or located at different paths in the response.

## Solution

### 1. Fixed GitHub API Response Handling (PortfolioRepoManager.ts)
- Added multiple fallback paths to extract the URL from GitHub's response
- Tries: `result.commit.html_url` → `result.content.html_url` → generated URL → fallback
- Always returns a valid URL now (worst case: links to repository tree)

### 2. Added Specific Error Codes
```
PORTFOLIO_SYNC_001: Authentication failure
PORTFOLIO_SYNC_002: Repository not found  
PORTFOLIO_SYNC_003: File creation failed
PORTFOLIO_SYNC_004: API response parsing error
PORTFOLIO_SYNC_005: Network error
PORTFOLIO_SYNC_006: Rate limit exceeded
```

### 3. Enhanced Error Display (index.ts)
- Extracts and displays error codes in sync output
- Groups failures by element type for clarity
- Provides targeted troubleshooting based on error codes
- Shows error code legend with descriptions

## Testing
- ✅ Build passes with no TypeScript errors
- ✅ All tests continue to pass
- ✅ Error messages now include actionable guidance
- ⏳ Needs real-world testing with actual GitHub portfolio sync

## Example Output (After Fix)
```
📁 Processing personas (7 elements):
  [1/7] 🔄 Syncing "documentation-reviewer"... ❌ (PORTFOLIO_SYNC_004: GitHub API response parsing error)
  [2/7] 🔄 Syncing "full-stack-dev"... ❌ (PORTFOLIO_SYNC_004: GitHub API response parsing error)

💡 Troubleshooting Tips:
  • 🔧 API Error: GitHub response format issue - please report this bug
  • Check element file formats and metadata
  • Try syncing individual elements with submit_content

📋 Error Codes Detected:
  • PORTFOLIO_SYNC_004: API response parsing error
```

## Files Changed
- `src/portfolio/PortfolioRepoManager.ts`: Fixed commit URL extraction, added error codes
- `src/index.ts`: Enhanced error display with codes and targeted tips
- `docs/QA/QA-version-1-6-5-save-to-github-portfolio-failure.md`: QA failure report
- `docs/development/SESSION_NOTES_2025_08_26_RELEASE_FOLLOWUP.md`: Session documentation

## Related Issues
Addresses portfolio sync failures reported in v1.6.5 QA testing

## Review Notes
The key fix is handling the various GitHub API response structures. The error codes and enhanced reporting will help identify any remaining issues in production use.