### PR TITLE
Hotfix: Add repository quick links to README header

### DIFF
--- a/README.github.md
+++ b/README.github.md
@@ -26,6 +26,13 @@
 
 ---
 
+**🌐 Repository**: https://github.com/DollhouseMCP/mcp-server  
+**🏪 Collection**: https://github.com/DollhouseMCP/collection  
+**📦 NPM Package**: https://www.npmjs.com/package/@dollhousemcp/mcp-server  
+**🌍 Website**: https://dollhousemcp.com (planned)
+
+---
+
 <div align="center">
   <img src="docs/assets/dollhouse-logo.png" alt="DollhouseMCP" width="200" />
   

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@
 
 ---
 
+**🌐 Repository**: https://github.com/DollhouseMCP/mcp-server  
+**🏪 Collection**: https://github.com/DollhouseMCP/collection  
+**📦 NPM Package**: https://www.npmjs.com/package/@dollhousemcp/mcp-server  
+**🌍 Website**: https://dollhousemcp.com (planned)
+
+---
+
 <div align="center">
   <img src="docs/assets/dollhouse-logo.png" alt="DollhouseMCP" width="200" />
   

--- a/docs/development/SESSION_NOTES_2025_08_31_LATE_AFTERNOON_RELEASE_PREP.md
+++ b/docs/development/SESSION_NOTES_2025_08_31_LATE_AFTERNOON_RELEASE_PREP.md
@@ -1,0 +1,202 @@
+# Session Notes - August 31, 2025 - Late Afternoon - v1.7.0 Release Preparation
+
+## Session Summary
+**Time**: 3:45 PM - 5:00 PM PST  
+**Focus**: README restoration, chunk file fixes, and v1.7.0 release preparation  
+**Branch**: `release/1.7.0`  
+**PR**: #866 - Release v1.7.0 to main  
+
+## What We Accomplished
+
+### 1. ✅ Fixed README Content Issues
+- **Problem**: PR #864 changes were auto-reverted by readme-sync workflow
+- **Root Cause**: Direct edits to README.md don't persist; must edit chunk source files
+- **Solution**: Updated chunk files in `docs/readme/chunks/`:
+  - `01-element-types-and-examples.md` - Added 20+ specific element examples
+  - `12-license.md` - Simplified commercial resale restriction
+
+### 2. ✅ Added Specific Element Examples
+Instead of generic "Examples: X, Y, Z", now showing actual elements:
+
+**Personas** (5 examples):
+- Creative Writer - Imaginative storyteller
+- Business Consultant - Strategic advisor  
+- Debug Detective - Systematic problem-solver
+- Security Analyst - Vulnerability assessment
+- Technical Analyst - Deep dive documentation
+
+**Skills** (5 examples):
+- Code Review - Quality analysis
+- Data Analysis - Statistical visualization
+- Language Translation - Multi-language
+- API Integration - External services
+- Testing Automation - Test suite generation
+
+**Templates** (5 examples):
+- Project Proposal - Business proposals
+- Penetration Test Report - Security docs
+- Meeting Notes - Organized summaries
+- Code Review - Evaluation format
+- Documentation - Technical structure
+
+**Agents** (5 examples):
+- Code Reviewer - Automated assessment
+- Task Manager - Project organization
+- Research Assistant - Information synthesis
+- Academic Researcher - Scholarly research
+- Security Fix Specialist - Vulnerability remediation
+
+### 3. ✅ Added New Element Types to Roadmap
+- **🔧 Tools**: External function calls (Git, Database, APIs, Files)
+- **📋 Prompts**: Reusable instruction sets (Checklists, Guidelines)
+
+### 4. ✅ Created Release Branch and PR
+- Created `release/1.7.0` branch from develop
+- Bumped version to 1.7.0 in package.json
+- Updated package-lock.json
+- Created PR #866 to merge to main
+- Resolved README conflict by rebuilding from chunks
+
+### 5. ✅ Addressed Security Review Concerns
+Fixed all critical issues from Claude review:
+
+1. **Path Traversal Prevention** (`scripts/build-readme.js`)
+   - Sanitizes chunk names to prevent directory traversal
+   - Validates resolved paths stay within intended directory
+
+2. **Command Injection Prevention** (`.github/workflows/readme-sync.yml`)
+   - Replaced `sed` with bash parameter expansion
+   - No shell execution with user input
+
+3. **License Simplification** (`docs/readme/chunks/12-license.md`)
+   - Changed to simple "Resell commercially" prohibition
+
+4. **NPM Cache Optimization** (`.github/workflows/readme-sync.yml`)
+   - Added `cache: 'npm'` to setup-node action
+
+## Current State
+
+### PR #866 Status
+- **Conflict**: ✅ Resolved
+- **Security Fixes**: ✅ Applied (commit e70aa4d)
+- **CI Checks**: 🔄 Running
+- **Ready to Merge**: Once CI passes
+
+### What's in v1.7.0
+- 68 commits from develop branch
+- 20+ specific element examples in README
+- New Tools and Prompts element types
+- Enhanced natural language usage examples
+- Simplified commercial resale restriction
+- Security fixes for path traversal and command injection
+- NPM cache optimization
+
+### Files Modified This Session
+```
+docs/readme/chunks/01-element-types-and-examples.md  # Element examples
+docs/readme/chunks/12-license.md                      # License simplification
+scripts/build-readme.js                               # Path traversal fix
+.github/workflows/readme-sync.yml                     # Command injection fix + cache
+README.md                                             # Auto-generated
+README.github.md                                      # Auto-generated
+package.json                                          # Version 1.7.0
+package-lock.json                                     # Updated dependencies
+```
+
+## Critical Information for Next Session
+
+### ⚠️ IMPORTANT: Chunk Files Are The Source
+- **README.md is auto-generated** from chunks in `docs/readme/chunks/`
+- **Never edit README.md directly** - changes will be lost
+- **Always edit chunk files** then run `npm run build:readme`
+- The automated workflow rebuilds README on every push
+
+### Todo List for Completion
+1. ✅ Fix path traversal risk in README builder
+2. ✅ Fix command injection in workflow  
+3. ✅ Simplify license to 'Cannot resell commercially'
+4. ✅ Add cache to setup-node action
+5. ⏳ **Merge PR #866 to main** (waiting for CI)
+6. 📋 **Create v1.7.0 tag after merge**
+7. 📋 **Merge release back to develop**
+8. 📋 **Publish to NPM** (if desired)
+
+### Commands for Next Session
+
+```bash
+# Check PR status
+gh pr checks 866
+gh pr view 866
+
+# Once CI passes, merge PR
+gh pr merge 866 --merge
+
+# After merge, create tag
+git checkout main
+git pull
+git tag -a v1.7.0 -m "Release v1.7.0
+
+- 20+ specific element examples in documentation
+- New Tools and Prompts element types
+- Enhanced natural language usage examples
+- Security fixes for path traversal and command injection
+- Simplified commercial license restriction"
+git push origin v1.7.0
+
+# Merge release back to develop
+git checkout develop
+git merge release/1.7.0
+git push
+
+# Publish to NPM (if desired)
+npm publish --access public
+```
+
+### NPM Publishing Checklist
+Before publishing to NPM:
+1. ✅ Version bumped to 1.7.0
+2. ✅ package-lock.json updated
+3. ✅ README.npm.md generated
+4. ⏳ Tests passing
+5. ⏳ Security audit clean
+6. ⏳ Tag created on GitHub
+7. ⏳ Release notes written
+
+### Potential Issues to Watch
+1. **CI Checks**: Monitor for any test failures
+2. **NPM Token**: Ensure NPM_TOKEN is set if using automated publishing
+3. **README Sync**: Workflow will run after merge - verify it preserves our changes
+4. **Branch Protection**: Main branch requires all checks to pass
+
+## Session Statistics
+- **Duration**: ~1.25 hours
+- **PRs Created**: 2 (#865 to develop, #866 to main)
+- **PRs Merged**: 1 (#865)
+- **Commits**: 4 (chunk updates, version bump, conflict resolution, security fixes)
+- **Security Issues Fixed**: 4 (path traversal, command injection, license, cache)
+- **Lines Changed**: ~150
+
+## Key Achievements
+1. ✅ Successfully restored all README improvements
+2. ✅ Fixed root cause by updating chunk source files
+3. ✅ Prepared complete v1.7.0 release
+4. ✅ Addressed all critical security concerns
+5. ✅ Followed GitFlow properly with release branch
+
+## Next Session Priority
+1. **Monitor CI checks** for PR #866
+2. **Merge PR #866** once checks pass
+3. **Create v1.7.0 tag**
+4. **Merge release back to develop**
+5. **Publish to NPM** (optional but recommended)
+6. **Create GitHub release** with release notes
+
+## Notes for NPM Publishing
+- Package name: `@dollhousemcp/mcp-server`
+- Current version: 1.6.11 → 1.7.0
+- License: AGPL-3.0
+- Make sure to use `--access public` flag
+
+---
+
+*Session ended at ~5:00 PM with release fully prepared and waiting for CI checks to complete. Next session will complete the release process.*

--- a/docs/readme/chunks/00-header-extended.md
+++ b/docs/readme/chunks/00-header-extended.md
@@ -23,3 +23,10 @@
 [![Node.js](https://img.shields.io/badge/Node.js-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![Extended Node Compatibility](https://github.com/DollhouseMCP/mcp-server/actions/workflows/extended-node-compatibility.yml/badge.svg)](https://github.com/DollhouseMCP/mcp-server/actions/workflows/extended-node-compatibility.yml)
 [![Docker Testing](https://github.com/DollhouseMCP/mcp-server/actions/workflows/docker-testing.yml/badge.svg)](https://github.com/DollhouseMCP/mcp-server/actions/workflows/docker-testing.yml)
+
+---
+
+**🌐 Repository**: https://github.com/DollhouseMCP/mcp-server  
+**🏪 Collection**: https://github.com/DollhouseMCP/collection  
+**📦 NPM Package**: https://www.npmjs.com/package/@dollhousemcp/mcp-server  
+**🌍 Website**: https://dollhousemcp.com (planned)


### PR DESCRIPTION
## 🔥 Hotfix

### Problem
The important quick links are missing from the main README on GitHub, making it harder for users to navigate to key resources.

### Solution
Added the following links prominently at the top of the README (after the badges):
- 🌐 **Repository**: https://github.com/DollhouseMCP/mcp-server  
- 🏪 **Collection**: https://github.com/DollhouseMCP/collection  
- 📦 **NPM Package**: https://www.npmjs.com/package/@dollhousemcp/mcp-server  
- 🌍 **Website**: https://dollhousemcp.com (planned)

### Files Changed
- `docs/readme/chunks/00-header-extended.md` - Added quick links section
- `README.github.md` - Auto-generated with links
- `README.md` - Updated with GitHub version

### Testing
- ✅ README builds correctly with links
- ✅ Links are properly formatted
- ✅ File size correct (34.7 KB)

This improves the repository's usability by making key resources immediately accessible.