### PR TITLE
fix: Add unique_id to YAML frontmatter for collection submissions

### DIFF
--- a/src/tools/portfolio/PortfolioElementAdapter.ts
+++ b/src/tools/portfolio/PortfolioElementAdapter.ts
@@ -196,6 +196,7 @@ export class PortfolioElementAdapter implements IElement {
       ...existingMetadata, // Existing metadata first
       ...this.metadata,    // Our validated metadata overwrites
       id: this.id,         // Always use our ID
+      unique_id: this.id,  // CRITICAL FIX: Add unique_id for collection workflow compatibility
       type: this.type,     // Always use our type
       version: this.version // Always use our version
     };
@@ -223,6 +224,7 @@ export class PortfolioElementAdapter implements IElement {
       // Fall back to minimal safe metadata
       const safeMetadata = {
         id: this.id,
+        unique_id: this.id,  // CRITICAL FIX: Include unique_id for collection workflow
         type: this.type,
         version: this.version,
         name: this.normalizeString(this.metadata.name || 'Untitled'),


### PR DESCRIPTION
## Problem
The collection workflow requires a `unique_id` field in the YAML frontmatter but the PortfolioElementAdapter was not including it. This caused all PR creation attempts to fail with 'Missing required field: unique_id'.

## Solution
Add `unique_id` field to the YAML frontmatter when serializing elements:
- Added to merged metadata (uses element ID as unique_id)
- Added to safe metadata fallback
- Both changes ensure collection workflow receives required field

## Impact
This fixes the issue where 11 elements submitted to collection (issues #174-182 in the collection repo) failed to generate PRs.

## Testing
- The unique_id field will now be included in all serialized elements
- Collection workflow will be able to process submissions successfully

## Related
- Collection repo PR will add better error handling and auto-generation fallback