### PR TITLE
Fix Windows performance test timeout in Extended Node Compatibility workflow

### DIFF
--- a/test/__tests__/performance/portfolio-filtering.performance.test.ts
+++ b/test/__tests__/performance/portfolio-filtering.performance.test.ts
@@ -153,7 +153,7 @@ describe('Portfolio Filtering Performance', () => {
       
       console.log(`Large file filtering: ${fileCount} files filtered in ${duration.toFixed(2)}ms`);
       console.log(`Filtered down to ${elements.length} legitimate files from ${fileCount} total`);
-    });
+    }, 30000); // Increase timeout to 30 seconds for Windows CI
 
     // Increase timeout for Windows Node 22 compatibility (60 seconds)
     it('should handle very large single directory efficiently', async () => {


### PR DESCRIPTION
## Summary
This PR fixes a timeout issue in the Extended Node Compatibility workflow that started failing on Windows after PR #846 was merged.

## Problem
The test 'should efficiently filter large numbers of files' in portfolio-filtering.performance.test.ts was timing out on Windows CI after 10 seconds. This test creates and filters 1000 files, which takes longer on Windows runners in the Extended Node Compatibility workflow.

## Solution
Increased the test timeout from 10s (Jest default) to 30s, matching the timeout we set for other performance tests like IndexOptimization in PR #846.

## Testing
✅ Test passes locally with the increased timeout
✅ This is the same solution that worked for the IndexOptimization test

## Impact
- Fixes the Windows test failure in Extended Node Compatibility workflow
- Allows develop branch CI to be green again
- No functional changes, just giving the test more time on slower environments

This is a minimal fix focused on the immediate issue. The test itself is working correctly, it just needs more time on Windows CI runners.