### PR TITLE
fix: Fix broken security badge link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Core Build & Test](https://github.com/DollhouseMCP/mcp-server/actions/workflows/core-build-test.yml/badge.svg)](https://github.com/DollhouseMCP/mcp-server/actions/workflows/core-build-test.yml)
 [![Build Artifacts](https://github.com/DollhouseMCP/mcp-server/actions/workflows/build-artifacts.yml/badge.svg)](https://github.com/DollhouseMCP/mcp-server/actions/workflows/build-artifacts.yml)
 [![Test Coverage](https://img.shields.io/badge/Coverage-1858%2B%20Tests-green)](https://github.com/DollhouseMCP/mcp-server/tree/main/__tests__)
-[![Enterprise-Grade Security](https://img.shields.io/badge/Security-Enterprise%20Grade-purple)](docs/SECURITY.md)
+[![Enterprise-Grade Security](https://img.shields.io/badge/Security-Enterprise%20Grade-purple)](SECURITY.md)
 
 ## Platform Support
 [![Windows Build Status](https://img.shields.io/badge/Windows-✓_Tested-0078D4?logo=windows&logoColor=white)](https://github.com/DollhouseMCP/mcp-server/actions/workflows/core-build-test.yml?query=branch:main "Windows CI Build Status")


### PR DESCRIPTION
## Summary
- Fixes 404 error when clicking on the security badge in README
- The badge was pointing to `docs/SECURITY.md` which doesn't exist
- Changed to point to `SECURITY.md` in the root directory where the actual security document lives

## Problem
The security badge link was broken, leading to a 404 error on GitHub when users clicked on it.

## Solution
Updated the link from `docs/SECURITY.md` to `SECURITY.md` to point to the correct location.

## Testing
- Verified that SECURITY.md exists in the root directory
- Link will now correctly navigate to the security documentation

🤖 Generated with Claude Code