### PR TITLE
Add homepage URL to repository and improve metadata management

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A comprehensive Model Context Protocol (MCP) server that enables dynamic AI pers
 **🌐 Repository**: https://github.com/DollhouseMCP/mcp-server  
 **🏪 Collection**: https://github.com/DollhouseMCP/collection  
 **📦 NPM Package**: https://www.npmjs.com/package/@dollhousemcp/mcp-server  
-**🌍 Website**: https://dollhousemcp.com (planned)  
+**🌍 Website**: https://dollhousemcp.com  
 **📦 Version**: v1.6.11
 
 > **🎉 New in v1.6.9**: Fixed version update script to prevent wrong file creation and package-lock.json corruption. The release workflow now works reliably with proper version management.

--- a/docs/REPOSITORY_METADATA.md
+++ b/docs/REPOSITORY_METADATA.md
@@ -1,0 +1,100 @@
+# Repository Metadata Guide
+
+## Overview
+This guide explains how to maintain and update the repository metadata to ensure proper display on GitHub and NPM.
+
+## Key Metadata Locations
+
+### 1. Package.json
+The `package.json` file contains the primary metadata:
+- **name**: `@dollhousemcp/mcp-server` - The NPM package name
+- **homepage**: `https://dollhousemcp.com` - The project website
+- **repository.url**: `git+https://github.com/DollhouseMCP/mcp-server.git` - Links NPM to GitHub
+- **description**: Brief description of the project
+
+### 2. GitHub Repository Settings
+These settings control what appears in the GitHub UI:
+- **Homepage URL**: Should match package.json homepage
+- **Topics**: Help with discoverability
+- **Description**: Shows in the About section
+
+## Updating Repository Metadata
+
+### Automatic Update Script
+Run the provided script to sync settings:
+```bash
+./scripts/update-repo-settings.sh
+```
+
+This script:
+1. Reads the homepage URL from package.json
+2. Updates the GitHub repository homepage setting
+3. Adds relevant topics for discoverability
+4. Verifies the changes
+
+### Manual Update via GitHub CLI
+```bash
+# Set homepage URL
+gh repo edit DollhouseMCP/mcp-server --homepage "https://dollhousemcp.com"
+
+# Add topics
+gh repo edit DollhouseMCP/mcp-server --add-topic "npm-package"
+
+# Update description
+gh repo edit DollhouseMCP/mcp-server --description "Your description here"
+```
+
+## NPM Package Link Display
+
+GitHub automatically displays the NPM package link in the About section when:
+
+1. **package.json exists** in the repository root
+2. **Package is published** to NPM registry
+3. **Repository field matches** - The `repository.url` in package.json points to the GitHub repository
+
+### Troubleshooting NPM Link Not Showing
+
+If the NPM package link doesn't appear:
+
+1. **Verify package.json repository field**:
+   ```json
+   "repository": {
+     "type": "git",
+     "url": "git+https://github.com/DollhouseMCP/mcp-server.git"
+   }
+   ```
+
+2. **Check NPM publication**:
+   ```bash
+   npm view @dollhousemcp/mcp-server
+   ```
+
+3. **Wait for GitHub to update** - It can take a few hours for GitHub to detect and display the NPM package link
+
+4. **Check package visibility** - Ensure the package is public on NPM
+
+## Expected Display Locations
+
+### GitHub Repository Page (Right Sidebar - About Section)
+- 🔗 Website link (from homepage URL)
+- 📦 NPM package link (auto-detected)
+- 📝 Description
+- 🏷️ Topics
+
+### NPM Package Page (Right Sidebar)
+- Homepage link (from package.json homepage)
+- Repository link (from package.json repository)
+- Issues link (from package.json bugs)
+
+## Best Practices
+
+1. **Keep metadata synchronized** across package.json and GitHub settings
+2. **Run update script** after changing package.json metadata
+3. **Use descriptive topics** to improve discoverability
+4. **Update version** in package.json before releases
+5. **Maintain accurate description** in both locations
+
+## Related Files
+- `/package.json` - Primary metadata source
+- `/scripts/update-repo-settings.sh` - Automation script
+- `/README.md` - Project documentation with links

--- a/scripts/update-repo-settings.sh
+++ b/scripts/update-repo-settings.sh
@@ -7,6 +7,7 @@ echo "📦 Updating GitHub repository settings for DollhouseMCP/mcp-server..."
 
 # Get the homepage URL from package.json
 HOMEPAGE_URL=$(node -p "require('./package.json').homepage" 2>/dev/null)
+PACKAGE_NAME=$(node -p "require('./package.json').name" 2>/dev/null)
 
 if [ -z "$HOMEPAGE_URL" ]; then
   echo "❌ No homepage URL found in package.json"
@@ -15,7 +16,7 @@ fi
 
 echo "🌐 Setting homepage URL to: $HOMEPAGE_URL"
 
-# Update the GitHub repository settings
+# Update the GitHub repository settings with homepage
 gh repo edit DollhouseMCP/mcp-server --homepage "$HOMEPAGE_URL"
 
 if [ $? -eq 0 ]; then
@@ -27,7 +28,28 @@ else
   exit 1
 fi
 
+# Add topics to help with NPM package discovery
+echo ""
+echo "📝 Adding repository topics for better discoverability..."
+gh repo edit DollhouseMCP/mcp-server --add-topic "npm-package" --add-topic "mcp" --add-topic "model-context-protocol" --add-topic "ai" --add-topic "claude" --add-topic "persona-management"
+
+# Note about NPM package link
+echo ""
+echo "📦 NPM Package Information:"
+echo "   Package: $PACKAGE_NAME"
+echo "   URL: https://www.npmjs.com/package/$PACKAGE_NAME"
+echo ""
+echo "ℹ️  Note: GitHub automatically detects and displays NPM package links"
+echo "   in the About section when:"
+echo "   1. The repository has a package.json file"
+echo "   2. The package is published to NPM"
+echo "   3. The package.json 'repository' field points to this GitHub repo"
+echo ""
+echo "   Our package.json correctly has:"
+echo "   - name: $PACKAGE_NAME"
+echo "   - repository.url: git+https://github.com/DollhouseMCP/mcp-server.git"
+
 # Verify the update
 echo ""
 echo "📊 Current repository settings:"
-gh repo view DollhouseMCP/mcp-server --json name,description,homepageUrl | jq '.'
+gh repo view DollhouseMCP/mcp-server --json name,description,homepageUrl,repositoryTopics | jq '.'

--- a/scripts/update-repo-settings.sh
+++ b/scripts/update-repo-settings.sh
@@ -5,12 +5,46 @@
 
 echo "📦 Updating GitHub repository settings for DollhouseMCP/mcp-server..."
 
+# Check for required dependencies
+echo "🔍 Checking dependencies..."
+
+# Check for gh CLI
+if ! command -v gh &> /dev/null; then
+  echo "❌ GitHub CLI (gh) is not installed"
+  echo "   Please install it from: https://cli.github.com/"
+  echo "   Or via Homebrew: brew install gh"
+  exit 1
+fi
+
+# Check for jq
+if ! command -v jq &> /dev/null; then
+  echo "⚠️  jq is not installed (optional but recommended for formatted output)"
+  echo "   Install via Homebrew: brew install jq"
+  echo "   Or download from: https://stedolan.github.io/jq/"
+  JQ_AVAILABLE=false
+else
+  JQ_AVAILABLE=true
+fi
+
+# Check for Node.js
+if ! command -v node &> /dev/null; then
+  echo "❌ Node.js is not installed"
+  echo "   This script requires Node.js to read package.json"
+  echo "   Please install from: https://nodejs.org/"
+  exit 1
+fi
+
+echo "✅ All required dependencies found"
+echo ""
+
 # Get the homepage URL from package.json
 HOMEPAGE_URL=$(node -p "require('./package.json').homepage" 2>/dev/null)
 PACKAGE_NAME=$(node -p "require('./package.json').name" 2>/dev/null)
 
 if [ -z "$HOMEPAGE_URL" ]; then
   echo "❌ No homepage URL found in package.json"
+  echo "   Please add a 'homepage' field to package.json"
+  echo "   Example: \"homepage\": \"https://dollhousemcp.com\""
   exit 1
 fi
 
@@ -24,7 +58,14 @@ if [ $? -eq 0 ]; then
   echo "🔗 The website link should now appear on the GitHub repository page"
 else
   echo "❌ Failed to update repository settings"
-  echo "💡 Make sure you have the necessary permissions and gh CLI is authenticated"
+  echo ""
+  echo "   Possible reasons:"
+  echo "   1. You don't have write permissions to the repository"
+  echo "   2. GitHub CLI is not authenticated (run: gh auth login)"
+  echo "   3. Network connection issues"
+  echo "   4. Repository name or organization has changed"
+  echo ""
+  echo "   To check your authentication status, run: gh auth status"
   exit 1
 fi
 
@@ -32,6 +73,12 @@ fi
 echo ""
 echo "📝 Adding repository topics for better discoverability..."
 gh repo edit DollhouseMCP/mcp-server --add-topic "npm-package" --add-topic "mcp" --add-topic "model-context-protocol" --add-topic "ai" --add-topic "claude" --add-topic "persona-management"
+
+if [ $? -eq 0 ]; then
+  echo "✅ Successfully added repository topics"
+else
+  echo "⚠️  Failed to add some topics (they may already exist)"
+fi
 
 # Note about NPM package link
 echo ""
@@ -52,4 +99,13 @@ echo "   - repository.url: git+https://github.com/DollhouseMCP/mcp-server.git"
 # Verify the update
 echo ""
 echo "📊 Current repository settings:"
-gh repo view DollhouseMCP/mcp-server --json name,description,homepageUrl,repositoryTopics | jq '.'
+
+if [ "$JQ_AVAILABLE" = true ]; then
+  gh repo view DollhouseMCP/mcp-server --json name,description,homepageUrl,repositoryTopics | jq '.'
+else
+  echo "   (Install jq for formatted output)"
+  gh repo view DollhouseMCP/mcp-server --json name,description,homepageUrl,repositoryTopics
+fi
+
+echo ""
+echo "✨ Repository metadata update complete!"

--- a/scripts/update-repo-settings.sh
+++ b/scripts/update-repo-settings.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Script to update GitHub repository settings for DollhouseMCP/mcp-server
+# This ensures consistency between package.json and GitHub repository settings
+
+echo "📦 Updating GitHub repository settings for DollhouseMCP/mcp-server..."
+
+# Get the homepage URL from package.json
+HOMEPAGE_URL=$(node -p "require('./package.json').homepage" 2>/dev/null)
+
+if [ -z "$HOMEPAGE_URL" ]; then
+  echo "❌ No homepage URL found in package.json"
+  exit 1
+fi
+
+echo "🌐 Setting homepage URL to: $HOMEPAGE_URL"
+
+# Update the GitHub repository settings
+gh repo edit DollhouseMCP/mcp-server --homepage "$HOMEPAGE_URL"
+
+if [ $? -eq 0 ]; then
+  echo "✅ Successfully updated repository homepage URL"
+  echo "🔗 The website link should now appear on the GitHub repository page"
+else
+  echo "❌ Failed to update repository settings"
+  echo "💡 Make sure you have the necessary permissions and gh CLI is authenticated"
+  exit 1
+fi
+
+# Verify the update
+echo ""
+echo "📊 Current repository settings:"
+gh repo view DollhouseMCP/mcp-server --json name,description,homepageUrl | jq '.'


### PR DESCRIPTION
## Summary
This PR addresses the missing website and NPM package links in the GitHub repository's About section.

## Changes Made

### 1. Created Repository Settings Update Script
- Added `scripts/update-repo-settings.sh` to sync GitHub repository settings
- Script reads homepage from package.json and updates GitHub settings
- Adds repository topics for better discoverability
- Explains how GitHub auto-detects NPM packages

### 2. Updated README
- Removed '(planned)' from website URL as https://dollhousemcp.com is now active
- Website link now shows as active in the documentation

### 3. Added Repository Metadata Documentation
- Created `docs/REPOSITORY_METADATA.md` with comprehensive guide
- Explains where metadata is stored and how to update it
- Documents GitHub's automatic NPM package detection
- Includes troubleshooting steps if NPM link doesn't appear

## Why Links Were Missing

### Website Link
- The homepage URL was in package.json but not in GitHub repository settings
- GitHub shows the website link from repository settings, not package.json

### NPM Package Link
- GitHub automatically detects and displays NPM packages when:
  1. package.json exists with correct repository.url field ✅
  2. Package is published to NPM ✅
  3. GitHub's indexing has updated (can take a few hours)

## How to Apply Changes

After merging this PR, run:
```bash
./scripts/update-repo-settings.sh
```

This will:
1. Set the homepage URL in GitHub settings
2. Add relevant topics for discoverability
3. Display current repository metadata

## Expected Results
- 🌍 Website link will appear in the About section immediately
- 📦 NPM package link should appear within a few hours (GitHub's automatic detection)
- 🏷️ Repository topics will improve discoverability