### PR TITLE
Hotfix: Add missing v1.9.10 documentation to README files

### DIFF
--- a/README.github.md
+++ b/README.github.md
@@ -873,6 +873,37 @@ For detailed guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## 🏷️ Version History
 
+### v1.9.10 - September 27, 2025
+
+**Enhanced Capability Index & Security**: Complete trigger extraction system and SonarCloud integration
+
+#### ✨ Major Features
+- **Enhanced Capability Index System** - NLP scoring with Jaccard similarity and Shannon entropy
+- **Cross-Element Relationships** - GraphRAG-style relationship mapping
+- **Complete Trigger Extraction** - All element types now support trigger extraction
+- **SonarCloud Integration** - Quality gate PASSING with 0% duplication
+
+#### 🔒 Security Improvements
+- Fixed 16 SonarCloud BLOCKER issues
+- GitHub Actions command injection vulnerabilities resolved
+- Full SHA pinning for all Actions
+- PATH manipulation vulnerability fixed
+
+#### 🛠️ Improvements
+- Extended Node compatibility fixes
+- Enhanced Index stability improvements
+- Type-safe relationship parsing
+- Docker Hub rate limit mitigation
+- Test isolation and CI improvements
+
+#### 📊 Statistics
+- 34 Pull Requests merged
+- Test Coverage: 98.17%
+- Security Hotspots: 100% reviewed
+- Code Duplication: 0% on new code
+
+---
+
 ### v1.9.9 - September 22, 2025
 
 **Security & Stability**: Prototype pollution protection and memory timestamp fixes

--- a/README.md
+++ b/README.md
@@ -873,6 +873,37 @@ For detailed guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## 🏷️ Version History
 
+### v1.9.10 - September 27, 2025
+
+**Enhanced Capability Index & Security**: Complete trigger extraction system and SonarCloud integration
+
+#### ✨ Major Features
+- **Enhanced Capability Index System** - NLP scoring with Jaccard similarity and Shannon entropy
+- **Cross-Element Relationships** - GraphRAG-style relationship mapping
+- **Complete Trigger Extraction** - All element types now support trigger extraction
+- **SonarCloud Integration** - Quality gate PASSING with 0% duplication
+
+#### 🔒 Security Improvements
+- Fixed 16 SonarCloud BLOCKER issues
+- GitHub Actions command injection vulnerabilities resolved
+- Full SHA pinning for all Actions
+- PATH manipulation vulnerability fixed
+
+#### 🛠️ Improvements
+- Extended Node compatibility fixes
+- Enhanced Index stability improvements
+- Type-safe relationship parsing
+- Docker Hub rate limit mitigation
+- Test isolation and CI improvements
+
+#### 📊 Statistics
+- 34 Pull Requests merged
+- Test Coverage: 98.17%
+- Security Hotspots: 100% reviewed
+- Code Duplication: 0% on new code
+
+---
+
 ### v1.9.9 - September 22, 2025
 
 **Security & Stability**: Prototype pollution protection and memory timestamp fixes

--- a/docs/readme/chunks/11-changelog-full.md
+++ b/docs/readme/chunks/11-changelog-full.md
@@ -1,5 +1,36 @@
 ## 🏷️ Version History
 
+### v1.9.10 - September 27, 2025
+
+**Enhanced Capability Index & Security**: Complete trigger extraction system and SonarCloud integration
+
+#### ✨ Major Features
+- **Enhanced Capability Index System** - NLP scoring with Jaccard similarity and Shannon entropy
+- **Cross-Element Relationships** - GraphRAG-style relationship mapping
+- **Complete Trigger Extraction** - All element types now support trigger extraction
+- **SonarCloud Integration** - Quality gate PASSING with 0% duplication
+
+#### 🔒 Security Improvements
+- Fixed 16 SonarCloud BLOCKER issues
+- GitHub Actions command injection vulnerabilities resolved
+- Full SHA pinning for all Actions
+- PATH manipulation vulnerability fixed
+
+#### 🛠️ Improvements
+- Extended Node compatibility fixes
+- Enhanced Index stability improvements
+- Type-safe relationship parsing
+- Docker Hub rate limit mitigation
+- Test isolation and CI improvements
+
+#### 📊 Statistics
+- 34 Pull Requests merged
+- Test Coverage: 98.17%
+- Security Hotspots: 100% reviewed
+- Code Duplication: 0% on new code
+
+---
+
 ### v1.9.9 - September 22, 2025
 
 **Security & Stability**: Prototype pollution protection and memory timestamp fixes


### PR DESCRIPTION
## 🔥 Hotfix: Complete v1.9.10 Release Documentation

This hotfix adds the missing v1.9.10 documentation to the README files in main.

### 🐛 Problem:
- PR #1143 updated CHANGELOG.md but not the README files
- Main branch has v1.9.10 code and CHANGELOG but README still shows v1.9.9

### ✅ Solution:
- Cherry-picked just the README documentation from develop
- No code changes, only documentation

### 📝 Files Changed:
- README.md - Added v1.9.10 to Version History
- README.github.md - Added v1.9.10 to Version History  
- docs/readme/chunks/11-changelog-full.md - Source for future README builds

### 🔍 Verification:
All three files now properly show v1.9.10 with complete feature list and statistics.

This completes the v1.9.10 release documentation.