### PR TITLE
Release v1.9.3 - Memory Element MCP Support Fix

### DIFF
--- a/.github/workflows/readme-sync.yml
+++ b/.github/workflows/readme-sync.yml
@@ -242,8 +242,7 @@ jobs:
               --title "chore: Sync README updates from develop" \
               --body "$PR_BODY" \
               --label "documentation" \
-              --label "automated" \
-              --label "chore"
+              --label "automated"
           else
             echo "✅ PR #$EXISTING_PR already exists for README sync"
             

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [1.9.3] - 2025-09-19
+
+### Fixed
+- **Memory Element MCP Support**: Added complete Memory element support to all MCP tool handlers
+  - Fixed "Unknown element type 'memories'" errors in DollhouseMCP client
+  - Added Memory case handling to 8 critical methods in src/index.ts:
+    - `listElements`: Lists available memories with retention policy and tags
+    - `activateElement`: Activates memory and shows status
+    - `getActiveElements`: Shows active memories with their tags
+    - `deactivateElement`: Deactivates memory elements
+    - `getElementDetails`: Shows comprehensive memory details
+    - `reloadElements`: Reloads memories from portfolio
+    - `createElement`: Creates new memory instances with content
+    - `editElement`: Supports editing memory properties
+  - Memory infrastructure was already implemented but MCP tool handlers were missing the switch cases
+  - Fixes user-reported issue with memories not working in v1.9.2
+
+### Fixed
+- **Test Compatibility**: Updated GenericElementTools test to use ensembles instead of memories
+  - Test was expecting memories to be unsupported but they are now fully functional
+  - Changed test to use ensembles which remain unsupported for creation/editing/validation
+
 ## [1.9.2] - 2025-09-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -873,21 +873,7 @@ For detailed guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## 🏷️ Version History
 
-### v1.9.1 - September 19, 2025
-
-**Hotfix Release**: Critical memory element support fix
-
-#### 🔧 Bug Fixes
-- **Fixed memory element validation** - Resolves "Invalid type 'memories'" error when browsing collection
-- **Updated tool descriptions** - All MCP tools now properly recognize memory elements
-- **Fixed element type handling** - Added missing switch cases for memory elements in index.ts
-
-#### 📋 Technical Details
-- Issue #1019 resolved - Memory elements can now be browsed and installed from collection
-- Clean hotfix approach with minimal changes (2 commits)
-- Cherry-picked fix from develop to maintain stable release
-
-### v1.9.0 - September 17, 2025
+### v1.9.0 - September 19, 2025
 
 **🎉 Memory Element Release**: Persistent context storage with enterprise-grade features
 

--- a/docs/development/SESSION_NOTES_2025_09_19_LATE_EVENING_BRANCH_SYNC_AND_RELEASE.md
+++ b/docs/development/SESSION_NOTES_2025_09_19_LATE_EVENING_BRANCH_SYNC_AND_RELEASE.md
@@ -1,0 +1,139 @@
+# Session Notes - September 19, 2025 Late Evening - Branch Synchronization and v1.9.2 Release
+
+**Date**: September 19, 2025
+**Time**: 3:30 PM - 4:00 PM PST
+**Context**: Branch divergence resolution and v1.9.2 release
+**Personas**: Alex Sterling (Evidence-based verification) & GitFlow Detective (Branch forensics)
+
+## Session Objectives
+1. Analyze and resolve branch divergence between main and develop
+2. Release v1.9.2 to synchronize branches
+3. Fix README Sync workflow failures
+
+## Part 1: Branch Divergence Investigation
+
+### Initial Analysis with GitFlow Detective
+Created custom GitFlow Detective persona specializing in branch divergence analysis to help investigate the situation described in earlier session notes.
+
+### Key Findings
+**SURPRISING DISCOVERY**: The session notes suggested 50+ commits of Memory features were missing from main, but investigation revealed:
+- Memory element implementation **already exists identically in both branches**
+- The actual divergence was only documentation and minor configuration
+- 58 commits ahead in develop, but 0 unique commits in main
+
+### Actual Differences
+1. **Documentation updates** (CHANGELOG, README, hero section)
+2. **Security audit path fix** (one line change in SecurityAuditor.ts)
+3. **Session notes** (developer documentation)
+
+The "missing v1.9.0 Memory features" were a misunderstanding - they were already in main!
+
+## Part 2: Release v1.9.2 - Branch Synchronization
+
+### Clean Merge Test
+```bash
+git checkout main
+git merge develop --no-commit --no-ff
+# Result: NO CONFLICTS! Clean merge possible
+```
+
+### Release Process
+1. Created `release/v1.9.2` branch from develop
+2. Updated version in package.json to 1.9.2
+3. Added CHANGELOG entry explaining branch synchronization
+4. Created PR #1024: https://github.com/DollhouseMCP/mcp-server/pull/1024
+5. All CI checks passed (13/13 green)
+6. Claude review approved with comprehensive analysis
+7. Merged PR to main
+8. Tagged as v1.9.2
+9. Merged main back to develop completing GitFlow cycle
+
+### Version Justification
+- v1.9.2 (patch) appropriate since only documentation/config changes
+- No functional code changes to Memory or other features
+- Released same day as v1.9.1 with likely zero users affected
+
+## Part 3: README Sync Workflow Fix
+
+### Problem Discovered
+- Red X appearing on repository main page after releases
+- Initial assumption: Workflow running on main when it shouldn't
+- **ACTUAL ISSUE**: Workflow failing on develop, status carrying to main
+
+### Root Cause Analysis
+1. README Sync workflow correctly configured to run only on develop
+2. When workflow runs on develop, it tries to create PR to main
+3. Workflow was adding non-existent "chore" label → failure
+4. When commits merge from develop→main, GitHub shows the failed status from develop
+
+### Fix Implementation
+1. Created `fix/readme-sync-label-error` branch
+2. Removed non-existent "chore" label from workflow (kept "documentation" and "automated")
+3. Created PR #1025: https://github.com/DollhouseMCP/mcp-server/pull/1025
+4. Merged to develop
+
+### How This Prevents Future Issues
+- Future README syncs won't fail due to missing label
+- Merges from develop to main won't carry failed status
+- No more red X's on releases!
+
+## Key Learnings
+
+### 1. Branch Divergence Can Be Misleading
+- Session notes suggested massive feature divergence
+- Reality: Only documentation differences
+- **Lesson**: Always verify with actual diffs, not just commit counts
+
+### 2. GitHub Status Inheritance
+- Failed checks on develop carry to main after merge
+- Even if workflow never ran on main branch
+- This creates confusing "phantom" failures
+
+### 3. GitFlow Working Well
+- Clean merge with no conflicts shows good branch management
+- Documentation-only changes in develop didn't break anything
+- Synchronization was straightforward
+
+### 4. Label Management Matters
+- Small issues (missing label) can cause visible failures
+- Workflows should only reference existing labels
+- Consider using `--label` with `|| true` to prevent failures
+
+## Session Metrics
+- **PRs Created**: 2 (#1024 for v1.9.2, #1025 for workflow fix)
+- **PRs Merged**: 2
+- **Version Released**: v1.9.2
+- **Branches Synchronized**: main and develop now identical
+- **Workflow Fixed**: README Sync no longer fails
+- **Time**: ~30 minutes
+
+## Current State
+- ✅ Branches fully synchronized at commit 1badb50
+- ✅ v1.9.2 released and tagged
+- ✅ README Sync workflow fixed
+- ✅ No actual features were missing from main
+- ⚠️ Existing red X on main will remain (historical failure)
+
+## Next Priorities
+1. **LinkedIn Post**: Share v1.9.2 release and Memory features
+2. **Website Work**: Continue development
+3. **Memory Features**: Test and explore the implementation
+4. **Documentation**: Ensure all features properly documented
+
+## Files for Reference
+- PR #1024: v1.9.2 release
+- PR #1025: README Sync workflow fix
+- Earlier session notes that prompted investigation
+
+## Session End Notes
+Excellent collaborative session using two AI personas:
+- **Alex Sterling**: Evidence-based verification approach
+- **GitFlow Detective**: Branch divergence specialist
+
+Successfully resolved what appeared to be a major divergence issue but turned out to be primarily documentation. The workflow fix prevents future red X's on releases.
+
+Owner taking a well-deserved break to explore Memory features after a productive day!
+
+---
+
+**Session Complete - All objectives achieved** 🎉

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/security-audit-report.md
+++ b/security-audit-report.md
@@ -1,0 +1,34 @@
+# Security Audit Report
+
+Generated: 2025-09-19T21:47:45.936Z
+Duration: 4ms
+
+## Summary
+
+- **Total Findings**: 1
+- **Files Scanned**: 1
+
+### Findings by Severity
+
+- 🔴 **Critical**: 0
+- 🟠 **High**: 0
+- 🟡 **Medium**: 0
+- 🟢 **Low**: 1
+- ℹ️ **Info**: 0
+
+## Detailed Findings
+
+### LOW (1)
+
+#### DMCP-SEC-006: Security operation without audit logging
+
+- **File**: `/var/folders/kj/45kjdq714853c8nlnsv7l0_r0000gn/T/security-audit-test-WATLlm/auth-handler.js`
+- **Confidence**: medium
+- **Remediation**: Add SecurityMonitor.logSecurityEvent() for audit trail
+
+## Recommendations
+
+1. Address all critical and high severity issues immediately
+2. Review medium severity issues and plan remediation
+3. Consider adding suppressions for false positives
+4. Run security audit regularly (e.g., in CI/CD pipeline)

--- a/test/__tests__/unit/server/tools/GenericElementTools.integration.test.ts
+++ b/test/__tests__/unit/server/tools/GenericElementTools.integration.test.ts
@@ -260,33 +260,33 @@ describe('Generic Element Tools Integration', () => {
   describe('Element Type Support', () => {
     it('should report unsupported element types for creation', async () => {
       const args = {
-        name: 'test-memory',
-        type: 'memories', // Not in ElementType enum yet
-        description: 'Test memory element'
+        name: 'test-ensemble',
+        type: 'ensembles', // Ensembles not yet supported for creation
+        description: 'Test ensemble element'
       };
-      
+
       const result = await server.createElement(args);
-      
+
       expect(result.content[0].text).toContain('❌ Element type');
     });
-    
+
     it('should report unsupported element types for editing', async () => {
       const args = {
         name: 'test-ensemble',
-        type: 'ensembles', // Not in ElementType enum yet
+        type: 'ensembles', // Ensembles not yet supported for editing
         field: 'description',
         value: 'New value'
       };
-      
+
       const result = await server.editElement(args);
-      
+
       expect(result.content[0].text).toContain('❌ Element type');
     });
-    
+
     it('should report unsupported element types for validation', async () => {
       const args = {
-        name: 'test-memory',
-        type: 'memories', // Not in ElementType enum yet
+        name: 'test-ensemble',
+        type: 'ensembles', // Ensembles not yet supported for validation
         strict: false
       };
       


### PR DESCRIPTION
## Release v1.9.3

This patch release fixes Memory element support in MCP tool handlers.

### What's Fixed

#### Memory Element MCP Support
- Fixed "Unknown element type 'memories'" errors when using memory tools
- Added Memory case handling to all 8 MCP tool methods that were missing it
- Memory infrastructure was already implemented, but the switch statements were incomplete
- Now memories can be listed, activated, deactivated, created, edited, and managed properly

#### Test Compatibility
- Updated test that was failing after Memory support was added
- Changed test to use ensembles (which remain unsupported) instead of memories

### Impact
- Users can now use Memory elements through the DollhouseMCP client
- All memory-related commands now work correctly
- Fixes issue reported with v1.9.2

### Testing
✅ All tests passing
✅ CI/CD green on develop branch
✅ Memory functionality verified

### Release Process
Following GitFlow:
- Release branch created from develop
- Version bumped to 1.9.3
- CHANGELOG updated
- Ready for merge to main

After merge, this will need to be:
1. Tagged as v1.9.3
2. Merged back to develop
3. Published to npm

cc @mickdarling 