### PR TITLE
feat: Template trigger extraction for Enhanced Capability Index (Issue #1122)

### DIFF
--- a/src/elements/templates/Template.ts
+++ b/src/elements/templates/Template.ts
@@ -32,7 +32,13 @@ export interface TemplateMetadata extends IElementMetadata {
   usage_count?: number;          // Track popularity
   last_used?: string;            // ISO date string
   examples?: TemplateExample[];   // Usage examples
-  triggers?: string[];            // Action verbs that trigger this template (e.g., "create", "generate", "draft")
+
+  /**
+   * Action verbs that trigger this template (e.g., "create", "generate", "draft")
+   * Used by Enhanced Capability Index for intelligent template suggestions
+   * @since v1.9.10
+   */
+  triggers?: string[];
 }
 
 export interface TemplateVariable {

--- a/src/elements/templates/Template.ts
+++ b/src/elements/templates/Template.ts
@@ -32,6 +32,7 @@ export interface TemplateMetadata extends IElementMetadata {
   usage_count?: number;          // Track popularity
   last_used?: string;            // ISO date string
   examples?: TemplateExample[];   // Usage examples
+  triggers?: string[];            // Action verbs that trigger this template (e.g., "create", "generate", "draft")
 }
 
 export interface TemplateVariable {

--- a/src/elements/templates/TemplateManager.ts
+++ b/src/elements/templates/TemplateManager.ts
@@ -433,10 +433,51 @@ export class TemplateManager implements IElementManager<Template> {
     // FIX #1122: Extract and validate triggers for Enhanced Index support
     // Following pattern from SkillManager (PR #1136) and MemoryManager (PR #1133)
     if (data.triggers && Array.isArray(data.triggers)) {
-      metadata.triggers = data.triggers
-        .map((trigger: any) => sanitizeInput(String(trigger), MAX_TRIGGER_LENGTH))
-        .filter((trigger: string) => trigger && TRIGGER_VALIDATION_REGEX.test(trigger))
-        .slice(0, 20); // Limit to 20 triggers max
+      const rawTriggers = data.triggers;
+      const sanitizedTriggers = rawTriggers.map((trigger: any) => ({
+        raw: trigger,
+        sanitized: sanitizeInput(String(trigger), MAX_TRIGGER_LENGTH)
+      }));
+
+      // Filter valid triggers and track rejected ones
+      const validTriggers: string[] = [];
+      const rejectedTriggers: string[] = [];
+
+      for (const { raw, sanitized } of sanitizedTriggers) {
+        if (!sanitized) {
+          rejectedTriggers.push(`"${raw}" (empty after sanitization)`);
+        } else if (!TRIGGER_VALIDATION_REGEX.test(sanitized)) {
+          rejectedTriggers.push(`"${sanitized}" (invalid format - must be alphanumeric with hyphens/underscores only)`);
+        } else {
+          validTriggers.push(sanitized);
+        }
+      }
+
+      // Log warnings for rejected triggers to aid debugging
+      if (rejectedTriggers.length > 0) {
+        logger.warn(
+          `Template "${metadata.name || 'unknown'}": Rejected ${rejectedTriggers.length} invalid trigger(s)`,
+          {
+            templateName: metadata.name,
+            rejectedTriggers,
+            acceptedCount: validTriggers.length
+          }
+        );
+      }
+
+      // Apply limit and warn if exceeded
+      if (validTriggers.length > 20) {
+        logger.warn(
+          `Template "${metadata.name || 'unknown'}": Trigger count exceeds limit (${validTriggers.length} > 20), truncating`,
+          {
+            templateName: metadata.name,
+            totalTriggers: validTriggers.length,
+            truncatedTriggers: validTriggers.slice(20)
+          }
+        );
+      }
+
+      metadata.triggers = validTriggers.slice(0, 20);
     }
     
     // Copy safe fields


### PR DESCRIPTION
## Summary

This PR adds trigger extraction support for Templates, completing the implementation for Issue #1122 as part of the Enhanced Capability Index feature.

## Changes

- ✨ Add `triggers` field to `TemplateMetadata` interface  
- 🔧 Implement trigger extraction and validation in `TemplateManager`
- ✅ Follow established patterns from Skills (PR #1136) and Memories (PR #1133)
- 🛡️ Validate triggers with regex pattern and length limits (max 50 chars, alphanumeric+hyphens)
- 💾 Preserve triggers when saving template metadata

## Testing

- ✅ All existing template unit tests pass (43 tests)
- ✅ Template trigger extraction follows same validation rules as other element types
- ⚠️ Integration tests deferred due to ESM compatibility issues (tracked separately)

## Related Issues

- Fixes #1122 - Template trigger extraction
- Part of Enhanced Capability Index improvements
- Follows patterns from:
  - PR #1133 (Memory triggers) 
  - PR #1136 (Skill triggers)

## Next Steps

After this PR, only Agents remain for trigger extraction (Issue #1123).

---
*No breaking changes - fully backwards compatible*