### PR TITLE
chore: Enable SonarCloud analysis for develop branch

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,50 @@
+name: SonarCloud Analysis
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  sonarcloud:
+    name: SonarCloud Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests with coverage
+        run: npm test -- --coverage --passWithNoTests
+        env:
+          CI: true
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.projectKey=DollhouseMCP_mcp-server
+            -Dsonar.organization=dollhousemcp
+            -Dsonar.sources=src
+            -Dsonar.tests=test
+            -Dsonar.javascript.lcov.reportPaths=test/coverage/lcov.info
+            -Dsonar.typescript.tsconfigPaths=tsconfig.json,tsconfig.test.json
+            -Dsonar.coverage.exclusions=**/*.test.ts,**/*.spec.ts,**/test/**,**/dist/**,**/node_modules/**,**/coverage/**
+            -Dsonar.cpd.exclusions=src/security/audit/config/suppressions.ts,src/security/audit/config/**,**/test/**,test/**
+            -Dsonar.exclusions=**/node_modules/**,**/dist/**,**/coverage/**,**/*.min.js,**/*.min.css


### PR DESCRIPTION
## Summary
Adds a dedicated SonarCloud workflow to enable branch analysis for the develop branch.

## Problem
- SonarCloud was only analyzing the main branch
- Automatic analysis doesn't support branch analysis
- We couldn't see the impact of our fixes in develop until they reached main

## Solution
- Created a CI-based SonarCloud workflow
- Configured to run on both main and develop branches
- Also runs on pull requests

## Configuration Required
⚠️ **IMPORTANT**: This workflow requires the `SONAR_TOKEN` secret to be set in the repository settings.

## Testing
Once merged, pushes to develop will trigger SonarCloud analysis and we'll be able to see:
- Bug count in develop (should show our fixes)
- Code quality metrics for develop
- Separate quality gates for each branch

## Notes
- This supplements (and may replace) the automatic analysis
- The workflow includes test coverage reporting
- Uses the same exclusions as configured in sonar-project.properties