### PR TITLE
chore(release): Prepare v1.9.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [1.9.13] - 2025-09-29
+
+### Fixed
+- **Memory System Critical Fixes (Issue #1206, PR #1207)**
+  - Fixed security scanner false positives preventing legitimate security documentation from loading
+  - Memory files with security terms (vulnerability, exploit, attack) now load correctly
+  - Local memory files are now pre-trusted (validateContent: false)
+
+  - Added visible error reporting for failed memory loads
+  - Users now see "Failed to load X memories" with detailed error messages
+  - New getLoadStatus() diagnostic method for troubleshooting
+
+  - New legacy memory migration tool (migrate-legacy-memories.ts)
+  - Migrates old .md files to .yaml format in date-organized folders
+  - Safe archiving of original files, dry-run mode by default
+
+### Added
+- **CLI Utility**: migrate-legacy-memories.ts for legacy file migration
+- **Diagnostic Method**: getLoadStatus() for memory loading diagnostics
+- **Error Tracking**: failedLoads tracking in MemoryManager
+
+### Code Quality
+- Fixed SonarCloud S3776: Reduced cognitive complexity in getLoadStatus()
+- Fixed SonarCloud S3358: Replaced nested ternary with if-else chain
+- Fixed SonarCloud S7785: Use top-level await instead of promise chain
+- Extracted handleLoadFailure() to eliminate code duplication
+- Use os.homedir() for cross-platform reliability
+
+### Security
+- Fixed DMCP-SEC-004: Added Unicode normalization to CLI input validation
+
 ## [1.9.12] - 2025-09-29
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "1.9.11",
+  "version": "1.9.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "1.9.11",
+      "version": "1.9.13",
       "license": "AGPL-3.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "1.9.12",
+  "version": "1.9.13",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/test/docker-v1913-memory-fixes/.dockerignore
+++ b/test/docker-v1913-memory-fixes/.dockerignore
@@ -1,0 +1,17 @@
+node_modules
+dist
+.git
+.github
+*.log
+.env
+.env.local
+coverage
+.nyc_output
+.DS_Store
+.vscode
+.idea
+*.swp
+*.swo
+*~
+# Include package-lock.json for npm ci
+!package-lock.json

--- a/test/docker-v1913-memory-fixes/Dockerfile
+++ b/test/docker-v1913-memory-fixes/Dockerfile
@@ -11,7 +11,11 @@ RUN useradd -m -s /bin/bash claude
 WORKDIR /home/claude
 
 # Copy the local MCP server source with our v1.9.13 fixes
-COPY --chown=claude:claude . /home/claude/mcp-server/
+# Note: Build context should be run from mcp-server root: docker build -f test/docker-v1913-memory-fixes/Dockerfile .
+COPY --chown=claude:claude package*.json /home/claude/mcp-server/
+COPY --chown=claude:claude tsconfig.json /home/claude/mcp-server/
+COPY --chown=claude:claude src /home/claude/mcp-server/src/
+COPY --chown=claude:claude scripts /home/claude/mcp-server/scripts/
 
 # Build the MCP server
 WORKDIR /home/claude/mcp-server
@@ -82,10 +86,7 @@ RUN chown -R claude:claude /home/claude
 USER claude
 WORKDIR /home/claude
 
-# Configure Claude
-RUN claude config set --global apiKeyHelper /home/claude/.claude/anthropic_key_helper.sh
-
-# Create comprehensive test script
+# Create comprehensive test script with runtime Claude configuration
 RUN echo '#!/bin/bash' > /home/claude/test-v1913-fixes.sh && \
     echo 'set -e' >> /home/claude/test-v1913-fixes.sh && \
     echo 'echo "==================================="' >> /home/claude/test-v1913-fixes.sh && \

--- a/test/docker-v1913-memory-fixes/test-runtime.sh
+++ b/test/docker-v1913-memory-fixes/test-runtime.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+echo "==================================="
+echo "Testing v1.9.13 Memory Fixes"
+echo "==================================="
+echo "API Key: ${ANTHROPIC_API_KEY:0:15}..."
+echo "MCP Config: /home/claude/.config/claude-code/config.json"
+echo ""
+
+echo "Test 1: Security Scanner False Positive (Fix #1)"
+echo "Attempting to activate test-security-docs memory..."
+echo "Activate the test-security-docs memory. It should load successfully despite containing security terms like vulnerability, exploit, attack vector. Reply with SUCCESS or FAILURE." | claude --model sonnet --print --mcp-config /home/claude/.config/claude-code/config.json --allowedTools mcp__dollhousemcp__activate_element
+echo ""
+
+echo "Test 2: Silent Error Reporting (Fix #2)"
+echo "Checking for warning logs about failed loads..."
+grep -i "Failed to load.*memories" /home/claude/.claude/logs/*.log 2>/dev/null || echo "No failed load warnings (expected if all files are valid)"
+echo ""
+
+echo "Test 3: Legacy Memory Migration (Fix #3)"
+echo "Running migration tool in dry-run mode..."
+cd /home/claude/mcp-server
+node dist/utils/migrate-legacy-memories.js /home/claude/.dollhouse/portfolio/memories
+echo ""
+
+echo "==================================="
+echo "Test Summary"
+echo "==================================="
+echo "Test 1 (Security False Positive): Check output above"
+echo "Test 2 (Error Reporting): Check logs"
+echo "Test 3 (Migration Tool): Check migration output"


### PR DESCRIPTION
Prepare for v1.9.13 release with version bump and CHANGELOG documentation.

## Changes
- Version bump from 1.9.12 → 1.9.13
- CHANGELOG.md updated with v1.9.13 release notes
- Docker test files for v1.9.13 verification

## Related
- Issue #1206
- PR #1207 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)