### PR TITLE
fix(formatter): ElementFormatter validateContent false positives (#1211)

### DIFF
--- a/src/security/secureYamlParser.ts
+++ b/src/security/secureYamlParser.ts
@@ -151,7 +151,8 @@ export class SecureYamlParser {
     }
 
     // 4. Pre-parse security validation
-    if (!ContentValidator.validateYamlContent(yamlContent)) {
+    // FIX (Issue #1211): Only validate content if validateContent option is true
+    if (opts.validateContent && !ContentValidator.validateYamlContent(yamlContent)) {
       SecurityMonitor.logSecurityEvent({
         type: 'YAML_INJECTION_ATTEMPT',
         severity: 'CRITICAL',


### PR DESCRIPTION
## Summary

Fixes #1211 - ElementFormatter and SecureYamlParser were triggering security scanner false positives on legitimate content because they ignored the `validateContent: false` option.

## Fixes Implemented

### 1. CRITICAL: SecureYamlParser ignores validateContent option
**Location**: `src/security/secureYamlParser.ts:154`

**Problem**: Pre-parse security validation ran unconditionally, ignoring `opts.validateContent`

**Fix**: Added conditional check - only validates if `opts.validateContent` is true

**Impact**: Allows local trusted files to bypass content scanning while maintaining security for untrusted sources

---

### 2. HIGH: ElementFormatter uses validateContent: true throughout  
**Locations**: Lines 178, 402, 531, 605, 622

**Problem**: All 5 SecureYamlParser.parse() calls used `validateContent: true`, triggering false positives on sonarcloud reference files

**Fix**: Changed all instances to `validateContent: false` (matches MemoryManager PR #1207)

---

### 3. MEDIUM: ElementFormatter generates bad memory names
**Location**: `src/utils/ElementFormatter.ts:482`

**Problem**: Used auto-generated entry IDs like `mem_1759077319164_w9m9fk56y`

**Fix**: Derive name from filename - produces readable names like `sonarcloud-rules-reference`

## Verification

✅ TypeScript builds successfully  
✅ Both test files format without security errors  
✅ Name fields correctly derived from filenames  
✅ All embedded metadata extracted to proper YAML structure

## Test Results
```
✓ sonarcloud-rules-reference.yaml - 1 issue found, 6 fixes applied
✓ sonarcloud-api-reference.yaml - 1 issue found, 6 fixes applied
```

**NO SECURITY ERRORS** on either file.

Closes #1211

🤖 Generated with [Claude Code](https://claude.com/claude-code)