### PR TITLE
fix(ci): Skip Claude Code Review for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+    # Skip Dependabot PRs since they don't have access to secrets (CLAUDE_CODE_OAUTH_TOKEN)
+    # Can manually request reviews with @claude mention if needed
+    if: github.actor != 'dependabot[bot]'
+
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,9 +34,6 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          
-          # Allow Dependabot to trigger Claude reviews
-          allowed_bots: "dependabot"
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"


### PR DESCRIPTION
## Problem

Dependabot PRs are failing the Claude Code Review workflow because they don't have access to repository secrets (`CLAUDE_CODE_OAUTH_TOKEN`).

**Error**: 
```
Environment variable validation failed:
  - Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required
```

This is a GitHub security feature - Dependabot PRs intentionally don't get access to secrets to prevent potential exposure.

## Solution

Added condition to skip Claude Code Review for Dependabot PRs:

```yaml
if: github.actor != 'dependabot[bot]'
```

## Impact

- ✅ Dependabot PRs will no longer show Claude Code Review as failing
- ✅ Can still manually request reviews with `@claude` mention if needed
- ✅ All other PRs continue to get automated Claude reviews
- ✅ Real CI checks (tests, builds, security) still run on Dependabot PRs

## Testing

Verified the issue occurs on:
- PR #1199 (MCP SDK update)
- PR #1200 (@types/node update)
- PR #1202 (jest update)
- PR #1203 (tsx update)
- PR #1204 (@jest/globals update)

All show the same secret access error.

## Related

Part of resolving Dependabot PR workflow issues identified in today's release session.