### PR TITLE
fix: Add early return after buildIndex to prevent undefined access

### DIFF
--- a/src/portfolio/EnhancedIndexManager.ts
+++ b/src/portfolio/EnhancedIndexManager.ts
@@ -320,6 +320,7 @@ export class EnhancedIndexManager {
       if ((error as any).code === 'ENOENT') {
         logger.info('No existing index found, will build new one');
         await this.buildIndex();
+        return; // Return early since buildIndex will set up the index
       } else {
         logger.error('Failed to load index', error);
         throw error;


### PR DESCRIPTION
## 🔧 Fix for CI Failures on Develop Branch

This PR fixes the test failures that occurred after merging PR #1106.

### Problem
The `loadIndex()` method in `EnhancedIndexManager` was trying to access `this.index.metadata` after calling `buildIndex()` in the catch block. The execution continued even though the index wasn't loaded from file, causing:

```
TypeError: Cannot read properties of undefined (reading 'metadata')
  at EnhancedIndexManager.loadIndex (src/portfolio/EnhancedIndexManager.ts:316:30)
```

### Solution
Add a `return` statement after `buildIndex()` is called in the ENOENT catch block. This ensures the method exits early since `buildIndex()` handles setting up the index properly.

### Test Impact
This was failing across all Node environments (20.x, 22.x) and all platforms (Ubuntu, Windows, macOS) in the test:
- `EnhancedIndexManager - Extensibility Tests › Schema Extensibility › should support arbitrary element types without code changes`

### Changes
- Added `return;` statement after `await this.buildIndex();` in the catch block

This is a minimal fix that resolves the immediate CI failures without changing any other behavior.