### PR TITLE
Release v1.6.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.6.11] - 2025-08-28
+
+### Fixed
+- Collection index URL updated to use GitHub Pages instead of raw GitHub URL
+- E2E tests now properly prioritize CI environment tokens over local .env files
+- MCP tool flow tests handle both string and object response formats for backward compatibility
+- Test suite reliability improvements for CI environments
+
 ## [1.6.10] - 2025-08-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -42,10 +42,6 @@ A comprehensive Model Context Protocol (MCP) server that enables dynamic AI pers
 # Install globally
 npm install -g @dollhousemcp/mcp-server
 
-# ✅ v1.6.9 fixes version management and release workflow!
-# Browse and submit to collection with or without authentication:
-# npm install -g @dollhousemcp/mcp-server@latest
-
 # Add to Claude Desktop config (see path below for your OS)
 # macOS: ~/Library/Application Support/Claude/claude_desktop_config.json
 # Windows: %APPDATA%\Claude\claude_desktop_config.json  

--- a/docs/development/SESSION_NOTES_2025_08_28_AFTERNOON_TEST_FIXES.md
+++ b/docs/development/SESSION_NOTES_2025_08_28_AFTERNOON_TEST_FIXES.md
@@ -1,0 +1,66 @@
+# Session Notes - August 28, 2025 - Afternoon Test Fixes
+
+## Session Context
+**PR**: #829 - Handle object response format in tests
+**Branch**: `fix/collection-test-failures`
+**Time**: Afternoon session
+**Focus**: Fix failing tests in CI for PR #829
+
+## Issues Identified
+
+### 1. Collection Index URL Mismatch
+**Problem**: Tests were expecting the old GitHub raw URL but implementation uses GitHub Pages URL
+**Solution**: Updated test to expect `https://dollhousemcp.github.io/collection/collection-index.json`
+**File**: `test/__tests__/unit/collection/CollectionIndexManager.test.ts`
+
+### 2. MCP Tool Flow Tests
+**Problem**: Tests expecting string responses but methods now return objects with content arrays
+**Status**: PR already has fixes for handling both formats - no additional changes needed
+**Files**: `test/e2e/mcp-tool-flow.test.ts` - Already updated with response format handling
+
+### 3. E2E GitHub Integration Tests
+**Problem**: Tests failing due to expired token in `.env.test.local` overriding CI token
+**Solution**: Modified `setup-test-env.ts` to prioritize CI environment variables over local .env file
+**File**: `test/e2e/setup-test-env.ts`
+
+## Fixes Applied
+
+### Commit 1: Collection URL Fix
+```bash
+git commit -m "fix: Update collection index URL in tests to match implementation"
+```
+- Updated expected URL from raw GitHub to GitHub Pages URL
+- This aligns tests with the actual implementation
+
+### Commit 2: E2E Token Priority Fix
+```bash
+git commit -m "fix: Prioritize CI GitHub token over local .env file"
+```
+- Store existing `GITHUB_TEST_TOKEN` before loading .env
+- Restore it after loading to ensure CI token takes precedence
+- Allows tests to use valid token from GitHub secrets in CI
+
+## Key Learnings
+
+1. **Response Format Changes**: The collection system fixes changed method responses from strings to objects with content arrays. The PR already handles this with backward compatibility.
+
+2. **Environment Variable Priority**: In CI environments, secrets should take precedence over local .env files to avoid expired/invalid tokens breaking tests.
+
+3. **URL Migration**: The collection index moved from raw GitHub URLs to GitHub Pages for better performance and caching.
+
+## Test Status After Fixes
+
+- ✅ Collection index URL test fixed
+- ✅ E2E tests now properly use CI token when available
+- ✅ MCP tool flow tests already handle object responses
+- 🔄 CI running with fixes
+
+## Files Modified
+1. `test/__tests__/unit/collection/CollectionIndexManager.test.ts` - URL fix
+2. `test/e2e/setup-test-env.ts` - Token priority fix
+3. `test/e2e/.env.test.local` - Added comment (not committed, gitignored)
+
+## Next Steps
+- Monitor CI results for PR #829
+- All major test issues have been addressed
+- E2E tests should now pass with proper GitHub token in CI

--- a/docs/development/SESSION_NOTES_2025_08_28_EVENING_COLLECTION_FIXES.md
+++ b/docs/development/SESSION_NOTES_2025_08_28_EVENING_COLLECTION_FIXES.md
@@ -7,7 +7,7 @@
 **Result**: ✅ Fixes implemented and working, ⚠️ Test failures need addressing  
 
 ## Context
-After completing the v1.6.10 release and documentation updates, received diagnostic report showing critical issues with the collection system preventing users from installing content.
+After completing the v1.6.11 release and documentation updates, received diagnostic report showing critical issues with the collection system preventing users from installing content.
 
 ## Issues Identified (from Diagnostic Report)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "1.6.9",
+  "version": "1.6.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "1.6.9",
+      "version": "1.6.11",
       "license": "AGPL-3.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cache/CollectionIndexCache.ts
+++ b/src/cache/CollectionIndexCache.ts
@@ -14,7 +14,7 @@ import { PerformanceMonitor } from '../utils/PerformanceMonitor.js';
 export class CollectionIndexCache {
   private cache: CachedIndex | null = null;
   private readonly TTL = 15 * 60 * 1000; // 15 minutes in milliseconds
-  private readonly INDEX_URL = 'https://raw.githubusercontent.com/DollhouseMCP/collection/main/public/collection-index.json';
+  private readonly INDEX_URL = 'https://dollhousemcp.github.io/collection/collection-index.json';
   private cacheDir: string;
   private cacheFile: string;
   private githubClient: GitHubClient;

--- a/test/e2e/mcp-tool-flow.test.ts
+++ b/test/e2e/mcp-tool-flow.test.ts
@@ -270,10 +270,17 @@ describe('MCP Tool Integration Flow', () => {
       // Use the submitContent function directly
       const submitResult = await server['submitContent'](`${testEnv.personaPrefix}test-ziggy`);
       
-      // Handle object response format
-      const submitText = typeof submitResult === 'string'
-        ? submitResult
-        : submitResult?.content?.[0]?.text || '';
+      // Handle object response format with validation
+      // Response can be either:
+      // 1. Legacy string format: direct text response
+      // 2. MCP object format: { content: [{ text: "..." }] }
+      // We validate the content array exists and has elements before accessing
+      let submitText = '';
+      if (typeof submitResult === 'string') {
+        submitText = submitResult;
+      } else if (submitResult?.content && Array.isArray(submitResult.content) && submitResult.content.length > 0) {
+        submitText = submitResult.content[0]?.text || '';
+      }
       
       console.log('     Submit result:', submitText.substring(0, 100));
       
@@ -336,10 +343,16 @@ describe('MCP Tool Integration Flow', () => {
       const authStatus = await server['checkGitHubAuth']();
       
       // Should show not authenticated
-      // Handle both string and object response formats
-      const authErrorText = typeof authStatus === 'string'
-        ? authStatus
-        : authStatus?.content?.[0]?.text || '';
+      // Handle both string and object response formats with validation
+      let authErrorText = '';
+      if (typeof authStatus === 'string') {
+        authErrorText = authStatus;
+      } else if (authStatus?.content && Array.isArray(authStatus.content) && authStatus.content.length > 0) {
+        authErrorText = authStatus.content[0]?.text || '';
+      }
+      
+      // Ensure we got a meaningful response
+      expect(authErrorText).toBeTruthy();
       expect(authErrorText).toMatch(/not authenticated|invalid|failed/i);
       console.log('     ✅ Auth error handled correctly');
       
@@ -366,10 +379,13 @@ describe('MCP Tool Integration Flow', () => {
       // Try to submit non-existent content
       const submitError = await server['submitContent']('non-existent-persona-xyz-123');
       
-      // Handle object response format
-      const errorMessage = typeof submitError === 'string'
-        ? submitError
-        : submitError?.content?.[0]?.text || '';
+      // Handle object response format with validation
+      let errorMessage = '';
+      if (typeof submitError === 'string') {
+        errorMessage = submitError;
+      } else if (submitError?.content && Array.isArray(submitError.content) && submitError.content.length > 0) {
+        errorMessage = submitError.content[0]?.text || '';
+      }
       
       // Should get helpful error message
       expect(errorMessage).toBeTruthy();

--- a/test/e2e/setup-test-env.ts
+++ b/test/e2e/setup-test-env.ts
@@ -50,7 +50,12 @@ export async function setupTestEnvironment(): Promise<TestEnvironment> {
 
   // Use existing token if it was set (CI), otherwise use the loaded one
   if (existingToken) {
-    process.env.GITHUB_TEST_TOKEN = existingToken;
+    // Validate token looks reasonable (GitHub tokens are typically 40+ chars)
+    if (existingToken.length < 10) {
+      console.warn('⚠️  CI token appears invalid (too short), falling back to .env file');
+    } else {
+      process.env.GITHUB_TEST_TOKEN = existingToken;
+    }
   }
 
   // Validate required variables


### PR DESCRIPTION
## Release v1.6.11

This release includes test suite reliability improvements and fixes for the collection system.

### Changes
- 🔧 Updated collection index URL to GitHub Pages 
- 🔧 Fixed e2e test token priority for CI environments
- 🔧 Added backward compatibility for response formats
- 📝 Removed outdated version references from README

### Test Fixes
- Collection tests now use correct GitHub Pages URL
- E2E tests prioritize CI tokens over local .env files  
- MCP tool flow tests handle both string and object formats

### Version Updates
- Version bumped from 1.6.10 to 1.6.11
- CHANGELOG updated with all fixes
- README cleaned up (removed v1.6.9 comment)

This release improves CI test reliability and ensures the collection system works properly with the new GitHub Pages hosting.