### PR TITLE
Fix CI 409 conflict errors with retry mechanism

### DIFF
--- a/test/e2e/real-github-integration.test.ts
+++ b/test/e2e/real-github-integration.test.ts
@@ -79,7 +79,13 @@ describe('Real GitHub Portfolio Integration Tests', () => {
       
       // Step 2: Upload to GitHub via PortfolioRepoManager
       console.log('  2️⃣ Uploading to GitHub...');
-      const uploadResult = await portfolioManager.saveElement(ziggyPersona, true);
+      const uploadResult = await retryIfRetryable(
+        async () => await portfolioManager.saveElement(ziggyPersona, true),
+        {
+          maxAttempts: 3,
+          onRetry: (attempt, error) => console.log(`     ↻ Retry ${attempt} due to: ${error.message}`)
+        }
+      );
       
       expect(uploadResult).toBeTruthy();
       expect(uploadResult).toContain('github.com');
@@ -147,9 +153,15 @@ describe('Real GitHub Portfolio Integration Tests', () => {
         prefix: testEnv.personaPrefix,
         name: `${testEnv.personaPrefix}null-commit-test-${Date.now()}`
       });
-      
+
       console.log('  1️⃣ Uploading test persona...');
-      const result = await portfolioManager.saveElement(testPersona, true);
+      const result = await retryIfRetryable(
+        async () => await portfolioManager.saveElement(testPersona, true),
+        {
+          maxAttempts: 3,
+          onRetry: (attempt, error) => console.log(`     ↻ Retry ${attempt} due to: ${error.message}`)
+        }
+      );
       
       // Even with potential null commit, should return a valid URL
       expect(result).toBeTruthy();
@@ -237,7 +249,13 @@ describe('Real GitHub Portfolio Integration Tests', () => {
         prefix: testEnv.personaPrefix,
         name: `${testEnv.personaPrefix}rate-limit-test-${Date.now()}`
       });
-      const result = await portfolioManager.saveElement(testPersona, true);
+      const result = await retryIfRetryable(
+        async () => await portfolioManager.saveElement(testPersona, true),
+        {
+          maxAttempts: 3,
+          onRetry: (attempt, error) => console.log(`     ↻ Retry ${attempt} due to: ${error.message}`)
+        }
+      );
       
       expect(result).toBeTruthy();
       console.log('     ✅ Rate limit handling verified');
@@ -270,8 +288,14 @@ describe('Real GitHub Portfolio Integration Tests', () => {
       // Upload only the public one
       const publicPersona = personas[0];
       console.log('  2️⃣ Uploading ONLY the public persona...');
-      
-      const result = await portfolioManager.saveElement(publicPersona, true);
+
+      const result = await retryIfRetryable(
+        async () => await portfolioManager.saveElement(publicPersona, true),
+        {
+          maxAttempts: 3,
+          onRetry: (attempt, error) => console.log(`     ↻ Retry ${attempt} due to: ${error.message}`)
+        }
+      );
       expect(result).toBeTruthy();
       
       // Use the actual generateFileName method for consistency
@@ -319,8 +343,14 @@ describe('Real GitHub Portfolio Integration Tests', () => {
       });
       
       console.log('  1️⃣ Uploading test persona...');
-      const result = await portfolioManager.saveElement(testPersona, true);
-      
+      const result = await retryIfRetryable(
+        async () => await portfolioManager.saveElement(testPersona, true),
+        {
+          maxAttempts: 3,
+          onRetry: (attempt, error) => console.log(`     ↻ Retry ${attempt} due to: ${error.message}`)
+        }
+      );
+
       // Verify URL format
       expect(result).toMatch(/https:\/\/github\.com\/.+/);
       expect(result).not.toContain('undefined');
@@ -373,7 +403,13 @@ describe('Real GitHub Portfolio Integration Tests', () => {
       // Step 3: System uploads to GitHub
       console.log('\n  3️⃣ System uploading to GitHub...');
       const startTime = Date.now();
-      const uploadUrl = await portfolioManager.saveElement(ziggyPersona, true);
+      const uploadUrl = await retryIfRetryable(
+        async () => await portfolioManager.saveElement(ziggyPersona, true),
+        {
+          maxAttempts: 3,
+          onRetry: (attempt, error) => console.log(`     ↻ Retry ${attempt} due to: ${error.message}`)
+        }
+      );
       const uploadTime = Date.now() - startTime;
       
       expect(uploadUrl).toBeTruthy();

--- a/test/e2e/utils/retry.ts
+++ b/test/e2e/utils/retry.ts
@@ -80,6 +80,10 @@ export function isRetryableError(error: any): boolean {
     if (status === 429 || status === 502 || status === 503 || status === 504) {
       return true;
     }
+    // GitHub specific: 409 Conflict can happen in parallel CI runs when SHA changes
+    if (status === 409 && error.message?.includes('is at')) {
+      return true;
+    }
     // GitHub specific: 422 can sometimes be transient
     if (status === 422 && error.message?.includes('is at')) {
       return true;


### PR DESCRIPTION
## Summary
This PR fixes the Extended Node Compatibility CI failures by adding proper retry handling for GitHub API 409 conflict errors that occur when parallel CI jobs modify the same test repository.

## Problem
The `real-github-integration.test.ts` was failing with 409 conflict errors:
```
GitHub API error (409): is at [sha1] but expected [sha2]
```

This occurs when:
1. Multiple CI jobs run in parallel on the same test repository
2. Job A fetches current SHA → Job B updates file → Job A tries to update with old SHA  
3. Result: 409 conflict error

## Root Cause Analysis
✅ **Production code is CORRECT** - properly fetches current SHA before updating  
❌ **Test lacks retry logic** for this race condition  
✅ **422 errors already retryable** but 409 errors were not  

## Solution
### 1. Added 409 to retryable errors  
Modified `test/e2e/utils/retry.ts` line 84-86:
```typescript
// GitHub specific: 409 Conflict can happen in parallel CI runs when SHA changes
if (status === 409 && error.message?.includes('is at')) {
  return true;
}
```

### 2. Wrapped saveElement calls with retry
Added `retryIfRetryable` wrapper to 5 `portfolioManager.saveElement()` calls:
```typescript
const result = await retryIfRetryable(
  async () => await portfolioManager.saveElement(persona, true),
  {
    maxAttempts: 3,
    onRetry: (attempt, error) => console.log(`↻ Retry ${attempt} due to: ${error.message}`)
  }
);
```

## Changes Made
- **`test/e2e/utils/retry.ts`**: Added 409 conflict error to retryable list
- **`test/e2e/real-github-integration.test.ts`**: Wrapped saveElement calls with retry logic

## Testing  
✅ Local tests pass (only expected Docker test failure)  
✅ Uses existing proven retry patterns from same file  
✅ No production code changes needed  

## Benefits
- Fixes CI flakiness from parallel execution
- Follows established retry patterns
- Clear error logging for debugging  
- Minimal, targeted change

This addresses the specific CI race condition while maintaining all existing functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>