### PR TITLE
fix: Remove non-existent 'chore' label from README sync workflow

### DIFF
--- a/.github/workflows/readme-sync.yml
+++ b/.github/workflows/readme-sync.yml
@@ -242,8 +242,7 @@ jobs:
               --title "chore: Sync README updates from develop" \
               --body "$PR_BODY" \
               --label "documentation" \
-              --label "automated" \
-              --label "chore"
+              --label "automated"
           else
             echo "✅ PR #$EXISTING_PR already exists for README sync"
             


### PR DESCRIPTION
## 🔧 Fix README Sync Workflow Label Error

### Problem
The README Sync workflow has been failing with this error:
```
could not add label: 'chore' not found
```

This happens when the workflow tries to create a PR from develop to main after README changes.

### Root Cause
The workflow was configured to add three labels to PRs:
- `documentation` ✅ (exists)
- `automated` ✅ (exists)  
- `chore` ❌ (doesn't exist)

The repository doesn't have a `chore` label, causing the workflow to fail.

### Solution
Removed the non-existent `chore` label from line 245 of `.github/workflows/readme-sync.yml`.

The workflow now only adds the two labels that actually exist.

### Impact
- ✅ Fixes the red X that appears on develop after releases
- ✅ README sync PRs will be created successfully
- ✅ No functional changes to the sync process

### Testing
The next time README files change on develop, the workflow should:
1. Build the README files
2. Create a PR to main
3. Apply only the `documentation` and `automated` labels
4. Complete successfully ✅

### Note
The workflow is correctly configured to **only run on develop branch**, not on main. The failures we've been seeing are on develop when it tries to create PRs to main after releases.

Fixes the workflow failure seen after PR #1024 merge.

🤖 Generated with [Claude Code](https://claude.ai/code)