### PR TITLE
fix: Align E2E test environment variable with CI workflows

### DIFF
--- a/test/e2e/.env.test.local.example
+++ b/test/e2e/.env.test.local.example
@@ -4,7 +4,7 @@
 
 # Required: GitHub personal access token with 'repo' scope
 # Create at: https://github.com/settings/tokens
-GITHUB_TEST_TOKEN=ghp_your_actual_token_here
+TEST_GITHUB_TOKEN=ghp_your_actual_token_here
 
 # Test repository for uploads (will be created if doesn't exist)
 # Format: username/repository-name

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -30,7 +30,7 @@ nano test/e2e/.env.test.local
 
 Required configuration:
 ```env
-GITHUB_TEST_TOKEN=ghp_your_actual_token_here
+TEST_GITHUB_TOKEN=ghp_your_actual_token_here
 GITHUB_TEST_REPO=yourusername/dollhouse-portfolio-test
 GITHUB_TEST_USER=yourusername
 ```
@@ -70,7 +70,7 @@ npx jest test/e2e/mcp-tool-flow.test.ts --verbose
 
 ```bash
 # Override environment variables
-GITHUB_TEST_TOKEN=ghp_xxx TEST_CLEANUP_AFTER=false npm run test:e2e:real
+TEST_GITHUB_TOKEN=ghp_xxx TEST_CLEANUP_AFTER=false npm run test:e2e:real
 
 # Verbose logging for debugging
 TEST_VERBOSE_LOGGING=true npm run test:e2e:real
@@ -201,7 +201,7 @@ jobs:
         
       - name: Run real integration tests
         env:
-          GITHUB_TEST_TOKEN: ${{ secrets.GITHUB_TEST_TOKEN }}
+          TEST_GITHUB_TOKEN: ${{ secrets.TEST_GITHUB_TOKEN }}
           GITHUB_TEST_REPO: ${{ github.repository }}-test
           TEST_CLEANUP_AFTER: true
         run: npm run test:e2e:real
@@ -209,7 +209,7 @@ jobs:
 
 ### Required Secrets
 Add to repository secrets:
-- `GITHUB_TEST_TOKEN`: Personal access token with repo scope
+- `TEST_GITHUB_TOKEN`: Personal access token with repo scope
 
 ## Performance Benchmarks
 

--- a/test/e2e/setup-test-env.ts
+++ b/test/e2e/setup-test-env.ts
@@ -35,7 +35,7 @@ export interface TestEnvironment {
  */
 export async function setupTestEnvironment(): Promise<TestEnvironment> {
   // Store existing token if set (CI environment takes precedence)
-  const existingToken = process.env.GITHUB_TEST_TOKEN;
+  const existingToken = process.env.TEST_GITHUB_TOKEN;
   
   // Try to load .env.test.local for other settings
   const envPath = path.join(__dirname, '.env.test.local');
@@ -54,23 +54,23 @@ export async function setupTestEnvironment(): Promise<TestEnvironment> {
     if (existingToken.length < 10) {
       console.warn('⚠️  CI token appears invalid (too short), falling back to .env file');
     } else {
-      process.env.GITHUB_TEST_TOKEN = existingToken;
+      process.env.TEST_GITHUB_TOKEN = existingToken;
     }
   }
 
   // Validate required variables
-  const githubToken = process.env.GITHUB_TEST_TOKEN;
+  const githubToken = process.env.TEST_GITHUB_TOKEN;
   if (!githubToken) {
     // In CI environment, skip tests that require GitHub token
     if (process.env.CI) {
-      console.log('⏭️  Skipping E2E tests in CI - GITHUB_TEST_TOKEN not available');
+      console.log('⏭️  Skipping E2E tests in CI - TEST_GITHUB_TOKEN not available');
       return {
         githubToken: '',
         skipTests: true
       };
     }
     throw new Error(
-      'GITHUB_TEST_TOKEN is required. Please set it in .env.test.local or environment variables.\n' +
+      'TEST_GITHUB_TOKEN is required. Please set it in .env.test.local or environment variables.\n' +
       'Create a token at: https://github.com/settings/tokens with "repo" scope'
     );
   }

--- a/test/e2e/test-mcp-simple-submit.js
+++ b/test/e2e/test-mcp-simple-submit.js
@@ -17,12 +17,12 @@ async function testMCPSubmit() {
   const { DollhouseMCPServer } = await import('../../dist/index.js');
   
   // Set token
-  process.env.GITHUB_TOKEN = process.env.GITHUB_TEST_TOKEN || process.env.GITHUB_TOKEN;
+  process.env.GITHUB_TOKEN = process.env.TEST_GITHUB_TOKEN || process.env.GITHUB_TOKEN;
   if (!process.env.GITHUB_TOKEN) {
     // Try to load from .env.test.local
     const dotenv = await import('dotenv');
     dotenv.config({ path: 'test/e2e/.env.test.local' });
-    process.env.GITHUB_TOKEN = process.env.GITHUB_TEST_TOKEN;
+    process.env.GITHUB_TOKEN = process.env.TEST_GITHUB_TOKEN;
   }
   
   console.log('Token available:', process.env.GITHUB_TOKEN ? 'Yes' : 'No');

--- a/test/e2e/test-real-mcp-submit.js
+++ b/test/e2e/test-real-mcp-submit.js
@@ -34,7 +34,7 @@ async function testRealMCPSubmit() {
     const server = new DollhouseMCPServer();
     
     // Set the token from environment
-    process.env.GITHUB_TOKEN = process.env.GITHUB_TEST_TOKEN;
+    process.env.GITHUB_TOKEN = process.env.TEST_GITHUB_TOKEN;
     process.env.DOLLHOUSE_USER = 'mickdarling';
     
     // The server initializes itself, we just need to ensure it's ready


### PR DESCRIPTION
## Problem

The E2E tests have been failing in CI for 3 days due to an environment variable mismatch:

- **CI workflows provide**: `TEST_GITHUB_TOKEN` (correct - avoids GitHub's restriction on GITHUB_* names)
- **E2E tests expect**: `GITHUB_TEST_TOKEN` (incorrect)

## Timeline

- **Aug 23 (PR #724)**: Workflows correctly set to `TEST_GITHUB_TOKEN`
- **Aug 26**: E2E tests created looking for `GITHUB_TEST_TOKEN` (mismatch introduced)
- **Aug 30 (today)**: Tests have been skipping/failing in CI for 3 days

## Solution

Fixed all E2E test files and documentation to use `TEST_GITHUB_TOKEN` consistently:

- `test/e2e/setup-test-env.ts`: Main test environment setup
- `test/e2e/test-mcp-simple-submit.js`: MCP test scripts  
- `test/e2e/test-real-mcp-submit.js`: Real submission tests
- `test/e2e/.env.test.local.example`: Example configuration
- `test/e2e/README.md`: Documentation

## Result

- ✅ Workflows provide: `TEST_GITHUB_TOKEN` 
- ✅ Tests expect: `TEST_GITHUB_TOKEN`
- ✅ E2E tests should now work with the configured PAT in CI

## Testing

This is an atomic, focused fix that only changes variable names to align with existing CI configuration. No functional changes to test logic.

Ready for quick review and merge! 🚀