### PR TITLE
🚨 HOTFIX: Remove hardcoded token from validation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ src/generated/
 .env.production.local
 test/e2e/.env.test.local
 
+# Scripts with credentials (should use environment variables)
+scripts/validation/run-sync-test-with-pat.sh
+
 # IDE files
 .vscode/
 .idea/

--- a/scripts/validation/run-sync-test-with-pat.sh
+++ b/scripts/validation/run-sync-test-with-pat.sh
@@ -3,8 +3,15 @@
 echo "🧪 Running Sync Test with Personal Access Token"
 echo "================================================"
 
-# The PAT from earlier in the session - it was working!
-PAT="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"
+# Use environment variable for PAT - never hardcode tokens!
+# Export GITHUB_TEST_TOKEN before running this script
+PAT="${GITHUB_TEST_TOKEN:-}"
+
+if [ -z "$PAT" ]; then
+  echo "❌ Error: GITHUB_TEST_TOKEN environment variable not set"
+  echo "Usage: GITHUB_TEST_TOKEN=ghp_your_token_here ./run-sync-test-with-pat.sh"
+  exit 1
+fi
 
 docker run --rm -i \
   --env-file docker/test-environment.env \


### PR DESCRIPTION
## Security Hotfix

Addresses SonarCloud BLOCKER vulnerability - hardcoded GitHub token in committed code.

## Changes
- Replace hardcoded PAT with environment variable `GITHUB_TEST_TOKEN`
- Add proper error handling if token not provided
- Add script to .gitignore to prevent future token leaks

## Details
The token `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` was hardcoded in `scripts/validation/run-sync-test-with-pat.sh`. While this token is **already expired/revoked** (returns 401), it still triggers security scanners.

## New Usage
```bash
GITHUB_TEST_TOKEN=ghp_your_token_here ./run-sync-test-with-pat.sh
```

## After Merge
This hotfix needs to be merged to both:
- [x] main (this PR)  
- [ ] develop (will do after main merge)

Fixes #1148