### PR TITLE
feat: Agent trigger extraction for Enhanced Capability Index (Issue #1123)

### DIFF
--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -27,6 +27,10 @@ const STATE_FILE_EXTENSION = '.state.yaml';
 const MAX_FILE_SIZE = 100 * 1024; // 100KB
 const MAX_YAML_SIZE = 64 * 1024; // 64KB for frontmatter
 
+// Validation constants for agent triggers
+const MAX_TRIGGER_LENGTH = 50;
+const TRIGGER_VALIDATION_REGEX = /^[a-zA-Z0-9\-_]+$/;
+
 // Element creation result interface
 interface ElementCreationResult {
   success: boolean;
@@ -531,6 +535,56 @@ export class AgentManager implements IElementManager<Agent> {
       throw new Error(`Invalid element type: expected '${ElementType.AGENT}', got '${typedMetadata.type}'`);
     }
 
+    // FIX #1123: Extract and validate triggers for Enhanced Index support
+    // Following pattern from TemplateManager (PR #1137), SkillManager (PR #1136) and MemoryManager (PR #1133)
+    if (typedMetadata.triggers && Array.isArray(typedMetadata.triggers)) {
+      const rawTriggers = typedMetadata.triggers;
+      const sanitizedTriggers = rawTriggers.map((trigger: any) => ({
+        raw: trigger,
+        sanitized: sanitizeInput(String(trigger), MAX_TRIGGER_LENGTH)
+      }));
+
+      // Filter valid triggers and track rejected ones
+      const validTriggers: string[] = [];
+      const rejectedTriggers: string[] = [];
+
+      for (const { raw, sanitized } of sanitizedTriggers) {
+        if (!sanitized) {
+          rejectedTriggers.push(`"${raw}" (empty after sanitization)`);
+        } else if (!TRIGGER_VALIDATION_REGEX.test(sanitized)) {
+          rejectedTriggers.push(`"${sanitized}" (invalid format - must be alphanumeric with hyphens/underscores only)`);
+        } else {
+          validTriggers.push(sanitized);
+        }
+      }
+
+      // Log warnings for rejected triggers to aid debugging
+      if (rejectedTriggers.length > 0) {
+        logger.warn(
+          `Agent "${metadata.name || 'unknown'}": Rejected ${rejectedTriggers.length} invalid trigger(s)`,
+          {
+            agentName: metadata.name,
+            rejectedTriggers,
+            acceptedCount: validTriggers.length
+          }
+        );
+      }
+
+      // Apply limit and warn if exceeded
+      if (validTriggers.length > 20) {
+        logger.warn(
+          `Agent "${metadata.name || 'unknown'}": Trigger count exceeds limit (${validTriggers.length} > 20), truncating`,
+          {
+            agentName: metadata.name,
+            totalTriggers: validTriggers.length,
+            truncatedTriggers: validTriggers.slice(20)
+          }
+        );
+      }
+
+      metadata.triggers = validTriggers.slice(0, 20);
+    }
+
     return {
       metadata,
       content: body.trim()
@@ -551,10 +605,11 @@ export class AgentManager implements IElementManager<Agent> {
       description: agent.metadata.description,
       decisionFramework: agent.extensions?.decisionFramework,
       riskTolerance: agent.extensions?.riskTolerance,
-      learningEnabled: agent.extensions?.learningEnabled !== undefined ? 
+      learningEnabled: agent.extensions?.learningEnabled !== undefined ?
         String(agent.extensions.learningEnabled) : undefined,
       maxConcurrentGoals: (agent.metadata as AgentMetadata).maxConcurrentGoals,
-      specializations: agent.extensions?.specializations
+      specializations: agent.extensions?.specializations,
+      triggers: (agent.metadata as AgentMetadata).triggers  // FIX #1123: Preserve triggers when saving
     };
 
     // Remove undefined values

--- a/src/elements/agents/types.ts
+++ b/src/elements/agents/types.ts
@@ -93,6 +93,13 @@ export interface AgentMetadata extends IElementMetadata {
   learningEnabled?: boolean;
   maxConcurrentGoals?: number;
   ruleEngineConfig?: any; // Partial<RuleEngineConfig> - using any to avoid circular dependency
+
+  /**
+   * Action verbs that trigger this agent (e.g., "automate", "orchestrate", "delegate")
+   * Used by Enhanced Capability Index for intelligent agent suggestions
+   * @since v1.9.10
+   */
+  triggers?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR adds trigger extraction support for Agents, **completing the implementation for all element types** as part of the Enhanced Capability Index feature (Issue #1123).

## Changes

- ✨ Add `triggers` field to `AgentMetadata` interface with comprehensive JSDoc
- 🔧 Implement trigger extraction and validation in `AgentManager`
- 🔍 Add detailed warning logs for rejected triggers to aid debugging
- ✅ Follow established patterns from Templates (PR #1137), Skills (PR #1136) and Memories (PR #1133)
- 🛡️ Validate triggers with regex pattern and length limits (max 50 chars, alphanumeric+hyphens)
- 💾 Preserve triggers when saving agent metadata

## Testing

- ✅ All 74 existing agent unit tests pass
- ✅ TypeScript compilation successful
- ✅ Agent trigger extraction follows same validation rules as other element types
- ⚠️ Integration tests deferred due to ESM compatibility issues (tracked separately)

## Trigger Examples for Agents

Agents can now define triggers like:
- `automate` - For automation-focused agents
- `orchestrate` - For multi-step orchestration agents
- `delegate` - For task delegation agents
- `monitor` - For monitoring and alerting agents
- `optimize` - For optimization agents

## Related Issues

- Fixes #1123 - Agent trigger extraction
- **Completes** Enhanced Capability Index trigger extraction for all element types:
  - ✅ Personas (already had triggers)
  - ✅ Skills (PR #1136)
  - ✅ Memories (PR #1133)
  - ✅ Templates (PR #1137)
  - ✅ Agents (this PR)
  - ✅ Ensembles (inherit from contained elements)

## 🎉 Milestone Achieved

This PR completes trigger extraction for all DollhouseMCP element types, enabling the Enhanced Capability Index to provide intelligent suggestions based on action verbs across the entire element ecosystem!

---
*No breaking changes - fully backwards compatible*