### PR TITLE
Fix GenericElementTools test after memory support addition

### DIFF
--- a/test/__tests__/unit/server/tools/GenericElementTools.integration.test.ts
+++ b/test/__tests__/unit/server/tools/GenericElementTools.integration.test.ts
@@ -260,33 +260,33 @@ describe('Generic Element Tools Integration', () => {
   describe('Element Type Support', () => {
     it('should report unsupported element types for creation', async () => {
       const args = {
-        name: 'test-memory',
-        type: 'memories', // Not in ElementType enum yet
-        description: 'Test memory element'
+        name: 'test-ensemble',
+        type: 'ensembles', // Ensembles not yet supported for creation
+        description: 'Test ensemble element'
       };
-      
+
       const result = await server.createElement(args);
-      
+
       expect(result.content[0].text).toContain('❌ Element type');
     });
-    
+
     it('should report unsupported element types for editing', async () => {
       const args = {
         name: 'test-ensemble',
-        type: 'ensembles', // Not in ElementType enum yet
+        type: 'ensembles', // Ensembles not yet supported for editing
         field: 'description',
         value: 'New value'
       };
-      
+
       const result = await server.editElement(args);
-      
+
       expect(result.content[0].text).toContain('❌ Element type');
     });
-    
+
     it('should report unsupported element types for validation', async () => {
       const args = {
-        name: 'test-memory',
-        type: 'memories', // Not in ElementType enum yet
+        name: 'test-ensemble',
+        type: 'ensembles', // Ensembles not yet supported for validation
         strict: false
       };
       


### PR DESCRIPTION
## Summary
Fixes failing test in GenericElementTools.integration.test.ts that was broken by PR #1026 which added Memory element support.

## Problem
The test 'should report unsupported element types for creation' was using 'memories' as an example of an unsupported type, but PR #1026 just added full support for Memory elements, causing the test to fail.

## Solution
Changed the test to use 'ensembles' instead of 'memories' since ensembles are not yet fully supported for creation/editing/validation operations.

## Testing
✅ Test should now pass since ensembles remain unsupported for these operations
✅ This fixes the CI failure in Extended Node Compatibility workflow

## Related
- Broken by PR #1026 (Memory element support)
- Fixes failing CI on develop branch