### PR TITLE
hotfix: Fix flaky Windows CI test

### DIFF
--- a/test/__tests__/unit/utils/ToolCache.test.ts
+++ b/test/__tests__/unit/utils/ToolCache.test.ts
@@ -209,7 +209,7 @@ describe('ToolCache', () => {
       const isCI = process.env.CI === 'true';
       const isWindows = process.platform === 'win32';
       // Windows CI needs even more relaxed threshold due to slower filesystem operations
-      const performanceThreshold = isCI ? (isWindows ? 75 : 50) : 10; // ms
+      const performanceThreshold = isCI ? (isWindows ? 100 : 50) : 10; // ms
       
       // Should be very fast (less than 10ms local, 50ms CI for 100 accesses)
       expect(duration).toBeLessThan(performanceThreshold);
@@ -297,7 +297,7 @@ describe('ToolCache', () => {
       const isCI = process.env.CI === 'true';
       const isWindows = process.platform === 'win32';
       // Windows CI needs even more relaxed threshold due to slower filesystem operations
-      const performanceThreshold = isCI ? (isWindows ? 75 : 50) : 10; // ms
+      const performanceThreshold = isCI ? (isWindows ? 100 : 50) : 10; // ms
       
       // Performance requirements with CI accommodation
       expect(averageTime).toBeLessThan(performanceThreshold); // <10ms local, <50ms CI average


### PR DESCRIPTION
## Summary
Single-line fix for flaky Windows CI test in Cross-Platform Simple workflow.

## Problem
ToolCache performance test failing when execution takes 76ms (threshold: 75ms).

## Solution  
Increased Windows CI threshold from 75ms to 100ms (line 212 and 301).

## Testing
This change only affects Windows CI runners, not local or other CI platforms.