### PR TITLE
fix: Correct anchor links for headers with emojis

### DIFF
--- a/README.github.md
+++ b/README.github.md
@@ -98,7 +98,7 @@
 ```bash
 npm install @dollhousemcp/mcp-server
 ```
-See [Quick Start](#quick-start) for complete setup instructions.
+See [Quick Start](#-quick-start) for complete setup instructions.
 
 ---
 
@@ -484,7 +484,7 @@ After configuring and restarting Claude Desktop, test with:
 list_elements type="personas"
 ```
 
-You should see your available personas. If not, check the [Troubleshooting](#troubleshooting) section.
+You should see your available personas. If not, check the [Troubleshooting](#-troubleshooting) section.
 
 ---
 

--- a/README.npm.md
+++ b/README.npm.md
@@ -178,7 +178,7 @@ After configuring and restarting Claude Desktop, test with:
 list_elements type="personas"
 ```
 
-You should see your available personas. If not, check the [Troubleshooting](#troubleshooting) section.
+You should see your available personas. If not, check the [Troubleshooting](#-troubleshooting) section.
 
 ---
 

--- a/docs/readme/chunks/00-hero-section.md
+++ b/docs/readme/chunks/00-hero-section.md
@@ -65,6 +65,6 @@
 ```bash
 npm install @dollhousemcp/mcp-server
 ```
-See [Quick Start](#quick-start) for complete setup instructions.
+See [Quick Start](#-quick-start) for complete setup instructions.
 
 ---

--- a/docs/readme/chunks/01-installation.md
+++ b/docs/readme/chunks/01-installation.md
@@ -164,7 +164,7 @@ After configuring and restarting Claude Desktop, test with:
 list_elements type="personas"
 ```
 
-You should see your available personas. If not, check the [Troubleshooting](#troubleshooting) section.
+You should see your available personas. If not, check the [Troubleshooting](#-troubleshooting) section.
 
 ---
 


### PR DESCRIPTION
## Summary
This PR fixes broken anchor links that weren't properly jumping to sections with emoji headers.

## The Problem
The Quick Start and Troubleshooting links were not working - they loaded the page but didn't jump to the sections. This was because GitHub generates anchor IDs differently for headers with emojis.

## Root Cause
GitHub converts emoji headers like `## 🚀 Quick Start` to anchors with the emoji replaced by a dash: `#-quick-start` (not `#quick-start`).

Our links were using the wrong format, so they couldn't find the target sections.

## Solution
Updated all anchor links to use the correct format with the dash prefix for emoji headers:
- `#quick-start` → `#-quick-start`
- `#troubleshooting` → `#-troubleshooting`

## Changes
1. **`docs/readme/chunks/00-hero-section.md`**: Fixed Quick Start link
2. **`docs/readme/chunks/01-installation.md`**: Fixed Troubleshooting link
3. **Generated READMEs**: Rebuilt with corrected anchors

## Testing
The corrected anchor format will now properly jump to:
- Quick Start section (line 499 in README.md)
- Troubleshooting section (line 704 in README.md)

## Impact
Users can now click these links and be taken directly to the relevant sections instead of just loading the page.