### PR TITLE
fix: Allow Dependabot PRs to trigger Claude Code reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,9 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          
+          # Allow Dependabot to trigger Claude reviews
+          allowed_bots: "dependabot"
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
@@ -48,6 +51,8 @@ jobs:
             - Performance considerations
             - Security concerns
             - Test coverage
+            
+            For Dependabot PRs: Focus on whether the dependency update might introduce breaking changes or compatibility issues.
             
             Be constructive and helpful in your feedback.
 


### PR DESCRIPTION
## Summary
This PR updates the claude-code-review workflow to allow Dependabot PRs to trigger Claude reviews.

## Problem
All 5 Dependabot PRs were failing the claude-review check with the error:
> Workflow initiated by non-human actor: dependabot (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

This was preventing a clean CI status even though the dependency updates were safe.

## Solution
1. Added `allowed_bots: "dependabot"` parameter to the claude-code-action
2. Updated the review prompt to include specific guidance for Dependabot PRs

## Changes
- Modified `.github/workflows/claude-code-review.yml`
  - Line 41: Added allowed_bots configuration
  - Line 55: Added Dependabot-specific review guidance

## Impact
- ✅ Dependabot PRs will now get Claude reviews
- ✅ Reviews will focus on breaking changes and compatibility issues
- ✅ All CI checks will pass for valid dependency updates

## Testing
Once this is merged to develop, the existing Dependabot PRs should automatically re-run and get proper reviews.

🤖 Generated with [Claude Code](https://claude.ai/code)