### PR TITLE
fix: Update MCP Inspector to 0.16.6 (Security Fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "AGPL-3.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.3",
@@ -1274,9 +1274,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/inspector": {
-      "version": "0.16.5",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/inspector/-/inspector-0.16.5.tgz",
-      "integrity": "sha512-3viCtcLn1p6ZYZG8L9DxnNx2XUw6damCZM37nBByKAd74stH7nZa2VxFAwLpUCjKylYqawCRthzYSyeSlWGf1g==",
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/inspector/-/inspector-0.16.6.tgz",
+      "integrity": "sha512-6x6dzTf8MV6z/XIdzr/4EMK4elMn1XUzTJHxczsBePLg1G5VNAM/4g5abNFIB9bzuxJ/1VH8016Vv6S7sj/24Q==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -1285,10 +1285,10 @@
         "cli"
       ],
       "dependencies": {
-        "@modelcontextprotocol/inspector-cli": "^0.16.5",
-        "@modelcontextprotocol/inspector-client": "^0.16.5",
-        "@modelcontextprotocol/inspector-server": "^0.16.5",
-        "@modelcontextprotocol/sdk": "^1.17.3",
+        "@modelcontextprotocol/inspector-cli": "^0.16.6",
+        "@modelcontextprotocol/inspector-client": "^0.16.6",
+        "@modelcontextprotocol/inspector-server": "^0.16.6",
+        "@modelcontextprotocol/sdk": "^1.17.5",
         "concurrently": "^9.2.0",
         "open": "^10.2.0",
         "shell-quote": "^1.8.3",
@@ -1304,13 +1304,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/inspector-cli": {
-      "version": "0.16.5",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/inspector-cli/-/inspector-cli-0.16.5.tgz",
-      "integrity": "sha512-6Flp9goLJutjUZTx6clDo4x/6TA7BwqeTGSYcC8ZeP8IEKjx+EZpvpYPVAV++rkHJYa0F5PViy02CMoGBGkzkg==",
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/inspector-cli/-/inspector-cli-0.16.6.tgz",
+      "integrity": "sha512-28RAaGoN9XgKYvl8kOo9wTHBrLp5Th+biTt5mNGUzowMdcoG/FpI8mHROIhcgDyp+kj0SYR5fmwcb6GIxBnjUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.17.3",
+        "@modelcontextprotocol/sdk": "^1.17.5",
         "commander": "^13.1.0",
         "spawn-rx": "^5.1.2"
       },
@@ -1319,13 +1319,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/inspector-client": {
-      "version": "0.16.5",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/inspector-client/-/inspector-client-0.16.5.tgz",
-      "integrity": "sha512-KjgtTRdFSDt964a9KtmF3aRpi4ntd+6wn3e4WUa5vcK7H8f34rq4wfIGF22dd/xoKbALP3zVVAsPqVN94SCGmg==",
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/inspector-client/-/inspector-client-0.16.6.tgz",
+      "integrity": "sha512-2dwB0OXI02PTTsECCTIsB9DkERImIrsTAuZW6LlfUojtQMLI5NpuUID4Y4LaYPcdGnxkkkR1eddrPTsuzgabvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.17.3",
+        "@modelcontextprotocol/sdk": "^1.17.5",
         "@radix-ui/react-checkbox": "^1.1.4",
         "@radix-ui/react-dialog": "^1.1.3",
         "@radix-ui/react-icons": "^1.3.0",
@@ -1348,7 +1348,6 @@
         "react-simple-code-editor": "^0.14.1",
         "serve-handler": "^6.1.6",
         "tailwind-merge": "^2.5.3",
-        "tailwindcss-animate": "^1.0.7",
         "zod": "^3.25.76"
       },
       "bin": {
@@ -1413,13 +1412,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/inspector-server": {
-      "version": "0.16.5",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/inspector-server/-/inspector-server-0.16.5.tgz",
-      "integrity": "sha512-mWKrEpimfNdSFOxMJGj3cYN1PxHANW9vjpek+tR0TLiP7ogq7DLV4bbsa+lPPGwOVogUIyUiXbffY8M1YHRZVA==",
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/inspector-server/-/inspector-server-0.16.6.tgz",
+      "integrity": "sha512-BkE/4K2Y8ZcXK/cGBucG+rLTcTIUAaSyQabxqh0p+ErhkJDmepDvI+63OqQnauWUJydXPZYtBQyHppL4JN7RGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.17.3",
+        "@modelcontextprotocol/sdk": "^1.17.5",
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "ws": "^8.18.0",
@@ -1450,9 +1449,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.4.tgz",
-      "integrity": "sha512-zq24hfuAmmlNZvik0FLI58uE5sriN0WWsQzIlYnzSuKDAHFqJtBFrl/LfB1NLgJT5Y7dEBzaX4yAKqOPrcetaw==",
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.5.tgz",
+      "integrity": "sha512-QakrKIGniGuRVfWBdMsDea/dx1PNE739QJ7gCM41s9q+qaCYTHCdsIBXQVVXry3mfWAiaM9kT22Hyz53Uw8mfg==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",
@@ -2977,7 +2976,7 @@
       "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
-      "version": "1.6.5",
+      "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
       "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
       "dev": true,
@@ -7783,24 +7782,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
-      }
-    },
-    "node_modules/tailwindcss": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.12.tgz",
-      "integrity": "sha512-DzFtxOi+7NsFf7DBtI3BJsynR+0Yp6etH+nRPTbpWnS2pZBaSksv/JGctNwSWzbFjp0vxSqknaUylseZqMDGrA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/tailwindcss-animate": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
-      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || insiders"
       }
     },
     "node_modules/test-exclude": {


### PR DESCRIPTION
## 🔒 Security Fix

This PR updates `@modelcontextprotocol/inspector` from 0.16.5 to 0.16.6 to fix a **HIGH severity** security vulnerability.

## Vulnerability Details

- **Package**: @modelcontextprotocol/inspector
- **Severity**: HIGH
- **Issue**: XSS vulnerability that could lead to command execution when connecting to an untrusted MCP server
- **CVE**: Dependabot Alert #1
- **Affected versions**: < 0.16.6
- **Fixed in**: 0.16.6

## Impact

This is a **development-only dependency** used for debugging MCP servers. It does not affect production code or the published NPM package. The vulnerability only affects developers who use the inspector tool and connect to untrusted/malicious MCP servers.

## Changes

- Updated `@modelcontextprotocol/inspector` from 0.16.5 to 0.16.6
- No code changes required
- Package-lock.json updated

## Testing

- ✅ `npm install` successful
- ✅ No new vulnerabilities reported
- ✅ Inspector tool still functional

## Checklist

- [x] Security vulnerability resolved
- [x] No breaking changes
- [x] Package-lock.json updated
- [x] Ready for merge

---

🤖 Generated with [Claude Code](https://claude.ai/code)