### PR TITLE
Hotfix: Add demo video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@
 
 ---
 
+## Demo
+
+<div align="center">
+  <img src="docs/assets/dollhouse-reddit-demo.gif" alt="DollhouseMCP Demo" width="800" />
+</div>
+
+---
+
 <div align="center">
   <img src="docs/assets/dollhouse-logo.png" alt="DollhouseMCP" width="200" />
   


### PR DESCRIPTION
## Summary
This hotfix adds the DollhouseMCP demo video (animated GIF) to the README for the Built with Claude competition/contest on Reddit.

## Changes
- Added `dollhouse-reddit-demo.gif` to `docs/assets/`
- Updated README to display the demo video between repository links and hero section

## Placement
The demo video is positioned strategically:
- After the repository/collection/NPM links
- Before the hero section with logo
- Good visibility for showcasing capabilities

## File Details
- Demo video: 25.8 MB animated GIF showing DollhouseMCP in action
- Location: `docs/assets/dollhouse-reddit-demo.gif`

## Testing
- [x] GIF displays correctly in README
- [x] File copied to correct location
- [x] README formatting maintained

This is a documentation-only change with no code impact.

🤖 Generated with [Claude Code](https://claude.ai/code)