### PR TITLE
fix: Add defensive checks for undefined metadata in EnhancedIndexManager

### DIFF
--- a/docs/development/SESSION_NOTES_2025_09_25_CACHE_INVESTIGATION.md
+++ b/docs/development/SESSION_NOTES_2025_09_25_CACHE_INVESTIGATION.md
@@ -1,0 +1,125 @@
+# Session Notes - September 25, 2025
+## Docker Hub Issues and Cache Investigation Deep Dive
+
+### Session Overview
+**Time**: September 25, 2025 (Afternoon/Evening)
+**Focus**: Resolving Docker Hub failures and Extended Node Compatibility test failures
+**Key Achievement**: Identified and fixed root cause of cache staleness, discovered new issue with test data structure
+
+### Part 1: Docker Hub Resolution (PR #1107)
+
+#### The Issue
+- Docker tests started failing immediately after PR #1106 merged to develop
+- Error: `401 Unauthorized` when pulling Docker images
+- Initial hypothesis: Docker Hub authentication needed
+
+#### Investigation
+- Discovered Docker Hub authentication was added but not working
+- Multiple username formats tried, all failed
+- Real issue: Docker Hub rate limiting for anonymous pulls
+
+#### Solution
+- **Removed Docker Hub authentication entirely**
+- Let it use anonymous pulls
+- Rate limit had reset by the time we tested
+- All Docker tests now passing
+
+### Part 2: Extended Node Compatibility Failures - The Cache Detective Story
+
+#### Initial Symptoms
+- Extended Node Compatibility tests failing with:
+  ```
+  TypeError: Cannot read properties of undefined (reading 'metadata')
+  at EnhancedIndexManager.ts:316
+  ```
+- Error persisted despite PR #1107 fix being merged
+
+#### Investigation with Alex Sterling & Debug Detective Personas
+
+##### Phase 1: Cache Key Analysis
+- Discovered workflow uses `restore-keys` fallback:
+  ```yaml
+  restore-keys: |
+    typescript-build-${{ runner.os }}-${{ matrix.node-version }}-
+    typescript-build-${{ runner.os }}-
+  ```
+- When exact cache key doesn't match, it falls back to older caches
+- Tests were using stale compiled JavaScript without our fix
+
+##### Phase 2: The Fix (PR #1109)
+- Removed dangerous `restore-keys` from both TypeScript and Jest caches
+- Forces rebuild when source files change
+- Ensures tests always run against current code
+
+##### Phase 3: The Plot Twist
+After merging PR #1109, tests STILL failed with same error!
+- Cache was successfully NOT being restored (our fix worked)
+- Fresh builds were happening
+- But error persisted at line 316
+
+#### The Real Root Cause (Discovered End of Session)
+
+**Critical Finding**: The test creates a YAML file that loads successfully but has `this.index.metadata` as undefined.
+
+The error shows:
+- Line 316: `elements: this.index.metadata.total_elements` (crashes here)
+- Line 319: `} catch (error) {`
+
+Our fix added `return;` at line 323, which IS in the source code. But the test is legitimately loading a YAML file where `metadata` is undefined or malformed.
+
+**Copilot's suggestion was actually correct**: Add defensive checks for `this.index.metadata` existence.
+
+### Key Learnings
+
+1. **Docker Hub Rate Limiting**
+   - Can be misleading (shows as 401 Unauthorized)
+   - Sometimes just need to wait for reset
+   - We don't have working Docker Hub auth process yet
+
+2. **GitHub Actions Cache Pitfalls**
+   - `restore-keys` can be dangerous with compiled artifacts
+   - Fallback caches can mask the real code being tested
+   - Always verify what's actually being cached/restored
+
+3. **Test Failure Analysis**
+   - Stack traces show source files, not always compiled output
+   - Jest transpiles TypeScript on the fly
+   - Error might be legitimate test case, not a bug
+
+4. **Investigation Methodology**
+   - Systematic evidence collection crucial
+   - Don't assume - verify with actual logs
+   - Sometimes multiple issues compound
+
+### PRs Created
+1. **PR #1107** - Fix EnhancedIndexManager + Docker Hub removal (MERGED)
+2. **PR #1108** - Band-aid cache invalidation (can be closed)
+3. **PR #1109** - Proper cache fix removing restore-keys (MERGED)
+
+### Next Session Action Items
+1. Add defensive checks to `EnhancedIndexManager.loadIndex()`:
+   ```typescript
+   if (!this.index.metadata || typeof this.index.metadata.total_elements !== 'number') {
+     throw new Error('Enhanced index file is missing required metadata fields');
+   }
+   ```
+2. Verify test is intentionally using malformed data
+3. Close PR #1108 as superseded
+4. Ensure Extended Node Compatibility tests finally pass
+
+### Technical Debt Identified
+- Need proper Docker Hub authentication setup for GitHub Actions
+- Consider if cache restore-keys should be removed from other workflows
+- Document cache strategy for compiled artifacts
+
+### Session Metrics
+- **PRs Merged**: 2 (PR #1107, #1109)
+- **Root Causes Found**: 2 (Docker rate limit, cache restore-keys)
+- **New Issue Discovered**: 1 (test data structure mismatch)
+- **Time Spent**: ~2 hours
+- **Personas Used**: Alex Sterling, Debug Detective, GitHub Actions Debugger skill
+
+---
+
+*Session conducted by Claude with Mick*
+*Alex Sterling and Debug Detective personas proved invaluable for systematic investigation*


### PR DESCRIPTION
## Summary
- Fixed EnhancedIndexManager test failures caused by undefined metadata in YAML files
- Added comprehensive defensive checks for malformed data throughout the codebase
- Added public `saveIndex()` method for test compatibility

## Problem
The tests were failing because EnhancedIndexManager didn't handle malformed YAML files gracefully. When tests created YAML files where metadata could be undefined, it caused TypeErrors at runtime.

## Solution
1. **Add defensive checks in loadIndex()**: Check if yamlLoad returns null/undefined before using
2. **Use optional chaining**: All metadata property accesses now use `?.` operator
3. **Add public saveIndex() method**: Tests were calling a non-existent public method
4. **Rename private method**: Changed private `saveIndex(index)` to `saveIndexToFile(index)` to avoid naming conflicts

## Testing
✅ All tests pass including the previously failing `EnhancedIndexManager.test.ts`

```bash
npm test
# PASS test/__tests__/unit/portfolio/EnhancedIndexManager.test.ts
```

## Technical Details
- Handle cases where `yamlLoad` returns null/undefined
- Safely access `entry.metadata.name` with fallback to 'unknown'
- Add warnings when skipping entries with missing metadata
- Maintain backward compatibility while improving robustness

Fixes test failures discovered during cache investigation session.

🤖 Generated with [Claude Code](https://claude.ai/code)