### PR TITLE
Hotfix: Restore GitHub README display on main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,298 @@
 # DollhouseMCP
 
-[![npm version](https://img.shields.io/npm/v/@dollhousemcp/mcp-server.svg)](https://www.npmjs.com/package/@dollhousemcp/mcp-server)
+## Project Status
 [![MCP Compatible](https://img.shields.io/badge/MCP-Compatible-green)](https://modelcontextprotocol.io)
+[![npm version](https://img.shields.io/npm/v/@dollhousemcp/mcp-server.svg)](https://www.npmjs.com/package/@dollhousemcp/mcp-server)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+[![GitHub Views](https://komarev.com/ghpvc/?username=DollhouseMCP&repo=mcp-server&label=Repository+Views&style=flat)](https://github.com/DollhouseMCP/mcp-server)
+
+## Build & Quality
 [![Core Build & Test](https://github.com/DollhouseMCP/mcp-server/actions/workflows/core-build-test.yml/badge.svg)](https://github.com/DollhouseMCP/mcp-server/actions/workflows/core-build-test.yml)
+[![Build Artifacts](https://github.com/DollhouseMCP/mcp-server/actions/workflows/build-artifacts.yml/badge.svg)](https://github.com/DollhouseMCP/mcp-server/actions/workflows/build-artifacts.yml)
+[![Test Coverage](https://img.shields.io/badge/Coverage-1858%2B%20Tests-green)](https://github.com/DollhouseMCP/mcp-server/tree/main/__tests__)
+[![Enterprise-Grade Security](https://img.shields.io/badge/Security-Enterprise%20Grade-purple)](docs/SECURITY.md)
 
-A comprehensive Model Context Protocol (MCP) server that enables dynamic AI persona management with an integrated GitHub-powered collection. DollhouseMCP allows Claude and other compatible AI assistants to activate different behavioral personas while supporting community sharing and monetization.
+## Platform Support
+[![Windows Build Status](https://img.shields.io/badge/Windows-✓_Tested-0078D4?logo=windows&logoColor=white)](https://github.com/DollhouseMCP/mcp-server/actions/workflows/core-build-test.yml?query=branch:main "Windows CI Build Status")
+[![macOS Build Status](https://img.shields.io/badge/macOS-✓_Tested-000000?logo=apple&logoColor=white)](https://github.com/DollhouseMCP/mcp-server/actions/workflows/core-build-test.yml?query=branch:main "macOS CI Build Status")
+[![Linux Build Status](https://img.shields.io/badge/Linux-✓_Tested-FCC624?logo=linux&logoColor=black)](https://github.com/DollhouseMCP/mcp-server/actions/workflows/core-build-test.yml?query=branch:main "Linux CI Build Status")
+[![Docker](https://img.shields.io/badge/Docker-Ready-2496ED?logo=docker&logoColor=white)](https://github.com/DollhouseMCP/mcp-server/blob/main/Dockerfile)
 
-**🌐 Repository**: https://github.com/DollhouseMCP/mcp-server  
-**🏪 Collection**: https://github.com/DollhouseMCP/collection  
-**📦 NPM Package**: https://www.npmjs.com/package/@dollhousemcp/mcp-server  
-**🌍 Website**: https://dollhousemcp.com (planned)
+## Technology
+[![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Node.js](https://img.shields.io/badge/Node.js-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
+[![Extended Node Compatibility](https://github.com/DollhouseMCP/mcp-server/actions/workflows/extended-node-compatibility.yml/badge.svg)](https://github.com/DollhouseMCP/mcp-server/actions/workflows/extended-node-compatibility.yml)
+[![Docker Testing](https://github.com/DollhouseMCP/mcp-server/actions/workflows/docker-testing.yml/badge.svg)](https://github.com/DollhouseMCP/mcp-server/actions/workflows/docker-testing.yml)
+
+---
+
+<div align="center">
+  <img src="docs/assets/dollhouse-logo.png" alt="DollhouseMCP" width="200" />
+  
+  # Open Source, Community-Powered AI Customization
+  
+  ### Create, Edit, and Share Customization Elements for Your AI Platforms
+  
+  [![Install](https://img.shields.io/badge/Install-npm%20install%20@dollhousemcp/mcp--server-blue?style=for-the-badge)](https://www.npmjs.com/package/@dollhousemcp/mcp-server)
+  [![Collection](https://img.shields.io/badge/Browse-Community%20Collection-purple?style=for-the-badge)](https://github.com/DollhouseMCP/collection)
+  [![Contribute](https://img.shields.io/badge/Share-Your%20Elements-green?style=for-the-badge)](https://github.com/DollhouseMCP/mcp-server#contributing)
+</div>
+
+---
+
+## Elements That Customize Your AI's Capabilities and Actions
+
+**DollhouseMCP** is open source, community-powered AI customization. Create your own customization elements—personas that shape behavior, skills that add capabilities, templates for consistent outputs, and agents for automation—or use and modify an ever-growing number of customization elements from the community. Every element you create can be saved to your portfolio and used again or shared back to the DollhouseMCP Collection to help others.
+
+### What Are Customization Elements?
+
+- **Personas** – Shape how your AI acts and responds in specific domains
+- **Skills** – Add specialized capabilities your AI can use
+- **Templates** – Ensure consistent, high-quality outputs
+- **Agents** – Enable autonomous task completion with smart decision-making
+
+### Core Capabilities
+
+- **🌍  Community Element Library** – A growing number of tested personas, skills, templates, and agents
+- **✨  Create Custom Elements** – Create personas, skills, templates, and agents from scratch using natural language
+- **🤝  Open Source** – AGPL-3.0 licensed, ensuring community contributions stay free
+- **📚  The DollhouseMCP Collection** – Install any community element with one command
+- **🛠️  41 Professional Tools** – Complete toolkit for element creation and management
+- **🛡️  Security-First Validation** – All elements validated against hundreds of attack vectors
+- **⚡  Hot-Swap Elements** – Change personas, skills, and templates without restarting as needed
+- **📦  Personal Portfolio** – Your library of custom AI configurations on your local computer or personal GitHub repo
+
+### Use Cases
+
+<table>
+<tr>
+<td width="25%" align="center">
+<h4>👨‍💻 For Developers</h4>
+<p>Use community-powered code review personas and debugging skills. Share your language-specific optimizations.</p>
+</td>
+<td width="25%" align="center">
+<h4>✍️ For Writers</h4>
+<p>Access community-crafted writing styles and templates. Contribute your genre expertise.</p>
+</td>
+<td width="25%" align="center">
+<h4>🎯 For Professionals</h4>
+<p>Leverage community-built industry elements. Share your domain knowledge.</p>
+</td>
+<td width="25%" align="center">
+<h4>🌟 For Everyone</h4>
+<p>Give your AI any personality you want. Describe it, modify it, save it to your portfolio, share it with the world.</p>
+</td>
+</tr>
+</table>
+
+### Get Started
+
+```bash
+npm install @dollhousemcp/mcp-server
+```
+See [Quick Start](#quick-start) for complete setup instructions.
+
+---
+
+## 🎯 Element Types: Available Now & Coming Soon
+
+### ✅ Available Now
+
+<table>
+<tr>
+<td width="50%">
+
+#### 🎭 Personas
+Shape how your AI behaves and responds
+- **Creative Writer** - Imaginative storyteller for engaging narratives
+- **Business Consultant** - Strategic advisor for business decisions
+- **Debug Detective** - Systematic problem-solver for code issues
+- **Security Analyst** - Vulnerability assessment and threat analysis
+- **Technical Analyst** - Deep dive technical documentation
+- **Use**: `"Activate the creative writer persona"`
+
+</td>
+<td width="50%">
+
+#### 💡 Skills  
+Add specialized capabilities your AI can use
+- **Code Review** - Analyze code quality and suggest improvements
+- **Data Analysis** - Statistical analysis and visualization
+- **Language Translation** - Multi-language communication
+- **API Integration** - Connect and interact with external services
+- **Testing Automation** - Generate and run test suites
+- **Use**: `"Enable the code review skill"`
+
+</td>
+</tr>
+<tr>
+<td width="50%">
+
+#### 📝 Templates
+Ensure consistent, high-quality outputs
+- **Project Proposal** - Structured business proposals
+- **Penetration Test Report** - Security assessment documentation
+- **Meeting Notes** - Organized meeting summaries
+- **Code Review** - Systematic code evaluation format
+- **Documentation** - Technical documentation structure
+- **Use**: `"Use the project proposal template"`
+
+</td>
+<td width="50%">
+
+#### 🤖 Agents
+Enable autonomous task completion
+- **Code Reviewer** - Automated code quality assessment
+- **Task Manager** - Project organization and tracking
+- **Research Assistant** - Information gathering and synthesis
+- **Academic Researcher** - Scholarly research and citations
+- **Security Fix Specialist** - Vulnerability remediation
+- **Use**: `"Run the code reviewer agent"`
+
+</td>
+</tr>
+</table>
+
+### 🔄 Coming Soon
+
+<table>
+<tr>
+<td width="50%">
+
+#### 🧠 Memory
+Persistent context across sessions
+- **Project Context** - Remember project details and decisions
+- **Learning Progress** - Track skill development over time
+- **Personal Preferences** - Store user-specific settings
+- **Conversation History** - Maintain dialogue continuity
+- **Status**: Coming Soon
+
+</td>
+<td width="50%">
+
+#### 🎯 Ensembles
+Combine multiple elements as one unified entity
+- **Full-Stack Developer** - Frontend + Backend + DevOps skills
+- **Writing Suite** - Creative + Technical + Editorial capabilities
+- **Security Team** - Analyst + Auditor + Remediation skills
+- **Data Science Platform** - Analysis + Visualization + ML skills
+- **Status**: Coming Soon
+
+</td>
+</tr>
+<tr>
+<td width="50%">
+
+#### 🔧 Tools
+External function calls and commands
+- **Git Operations** - Version control management
+- **Database Queries** - Direct database interaction
+- **API Calls** - External service integration
+- **File Operations** - Advanced file manipulation
+- **Status**: Planned
+
+</td>
+<td width="50%">
+
+#### 📋 Prompts
+Reusable instruction sets
+- **Code Review Checklist** - Systematic review steps
+- **Security Audit Guide** - Vulnerability assessment process
+- **Writing Guidelines** - Style and tone instructions
+- **Debug Workflow** - Problem-solving methodology
+- **Status**: Planned
+
+</td>
+</tr>
+</table>
+
+## 💬 Natural Language Usage Examples
+
+DollhouseMCP is designed for natural language interaction. Just describe what you want in plain English - you don't need to be overly specific, the system will figure it out.
+
+### Importing from the Community Collection
+
+**Natural Language Examples:**
+- `"Show me all the personas in the Dollhouse Collection"`
+- `"What creative writing personas are available?"`
+- `"Install the storyteller persona from the collection"`
+- `"Search for Python development skills"`
+- `"Find templates for technical documentation"`
+
+**Direct Commands (if you prefer):**
+```bash
+browse_collection type="personas"
+search_collection "creative writing"
+install_content "personas/storyteller.md"
+```
+
+### Managing Your Portfolio
+
+**Natural Language Examples:**
+- `"What's in my portfolio?"`
+- `"Show me all my custom personas"`
+- `"Sync my portfolio with GitHub"`
+- `"Create a backup of my elements"`
+- `"Search my portfolio for marketing templates"`
+
+**Direct Commands (if you prefer):**
+```bash
+portfolio_status
+list_elements type="personas"
+sync_portfolio
+search_portfolio "marketing"
+```
+
+### Working with Elements
+
+**Natural Language Examples:**
+- `"Activate the code reviewer persona"`
+- `"What's currently active?"`
+- `"Switch to creative writing mode"`
+- `"Deactivate all elements"`
+- `"Show me details about the data analyst skill"`
+- `"Create a new persona for customer support"`
+- `"Edit the email template to be more formal"`
+
+**Direct Commands (if you prefer):**
+```bash
+activate_element "code-reviewer" type="personas"
+get_active_elements
+deactivate_element type="personas"
+get_element_details "data-analyst" type="skills"
+create_element type="personas" name="customer-support"
+```
+
+### Complete Workflow Example
+
+Here's how a typical session might look:
+
+```
+You: "I need help with creative writing"
+Assistant: "I'll help you with creative writing. Let me check what personas are available..."
+
+You: "Show me creative writing personas in the collection"
+Assistant: [Shows list of available creative writing personas]
+
+You: "Install and activate the storyteller persona"
+Assistant: "I've installed and activated the Storyteller persona. I'm now ready to help craft engaging narratives..."
+
+You: "Actually, let me create my own persona for science fiction writing"
+Assistant: "I'll help you create a custom science fiction writing persona. What characteristics would you like?"
+
+You: "Make it focus on hard sci-fi with attention to scientific accuracy"
+Assistant: [Creates custom persona with specified traits]
+
+You: "Save that to my portfolio as 'Hard SciFi Writer'"
+Assistant: "I've saved 'Hard SciFi Writer' to your portfolio. You can activate it anytime."
+```
+
+### Pro Tips
+
+- **Be conversational**: `"Help me write better code"` works as well as specific commands
+- **Stack elements**: `"Activate both the code reviewer and the Python expert"`  
+- **Save your favorites**: `"Save this configuration as my default setup"`
+- **Share with others**: `"Submit my custom persona to the community collection"`
 
 ## 🚀 Quick Start
 
@@ -226,73 +508,529 @@ search_collection query="python" type="skills"
 | 🛡️ **Data Protection** | Copy-on-write for default personas, comprehensive backup system |
 | 🏠 **Local-First Architecture** | Full functionality without cloud dependency |
 
-## 🎨 Portfolio Elements
+## 🎨 Portfolio System
 
-DollhouseMCP supports multiple element types for customizing AI behavior:
+The DollhouseMCP Portfolio system provides a comprehensive framework for managing AI elements locally and in the cloud.
 
-| Element | Purpose | Status |
-|---------|---------|--------|
-| 🎭 **Personas** | Define AI personality, tone, and behavioral characteristics | ✅ Available |
-| 🛠️ **Skills** | Add specific capabilities like code review, data analysis, or creative writing | ✅ Available |
-| 📝 **Templates** | Create reusable response formats for emails, reports, documentation | ✅ Available |
-| 🤖 **Agents** | Build autonomous assistants that can pursue goals and make decisions | ✅ Available |
-| 💬 **Prompts** | Pre-configured conversation starters and structured interactions | 🔄 Coming Soon |
-| 🧠 **Memory** | Persistent context storage with retention policies and search capabilities | 🔄 Coming Soon |
-| 🎯 **Ensemble** | Orchestrate multiple elements together as one unified entity | 🔄 Coming Soon |
+### Portfolio Structure
 
-Your portfolio lives in `~/.dollhouse/portfolio/` with elements organized by type.
+Your portfolio is organized by element type:
 
-## 🔧 Troubleshooting
+```
+~/.dollhouse/portfolio/
+├── personas/       # Behavioral profiles
+├── skills/         # Discrete capabilities  
+├── templates/      # Reusable content structures
+├── agents/         # Goal-oriented actors
+├── memories/       # Persistent context
+└── ensembles/      # Element combinations
+```
+
+### Key Features
+
+- **Local-First Architecture**: All elements stored locally with optional cloud sync
+- **GitHub Integration**: Sync your portfolio with GitHub for backup and sharing
+- **Version Control**: Full git integration for tracking changes
+- **Smart Detection**: Automatically identifies element types from content
+- **Flexible Naming**: Use any naming convention you prefer
+
+### Portfolio Management Tools
+
+Use the comprehensive set of MCP tools to manage your portfolio:
+
+- `list_portfolio_elements` - View all elements across types
+- `sync_portfolio` - Synchronize with GitHub
+- `upload_to_portfolio` - Share elements with the community
+- `download_from_portfolio` - Get elements from GitHub
+
+For detailed portfolio documentation, see the [Portfolio Guide](docs/guides/PORTFOLIO_SETUP_GUIDE.md).
+
+## 🔒 Security
+
+DollhouseMCP implements enterprise-grade security measures to protect your data and ensure safe operation.
+
+### Security Features
+
+- **Input Sanitization**: All user inputs validated and sanitized
+- **Path Traversal Prevention**: Filesystem access strictly controlled
+- **YAML Injection Protection**: Safe parsing with validation
+- **Command Injection Prevention**: No direct shell command execution
+- **Token Encryption**: OAuth tokens encrypted at rest
+- **Rate Limiting**: API calls throttled to prevent abuse
+- **Audit Logging**: Security events tracked for analysis
+
+### Security Testing
+
+- **Automated Security Scanning**: GitHub Advanced Security enabled
+- **Dependency Scanning**: Automated vulnerability detection
+- **Code Analysis**: Static analysis with CodeQL
+- **Secret Scanning**: Prevents credential leaks
+
+### Reporting Security Issues
+
+If you discover a security vulnerability, please:
+
+1. **DO NOT** create a public GitHub issue
+2. Open a private security advisory on GitHub
+3. Include steps to reproduce if possible
+4. Allow up to 48 hours for initial response
+
+For more details, see our [Security Policy](SECURITY.md).
+
+## 🛠️ Development
+
+### Getting Started
+
+```bash
+# Clone the repository
+git clone https://github.com/DollhouseMCP/mcp-server.git
+cd mcp-server
+
+# Install dependencies
+npm install
+
+# Build the project
+npm run build
+
+# Run tests
+npm test
+```
+
+### Development Workflow
+
+1. **Create Feature Branch**: `git checkout -b feature/your-feature`
+2. **Make Changes**: Implement your feature or fix
+3. **Run Tests**: `npm test`
+4. **Build**: `npm run build`
+5. **Submit PR**: Create pull request to develop branch
+
+### Available Scripts
+
+- `npm run build` - Compile TypeScript
+- `npm run dev` - Development mode with watch
+- `npm test` - Run test suite
+- `npm run lint` - Check code style
+- `npm run typecheck` - TypeScript type checking
+
+### Project Structure
+
+```
+src/
+├── index.ts           # Main server entry
+├── tools/            # MCP tool implementations
+├── utils/            # Utility functions
+├── types/            # TypeScript definitions
+└── elements/         # Element system
+```
+
+For detailed development guides, see [Development Documentation](docs/development/).
+
+## 🏭 Architecture
+
+### System Overview
+
+DollhouseMCP follows a modular, extensible architecture built on the Model Context Protocol (MCP) standard.
+
+### Core Components
+
+#### MCP Server
+- **Transport**: StdioServerTransport for Claude Desktop integration
+- **Protocol**: JSON-RPC 2.0 communication
+- **Tools**: 41 MCP tools for comprehensive functionality
+
+#### Element System
+- **BaseElement**: Abstract base class for all elements
+- **IElement Interface**: Common contract for elements
+- **Element Types**: Personas, Skills, Templates, Agents, Memories, Ensembles
+
+#### Portfolio Manager
+- **Local Storage**: File-based element storage
+- **GitHub Sync**: Git-based synchronization
+- **Version Control**: Full git integration
+
+#### Security Layer
+- **Input Validation**: All inputs sanitized
+- **Path Security**: Traversal prevention
+- **Token Management**: Encrypted storage
+
+### Data Flow
+
+1. **Client Request** → MCP Server
+2. **Tool Routing** → Appropriate handler
+3. **Element Processing** → Element system
+4. **Storage** → Portfolio manager
+5. **Response** → Client
+
+For detailed architecture documentation, see [Architecture Guide](docs/ARCHITECTURE.md).
+
+## 🎯 Troubleshooting
 
 ### Common Issues
 
-| Issue | Solution |
-|-------|----------|
-| **Personas not loading** | Check `~/.dollhouse/portfolio/personas/` directory exists |
-| **Server won't start** | Ensure Node.js v20+ is installed: `node --version` |
-| **Collection not working** | Check internet connection and GitHub API access |
-| **Tools not appearing in Claude** | Restart Claude Desktop completely after config changes |
-| **"Cannot find module" errors** | Reinstall: `npm install -g @dollhousemcp/mcp-server@latest` |
-| **Rate limit errors** | Wait 60 seconds; GitHub API has hourly limits |
+#### MCP Server Not Connecting
 
-### Need Help?
+**Symptoms**: Claude Desktop doesn't show DollhouseMCP in available servers
 
-- 📖 [Full Troubleshooting Guide](docs/TROUBLESHOOTING.md)
-- 💬 [GitHub Issues](https://github.com/DollhouseMCP/mcp-server/issues)
-- 💭 [GitHub Discussions](https://github.com/DollhouseMCP/mcp-server/discussions)
+**Solutions**:
+1. Verify configuration file location:
+   - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+   - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+2. Check JSON syntax is valid
+3. Restart Claude Desktop after configuration changes
+
+#### OAuth Authentication Fails
+
+**Symptoms**: Cannot authenticate with GitHub
+
+**Solutions**:
+1. Check internet connection
+2. Verify GitHub account has proper permissions
+3. Try using Personal Access Token instead:
+   ```bash
+   export GITHUB_TOKEN=your_pat_token
+   ```
+4. Clear cached credentials and retry
+
+#### Elements Not Loading
+
+**Symptoms**: Portfolio appears empty
+
+**Solutions**:
+1. Check portfolio directory exists: `~/.dollhouse/portfolio/`
+2. Verify file permissions
+3. Run `list_portfolio_elements` tool to diagnose
+4. Check element file format (YAML frontmatter required)
+
+#### Performance Issues
+
+**Symptoms**: Slow response times
+
+**Solutions**:
+1. Check portfolio size (large portfolios may be slow)
+2. Verify adequate system resources
+3. Consider using pagination for large lists
+4. Check network latency for GitHub operations
+
+### Getting Help
+
+- **Documentation**: [Full docs](https://github.com/DollhouseMCP/mcp-server/tree/main/docs)
+- **Issues**: [GitHub Issues](https://github.com/DollhouseMCP/mcp-server/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/DollhouseMCP/mcp-server/discussions)
+
+For detailed troubleshooting, see [Troubleshooting Guide](docs/troubleshooting/).
+
+## 🤝 Contributing
+
+We welcome contributions to DollhouseMCP! Here's how you can help:
+
+### Ways to Contribute
+
+- **🐛 Report Bugs**: Open an issue with reproduction steps
+- **✨ Request Features**: Suggest new functionality
+- **📝 Improve Documentation**: Fix typos, add examples
+- **💻 Submit Code**: Fix bugs or implement features
+- **🎨 Share Elements**: Contribute personas, skills, templates
+
+### Development Process
+
+1. **Fork the Repository**
+   ```bash
+   gh repo fork DollhouseMCP/mcp-server
+   ```
+
+2. **Create Feature Branch**
+   ```bash
+   git checkout -b feature/your-feature
+   ```
+
+3. **Make Changes**
+   - Follow existing code style
+   - Add tests for new functionality
+   - Update documentation
+
+4. **Test Thoroughly**
+   ```bash
+   npm test
+   npm run lint
+   npm run typecheck
+   ```
+
+5. **Submit Pull Request**
+   - Target the `develop` branch
+   - Provide clear description
+   - Reference any related issues
+
+### Code Style
+
+- TypeScript with strict mode
+- ESLint configuration provided
+- Prettier for formatting
+- Comprehensive JSDoc comments
+
+### Commit Messages
+
+Follow conventional commits:
+- `feat:` New feature
+- `fix:` Bug fix
+- `docs:` Documentation
+- `test:` Testing
+- `chore:` Maintenance
+
+### Review Process
+
+1. Automated CI checks must pass
+2. Code review by maintainers
+3. Address feedback
+4. Merge when approved
+
+For detailed guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## 📚 Resources
 
 ### Documentation
-- [Roundtrip Workflow Guide](docs/guides/ROUNDTRIP_WORKFLOW_USER_GUIDE.md)
-- [Portfolio Setup Guide](docs/guides/PORTFOLIO_SETUP_GUIDE.md)
-- [Element Detection Guide](docs/guides/ELEMENT_DETECTION_GUIDE.md)
-- [PersonaTools Migration Guide](docs/PERSONATOOLS_MIGRATION_GUIDE.md)
-- [API Documentation](docs/API.md)
+
+- **[Quick Start Guide](docs/QUICK_START.md)** - Get up and running quickly
+- **[Portfolio Setup](docs/guides/PORTFOLIO_SETUP_GUIDE.md)** - Configure your portfolio
+- **[Element Development](docs/ELEMENT_DEVELOPER_GUIDE.md)** - Create custom elements
+- **[API Reference](docs/API_REFERENCE.md)** - Complete tool documentation
+- **[Architecture Guide](docs/ARCHITECTURE.md)** - System design details
+- **[Security Documentation](docs/SECURITY.md)** - Security measures and best practices
+
+### Repositories
+
+- **[Main Repository](https://github.com/DollhouseMCP/mcp-server)** - Core MCP server
+- **[Collection](https://github.com/DollhouseMCP/collection)** - Community elements
+- **[Developer Kit](https://github.com/DollhouseMCP/developer-kit)** - Development tools
 
 ### Community
-- [GitHub Repository](https://github.com/DollhouseMCP/mcp-server)
-- [NPM Package](https://www.npmjs.com/package/@dollhousemcp/mcp-server)
-- [Community Collection](https://github.com/DollhouseMCP/collection)
-- [Discord Community](https://discord.gg/dollhousemcp) (coming soon)
 
-### Development
-- [Contributing Guide](CONTRIBUTING.md)
-- [Security Policy](SECURITY.md)
-- [Full Changelog](CHANGELOG.md)
+- **[GitHub Discussions](https://github.com/DollhouseMCP/mcp-server/discussions)** - Q&A and ideas
+- **[GitHub Issues](https://github.com/DollhouseMCP/mcp-server/issues)** - Bug reports and features
+- **[Discord Server](#)** - Real-time chat (coming soon)
 
-## 📄 License
+### External Resources
 
-DollhouseMCP is licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+- **[Model Context Protocol](https://modelcontextprotocol.io)** - MCP specification
+- **[Claude Desktop](https://claude.ai/download)** - AI assistant with MCP support
+- **[Anthropic Documentation](https://docs.anthropic.com)** - Claude documentation
 
-### What this means:
-- ✅ **Free to use** for personal and commercial purposes
-- ✅ **Modify and distribute** with the same license
-- ✅ **Network use** requires source code disclosure
-- ✅ **Platform stability** commitments protect users
+### Learning Materials
 
-See [LICENSE](LICENSE) for full terms.
+- **Tutorials** (coming soon)
+  - Building Your First Persona
+  - Creating Custom Skills
+  - Portfolio Management Best Practices
+  - GitHub Integration Setup
+
+- **Videos** (coming soon)
+  - Installation Walkthrough
+  - Feature Demonstrations
+  - Developer Tutorials
+
+### Support
+
+- **GitHub Issues**: [Report issues or request features](https://github.com/DollhouseMCP/mcp-server/issues)
+- **Security Issues**: [Private security advisories](https://github.com/DollhouseMCP/mcp-server/security/advisories)
+- **Discussions**: [Community Q&A](https://github.com/DollhouseMCP/mcp-server/discussions)
+
+## 🏷️ Version History
+
+### v1.6.11 - August 28, 2025
+
+**Test Reliability & Collection Fixes**: Improved test suite stability and fixed collection system
+
+#### 🔧 Bug Fixes
+- **Collection Index URL**: Fixed to use GitHub Pages for better reliability
+- **E2E Test Tokens**: Improved token prioritization for CI environments
+- **Response Format**: Enhanced compatibility with various response formats
+- **Type Safety**: Improved TypeScript types throughout test suite
+
+#### ✨ Improvements
+- Added helper functions for better code organization
+- Enhanced test reliability in CI/CD pipelines
+- General code quality improvements
 
 ---
 
-*Built with ❤️ by the DollhouseMCP team*
+### v1.6.10 - August 28, 2025
+
+**Collection Submission Fix**: Critical fix for collection submission pipeline
+
+#### 🔧 Bug Fixes
+- **Collection Submission**: Fixed workflow failing due to missing element types
+- **Local Path Parameter**: Added missing localPath parameter to submission tool
+- **Duplicate Detection**: Added detection for duplicate portfolio uploads and collection issues
+
+#### ✨ Improvements
+- Added comprehensive QA tests for collection submission validation
+- Cleaned up QA documentation files
+- Updated all documentation to v1.6.10
+
+---
+
+### v1.6.9 - August 26, 2025
+
+**Critical Fixes**: Fixed OAuth helper NPM packaging and performance testing workflow
+
+#### 🔧 Bug Fixes
+- **OAuth NPM Packaging**: Fixed missing `oauth-helper.mjs` file in NPM distribution
+  - File was present in repository but not included in published package
+  - OAuth authentication now works correctly for NPM users
+- **Performance Tests**: Fixed CI workflow running all tests instead of performance tests
+  - Performance monitoring now works correctly in GitHub Actions
+
+---
+
+### v1.6.3 - August 25, 2025
+
+**OAuth Authentication Fix**: Fixed invalid OAuth client ID and improved error handling
+
+#### 🔧 Bug Fixes
+- **OAuth Client ID**: Updated from incorrect ID to correct `Ov23li9gyNZP6m9aJ2EP`
+- **Error Messages**: Improved clarity of OAuth error messages for better debugging
+- **Setup Tool**: Fixed `setup_github_auth` tool to properly handle authentication flow
+
+---
+
+### v1.6.2 - August 25, 2025
+
+**Critical Hotfix**: Fixed OAuth default client ID not being used in `setup_github_auth` tool
+
+#### 🔧 Bug Fixes
+- **OAuth Default Client**: Fixed `setup_github_auth` tool not using default client ID when none provided
+- **Authentication Flow**: Restored ability to authenticate without manual client ID entry
+
+#### 📝 Documentation
+- Added troubleshooting guide for OAuth issues
+- Updated setup instructions with clearer OAuth configuration steps
+
+---
+
+### v1.6.1 - August 25, 2025
+
+**⚠️ Breaking Changes**:
+- 🔄 **Serialization Format Change** - `BaseElement.serialize()` now returns markdown with YAML frontmatter instead of JSON
+
+#### 🔧 Bug Fixes
+- **Serialization Format**: Fixed `BaseElement.serialize()` to return markdown format
+  - Changed from JSON string to markdown with YAML frontmatter
+  - Maintains consistency with existing persona format
+  - Fixes portfolio round-trip workflow
+
+#### ✨ Improvements
+- **Code Quality**: Extracted validation methods into ValidationService
+- **Error Handling**: Improved validation error messages with specific field information
+- **Test Coverage**: Added comprehensive tests for markdown serialization
+
+---
+
+### v1.6.0 - August 25, 2025
+
+**🚀 Major Release: Portfolio System & OAuth Integration**
+
+This release introduces the complete portfolio management system with GitHub OAuth authentication, enabling secure cloud-based element synchronization and management.
+
+#### ✨ New Features
+
+##### 🔐 GitHub OAuth Authentication
+- **OAuth App Integration**: Full OAuth flow with GitHub for secure authentication
+- **Personal Access Token Support**: Alternative authentication method for CI/CD
+- **Token Management**: Secure storage and rotation of authentication tokens
+- **Multi-Account Support**: Handle multiple GitHub accounts seamlessly
+
+##### 📦 Portfolio Management System
+- **Cloud Sync**: Automatic synchronization between local and GitHub portfolios
+- **Version Control**: Full git integration for portfolio elements
+- **Conflict Resolution**: Smart merging of local and remote changes
+- **Batch Operations**: Upload/download multiple elements efficiently
+
+##### 🛠️ New MCP Tools (42 total)
+- `setup_github_auth`: Interactive GitHub OAuth setup
+- `check_github_auth`: Verify authentication status
+- `refresh_github_token`: Rotate OAuth tokens
+- `sync_portfolio`: Bidirectional portfolio synchronization
+- `upload_to_portfolio`: Upload local elements to GitHub
+- `download_from_portfolio`: Download elements from GitHub
+- `submit_to_portfolio`: Submit elements for review
+- And 30 more tools for complete portfolio management
+
+#### 🔧 Bug Fixes
+- **Element Detection**: Fixed smart detection of element types
+- **YAML Parsing**: Improved handling of complex YAML structures
+- **Path Resolution**: Fixed Windows path compatibility issues
+- **Token Security**: Enhanced token storage encryption
+
+#### 📝 Documentation
+- Comprehensive OAuth setup guide
+- Portfolio management tutorials
+- Troubleshooting guides for common issues
+- API documentation for all new tools
+
+#### 🔒 Security
+- OAuth token encryption at rest
+- Secure token transmission
+- Rate limiting for API calls
+- Audit logging for all operations
+
+---
+
+For complete release history prior to v1.6.0, see the [GitHub Releases](https://github.com/DollhouseMCP/mcp-server/releases) page.
+
+## 📜 License
+
+This project is licensed under the **GNU Affero General Public License v3.0 (AGPL-3.0)** with Platform Stability Commitments.
+
+### What This Means
+
+#### ✅ You CAN:
+- Use the software for personal projects
+- Use the software for commercial projects
+- Modify the source code
+- Distribute the software
+- Use personas and elements you create
+
+#### ⚠️ You MUST:
+- Include the license and copyright notice
+- State changes made to the code
+- Disclose your source code when distributing
+- Use the same AGPL-3.0 license for derivatives
+- **Make network use source available** (AGPL requirement)
+
+#### ❌ You CANNOT:
+- Hold us liable for damages
+- Use our trademarks without permission
+- Claim warranty or guarantee of fitness
+- Resell commercially
+
+### Platform Stability Commitments
+
+We provide additional guarantees beyond the AGPL-3.0:
+
+- **90-day advance notice** for monetization policy changes
+- **12-month revenue sharing locks** for content creators
+- **Full data portability** - export all your content anytime
+- **180-day transition period** for platform ownership changes
+- **Community advisory input** on major policy decisions
+
+### Contributor License Agreement
+
+By contributing to DollhouseMCP, you agree that:
+
+1. You have the right to grant us license to your contribution
+2. Your contribution is licensed under AGPL-3.0
+3. You grant us additional rights to use your contribution in our commercial offerings
+4. You retain copyright to your contribution
+
+For the complete license text, see [LICENSE](LICENSE).
+
+### Questions?
+
+If you have questions about the license or what you can do with DollhouseMCP:
+
+- **Documentation**: [License FAQ](docs/LICENSE_FAQ.md)
+- **GitHub Issue**: Open an issue with the `license` label
+- **Discussions**: Ask in [GitHub Discussions](https://github.com/DollhouseMCP/mcp-server/discussions)
+
+---
+
+*Copyright © 2025 DollhouseMCP. All rights reserved.*


### PR DESCRIPTION
## 🔥 Hotfix

### Problem
After the v1.7.0 release, the main branch's README.md is showing the NPM version instead of the full GitHub version. This makes the repository page display incomplete information.

### Root Cause
The automated README sync workflow is failing due to branch protection rules preventing direct pushes to main. The workflow needs to either:
1. Bypass branch protection (requires admin token)
2. Create PRs instead of direct pushes

### Immediate Fix
This hotfix updates README.md to use the full GitHub version (README.github.md) for proper repository display.

### Files Changed
- `README.md` - Replaced NPM version with full GitHub version (791 insertions, 53 deletions)

### Long-term Solution Needed
The readme-sync workflow needs to be updated to handle protected branches. Options:
- Use a GitHub App or admin token that can bypass protection
- Change workflow to create PRs instead of direct pushes
- Add the workflow bot to bypass list in branch protection settings

### Testing
- ✅ README.github.md builds correctly from chunks
- ✅ Content includes all v1.7.0 improvements
- ✅ File size correct (34.4 KB)

This is a critical display issue that affects the repository's presentation to users.