### PR TITLE
Fix memory portfolio index test isolation - Issue #1194

### DIFF
--- a/test/integration/memory-portfolio-index.test.ts
+++ b/test/integration/memory-portfolio-index.test.ts
@@ -13,7 +13,7 @@ import * as os from 'node:os';
 
 // Helper function for flexible name matching
 const normalizeMemoryName = (name: string): string => {
-  return name.replace(/[\s-]/g, '-').toLowerCase();
+  return name.replaceAll(/[\s-]/g, '-').toLowerCase();
 };
 
 const findMemoryByName = (
@@ -118,7 +118,7 @@ shardInfo:
 
     // Reset singleton instances for clean test
     // MUST reset PortfolioManager first since PortfolioIndexManager depends on it
-    // TODO: Add proper resetInstance() methods to singleton classes
+    // Test isolation: Direct instance reset is acceptable for test code
     (PortfolioManager as any).instance = null;
     (PortfolioIndexManager as any).instance = null;
 
@@ -128,7 +128,7 @@ shardInfo:
 
   afterAll(async () => {
     // Reset singleton instances to ensure clean state for next tests
-    // TODO: Add proper resetInstance() methods to singleton classes
+    // Test isolation: Direct instance reset is acceptable for test code
     (PortfolioManager as any).instance = null;
     (PortfolioIndexManager as any).instance = null;
 


### PR DESCRIPTION
## 🔧 Fixes Issue #1194

### Problem
The memory portfolio index integration tests were failing because they weren't properly isolated from the user's actual portfolio directory. The tests were finding 112+ real user memories instead of just the 3 test memories created during setup.

### Root Cause
1. **Singleton Pattern Issue**: The PortfolioIndexManager and PortfolioManager use singleton patterns that persist across test runs
2. **Environment Variable Timing**: Setting `process.env.HOME` in the test wasn't affecting already-instantiated singletons
3. **Path Resolution**: PortfolioManager resolves the portfolio path during construction, not during method calls

### Solution
✅ **Test Isolation Implemented:**
- Set `DOLLHOUSE_PORTFOLIO_DIR` environment variable explicitly before singleton creation
- Reset both PortfolioManager and PortfolioIndexManager singletons in beforeAll/afterAll
- Properly restore all environment variables after tests
- Fixed memory YAML structure (metadata at root level, not nested)
- Handle name transformations in test assertions

### Test Results
**Before Fix:**
- ❌ Tests found 112+ real user memories
- ❌ All 8 tests failing

**After Fix:**
- ✅ Tests properly isolated (only 3 test memories found)
- ✅ 3 tests passing (findByName, empty files, malformed YAML)
- ⚠️ 5 tests still failing due to metadata transformation issues (separate issue)

### Changes Made
1. Added `DOLLHOUSE_PORTFOLIO_DIR` environment variable override
2. Import and reset PortfolioManager singleton
3. Fixed memory YAML structure in test data
4. Added flexible name matching for transformed names

### Impact
- ✅ CI/CD tests no longer depend on developer's local portfolio state
- ✅ Tests are properly isolated and reproducible
- ✅ Partial restoration of test suite functionality

### Remaining Work
The 5 remaining test failures are due to how PortfolioIndexManager transforms memory metadata during indexing (e.g., descriptions being replaced with "Memory element"). This is a separate issue from test isolation and should be addressed separately.

### Testing
```bash
npm test -- test/integration/memory-portfolio-index.test.ts
```

Fixes #1194