### PR TITLE
Disable export_persona and export_all_personas tools

### DIFF
--- a/src/server/tools/PersonaTools.ts
+++ b/src/server/tools/PersonaTools.ts
@@ -9,39 +9,41 @@ import { IToolHandler } from '../types.js';
 
 export function getPersonaExportImportTools(server: IToolHandler): Array<{ tool: ToolDefinition; handler: any }> {
   return [
-    {
-      tool: {
-        name: "export_persona",
-        description: "Export a single persona to a JSON format",
-        inputSchema: {
-          type: "object",
-          properties: {
-            persona: {
-              type: "string",
-              description: "The persona name or filename to export",
-            },
-          },
-          required: ["persona"],
-        },
-      },
-      handler: (args: any) => server.exportPersona(args.persona)
-    },
-    {
-      tool: {
-        name: "export_all_personas",
-        description: "Export all personas to a JSON bundle",
-        inputSchema: {
-          type: "object",
-          properties: {
-            includeDefaults: {
-              type: "boolean",
-              description: "Include default personas in export (default: true)",
-            },
-          },
-        },
-      },
-      handler: (args: any) => server.exportAllPersonas(args.includeDefaults)
-    },
+    // Disabled: export_persona and export_all_personas are not compatible with the current element system
+    // These tools may be re-implemented once the element system is fully stabilized
+    // {
+    //   tool: {
+    //     name: "export_persona",
+    //     description: "Export a single persona to a JSON format",
+    //     inputSchema: {
+    //       type: "object",
+    //       properties: {
+    //         persona: {
+    //           type: "string",
+    //           description: "The persona name or filename to export",
+    //         },
+    //       },
+    //       required: ["persona"],
+    //     },
+    //   },
+    //   handler: (args: any) => server.exportPersona(args.persona)
+    // },
+    // {
+    //   tool: {
+    //     name: "export_all_personas",
+    //     description: "Export all personas to a JSON bundle",
+    //     inputSchema: {
+    //       type: "object",
+    //       properties: {
+    //         includeDefaults: {
+    //           type: "boolean",
+    //           description: "Include default personas in export (default: true)",
+    //         },
+    //       },
+    //     },
+    //   },
+    //   handler: (args: any) => server.exportAllPersonas(args.includeDefaults)
+    // },
     {
       tool: {
         name: "import_persona",


### PR DESCRIPTION
## Summary
This PR disables the `export_persona` and `export_all_personas` tools by commenting them out, keeping only `import_persona` active from the persona-specific tools.

## Rationale
These export tools are not compatible with the current element system architecture:
- They were designed for the old persona-only system
- They don't properly handle the new multi-element portfolio structure
- The underlying PersonaExporter implementation is outdated
- Users have reported these tools are not working correctly

## Changes
- **Commented out** `export_persona` tool definition
- **Commented out** `export_all_personas` tool definition
- **Kept active** `import_persona` tool (needs manual testing)
- **Preserved** method implementations for backward compatibility
- **Tool count**: Now 39 tools (was 41 before this change)

## Tools Status After This PR
- **Removed completely** (PR #850): share_persona, import_from_url
- **Disabled** (this PR): export_persona, export_all_personas  
- **Active**: import_persona (only remaining persona-specific tool)

## Testing
- ✅ Build passes (`npm run build`)
- ✅ TypeScript compilation successful
- ⏳ import_persona needs manual testing to verify it still works

## Future Considerations
The export functionality should be re-implemented as generic element export tools that work with all element types (personas, skills, templates, agents, etc.) rather than persona-specific tools.

## Related
- Follows PR #850 which removed share_persona and import_from_url
- Related to PR #851 which fixes tool count documentation