### PR TITLE
Hotfix: Support flexible element naming in activation, deactivation, and details

### DIFF
--- a/docs/development/SESSION_NOTES_2025_08_31_FLEXIBLE_ELEMENT_ACTIVATION.md
+++ b/docs/development/SESSION_NOTES_2025_08_31_FLEXIBLE_ELEMENT_ACTIVATION.md
@@ -1,0 +1,127 @@
+# Session Notes - August 31, 2025 - Flexible Element Activation Hotfix
+
+## Session Overview
+**Date**: August 31, 2025  
+**Time**: Late evening (post v1.7.0 release)  
+**Branch**: `hotfix/flexible-element-activation`  
+**Context**: Fixing usability issue with element activation discovered by user
+
+## Problem Identified
+
+User noticed that when installing elements from the collection, activation fails when using the filename instead of the exact display name:
+- **Install**: `install_content "technical-analyst"` ✅ Works
+- **Activate with filename**: `activate_element "technical-analyst"` ❌ Fails  
+- **Activate with display name**: `activate_element "Technical Analyst"` ✅ Works
+
+This is a poor user experience - users should be able to activate elements using either format.
+
+## Root Cause Analysis
+
+- Personas already have flexible finding logic (searches by both filename and display name)
+- Other element types (Skills, Templates, Agents) only search by exact `metadata.name`
+- This inconsistency causes activation failures when users naturally use the filename
+
+## Solution Implemented
+
+### 1. Added Flexible Finding Helper Methods
+
+Added two new helper methods to `src/index.ts`:
+
+```typescript
+private async findElementFlexibly(name: string, elementList: any[]): Promise<any>
+private slugify(text: string): string
+```
+
+The `findElementFlexibly` method:
+- First tries exact name match (case-insensitive)
+- Then tries slug match (filename format)
+- Finally tries partial match
+- Returns the found element or undefined
+
+### 2. Updated Element Activation
+
+Modified `activateElement` method to use flexible finding for:
+- ✅ Skills - Updated to use `findElementFlexibly`
+- ✅ Templates - Updated to use `findElementFlexibly`
+- ✅ Agents - Updated to use `findElementFlexibly`
+- ✅ Personas - Already had flexible logic
+
+## Files Modified
+
+1. **src/index.ts**:
+   - Added `findElementFlexibly` helper method (lines 331-364)
+   - Added `slugify` helper method (lines 370-378)
+   - Updated Skills activation (lines 807-817)
+   - Updated Templates activation (lines 831-841)
+   - Updated Agents activation (lines 853-863)
+
+## Work Remaining
+
+Due to context limitations, the following tasks still need completion:
+
+### Immediate Tasks (for next session)
+1. **Update deactivateElement** - Apply same flexible finding
+2. **Update getElementDetails** - Apply same flexible finding
+3. **Test the fix** - Verify all element types work with both naming formats
+4. **Create PR** - Submit hotfix PR to main branch
+
+### Code Snippets to Apply
+
+For `deactivateElement` method, update similar to:
+```typescript
+// Use flexible finding to support both display name and filename
+const allElements = await this.elementManager.list();
+const element = await this.findElementFlexibly(name, allElements);
+```
+
+## Testing Checklist
+
+When testing, verify these scenarios work:
+- [ ] Install element from collection with kebab-case name
+- [ ] Activate using kebab-case filename (e.g., "technical-analyst")
+- [ ] Activate using display name (e.g., "Technical Analyst")
+- [ ] Deactivate using both formats
+- [ ] Get details using both formats
+- [ ] Test with Skills, Templates, and Agents
+
+## Commands for Next Session
+
+```bash
+# Continue on hotfix branch
+cd /Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server
+git status
+
+# Complete remaining edits for deactivateElement and getElementDetails
+# Test the changes
+npm test
+
+# Create PR when ready
+gh pr create --title "Hotfix: Support flexible element naming in activation" \
+  --body "Fixes activation failures when using filename instead of display name" \
+  --base main
+```
+
+## Key Decisions
+
+1. **Hotfix approach**: Started as hotfix to assess complexity
+2. **Search strategy**: Progressive matching (exact → slug → partial)
+3. **Consistency**: Applied same logic across all element types
+4. **Backward compatibility**: Maintains existing exact name matching
+
+## Session End State
+
+- **Branch**: hotfix/flexible-element-activation (uncommitted changes)
+- **Status**: Partially complete - activation updated, deactivation pending
+- **Context**: ~95% used
+- **Todo Progress**: 2/6 tasks complete
+
+## Impact
+
+This fix will significantly improve user experience by:
+- Allowing natural use of filenames for activation
+- Reducing "element not found" errors
+- Making the system more forgiving of naming variations
+- Providing consistency across all element types
+
+---
+*Session ending due to context limit. Continue with deactivateElement and getElementDetails updates in next session.*

--- a/security-audit-report.md
+++ b/security-audit-report.md
@@ -1,7 +1,7 @@
 # Security Audit Report
 
-Generated: 2025-08-31T20:27:12.866Z
-Duration: 3ms
+Generated: 2025-08-31T22:37:46.828Z
+Duration: 7ms
 
 ## Summary
 
@@ -22,7 +22,7 @@ Duration: 3ms
 
 #### DMCP-SEC-006: Security operation without audit logging
 
-- **File**: `/var/folders/kj/45kjdq714853c8nlnsv7l0_r0000gn/T/security-audit-test-fskW1M/auth-handler.js`
+- **File**: `/var/folders/kj/45kjdq714853c8nlnsv7l0_r0000gn/T/security-audit-test-1zj5Mn/auth-handler.js`
 - **Confidence**: medium
 - **Remediation**: Add SecurityMonitor.logSecurityEvent() for audit trail
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -840,7 +840,7 @@ export class DollhouseMCPServer implements IToolHandler {
             };
           }
           
-          const variables = template.metadata.variables?.map(v => v.name).join(', ') || 'none';
+          const variables = template.metadata.variables?.map((v: any) => v.name).join(', ') || 'none';
           return {
             content: [{
               type: "text",
@@ -987,7 +987,9 @@ export class DollhouseMCPServer implements IToolHandler {
           return this.deactivatePersona();
           
         case ElementType.SKILL: {
-          const skill = await this.skillManager.find(s => s.metadata.name === name);
+          // Use flexible finding to support both display name and filename
+          const allSkills = await this.skillManager.list();
+          const skill = await this.findElementFlexibly(name, allSkills);
           if (!skill) {
             return {
               content: [{
@@ -1001,7 +1003,7 @@ export class DollhouseMCPServer implements IToolHandler {
           return {
             content: [{
               type: "text",
-              text: `✅ Skill '${name}' deactivated`
+              text: `✅ Skill '${skill.metadata.name}' deactivated`
             }]
           };
         }
@@ -1016,7 +1018,9 @@ export class DollhouseMCPServer implements IToolHandler {
         }
         
         case ElementType.AGENT: {
-          const agent = await this.agentManager.find(a => a.metadata.name === name);
+          // Use flexible finding to support both display name and filename
+          const allAgents = await this.agentManager.list();
+          const agent = await this.findElementFlexibly(name, allAgents);
           if (!agent) {
             return {
               content: [{
@@ -1030,7 +1034,7 @@ export class DollhouseMCPServer implements IToolHandler {
           return {
             content: [{
               type: "text",
-              text: `✅ Agent '${name}' deactivated`
+              text: `✅ Agent '${agent.metadata.name}' deactivated`
             }]
           };
         }
@@ -1064,7 +1068,9 @@ export class DollhouseMCPServer implements IToolHandler {
           return this.getPersonaDetails(name);
           
         case ElementType.SKILL: {
-          const skill = await this.skillManager.find(s => s.metadata.name === name);
+          // Use flexible finding to support both display name and filename
+          const allSkills = await this.skillManager.list();
+          const skill = await this.findElementFlexibly(name, allSkills);
           if (!skill) {
             return {
               content: [{
@@ -1089,7 +1095,7 @@ export class DollhouseMCPServer implements IToolHandler {
           
           if (skill.metadata.parameters && skill.metadata.parameters.length > 0) {
             details.push('', '**Parameters**:');
-            skill.metadata.parameters.forEach(p => {
+            skill.metadata.parameters.forEach((p: any) => {
               details.push(`- ${p.name} (${p.type}): ${p.description}`);
             });
           }
@@ -1103,7 +1109,9 @@ export class DollhouseMCPServer implements IToolHandler {
         }
         
         case ElementType.TEMPLATE: {
-          const template = await this.templateManager.find(t => t.metadata.name === name);
+          // Use flexible finding to support both display name and filename
+          const allTemplates = await this.templateManager.list();
+          const template = await this.findElementFlexibly(name, allTemplates);
           if (!template) {
             return {
               content: [{
@@ -1126,7 +1134,7 @@ export class DollhouseMCPServer implements IToolHandler {
           
           if (template.metadata.variables && template.metadata.variables.length > 0) {
             details.push('', '**Variables**:');
-            template.metadata.variables.forEach(v => {
+            template.metadata.variables.forEach((v: any) => {
               details.push(`- ${v.name} (${v.type}): ${v.description}`);
             });
           }
@@ -1140,7 +1148,9 @@ export class DollhouseMCPServer implements IToolHandler {
         }
         
         case ElementType.AGENT: {
-          const agent = await this.agentManager.find(a => a.metadata.name === name);
+          // Use flexible finding to support both display name and filename
+          const allAgents = await this.agentManager.list();
+          const agent = await this.findElementFlexibly(name, allAgents);
           if (!agent) {
             return {
               content: [{

--- a/src/index.ts
+++ b/src/index.ts
@@ -335,7 +335,7 @@ export class DollhouseMCPServer implements IToolHandler {
     
     // Normalize the search name for comparison
     const searchNameLower = name.toLowerCase();
-    const searchNameSlug = this.slugify(name);
+    const searchNameSlug = slugify(name);
     
     // First try exact name match (case-insensitive)
     let element = elementList.find(e => 
@@ -345,7 +345,7 @@ export class DollhouseMCPServer implements IToolHandler {
     // If not found, try slug match (filename without extension)
     if (!element) {
       element = elementList.find(e => {
-        const elementSlug = this.slugify(e.metadata?.name || '');
+        const elementSlug = slugify(e.metadata?.name || '');
         return elementSlug === searchNameSlug || elementSlug === searchNameLower;
       });
     }
@@ -354,7 +354,7 @@ export class DollhouseMCPServer implements IToolHandler {
     if (!element) {
       element = elementList.find(e => {
         const elementName = e.metadata?.name || '';
-        const elementSlug = this.slugify(elementName);
+        const elementSlug = slugify(elementName);
         return elementSlug.includes(searchNameSlug) || 
                elementName.toLowerCase().includes(searchNameLower);
       });
@@ -367,15 +367,6 @@ export class DollhouseMCPServer implements IToolHandler {
    * Convert a string to a slug format (lowercase with hyphens)
    * Matches the format used for element filenames
    */
-  private slugify(text: string): string {
-    return text
-      .toLowerCase()
-      .trim()
-      .replace(/[^\w\s-]/g, '') // Remove non-word chars except spaces and hyphens
-      .replace(/[\s_]+/g, '-')  // Replace spaces and underscores with hyphens
-      .replace(/--+/g, '-')     // Replace multiple hyphens with single hyphen
-      .replace(/^-+|-+$/g, ''); // Remove leading/trailing hyphens
-  }
   
   /**
    * Sanitize metadata object to prevent prototype pollution


### PR DESCRIPTION
## Problem
Users were experiencing issues when trying to manage elements using the filename format instead of the display name. For example:
- ❌ `activate_element "technical-analyst"` would fail
- ✅ `activate_element "Technical Analyst"` would work

This was a poor user experience since users naturally use the filename format after installing from the collection.

## Solution
Implemented flexible element finding that searches by:
1. Exact name match (case-insensitive)
2. Slug match (filename format)
3. Partial match as fallback

## Testing
- ✅ Verified slugify function works correctly with various inputs
- ✅ Build succeeds without TypeScript errors
- ✅ All tests passing (except one unrelated GitHub integration test)

## Impact
This significantly improves user experience by allowing natural use of filenames for all element operations.