### PR TITLE
docs: Add README to data/ directory clarifying bundled elements

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,80 @@
+# Bundled Starter Elements
+
+## Purpose
+
+This directory contains **default example elements** that ship with the DollhouseMCP NPM package. These are NOT user-generated files - they are part of the product.
+
+## What Are Bundled Elements?
+
+On first run, DollhouseMCP copies these example elements to the user's local portfolio (`~/.dollhouse/portfolio/`) to provide:
+
+1. **Working examples** - Users can immediately try personas, skills, and templates
+2. **Learning material** - See proper element structure and metadata
+3. **Quick start** - No empty portfolio on first install
+
+## Directory Structure
+
+```
+data/
+├── personas/       Example AI behavioral profiles
+├── skills/         Example discrete capabilities
+├── templates/      Example reusable content structures
+├── agents/         Example goal-oriented decision makers
+├── memories/       Example persistent context storage
+└── ensembles/      Example combined element orchestration
+```
+
+## Important Distinctions
+
+| This Directory (data/) | User Portfolio (~/.dollhouse/portfolio/) |
+|------------------------|------------------------------------------|
+| ✅ In git repository   | ❌ NOT in repository                     |
+| ✅ Ships with NPM      | ❌ Local user storage only               |
+| ✅ Read-only examples  | ✅ User's active elements                |
+| ✅ Version controlled  | ❌ .gitignored                           |
+
+## For Developers
+
+### NPM Package Inclusion
+
+These files are explicitly included in package.json:
+
+```json
+"files": [
+  "data/personas/**/*.md",
+  "data/skills/**/*.md",
+  "data/templates/**/*.md",
+  "data/agents/**/*.md",
+  "data/memories/**/*.md",
+  "data/ensembles/**/*.md"
+]
+```
+
+### Loading Mechanism
+
+See `src/portfolio/DefaultElementProvider.ts` for the implementation that:
+- Locates bundled data in NPM installation or git repo
+- Copies elements to user portfolio on first run
+- Handles development vs production modes
+
+### Testing
+
+`test/__tests__/basic.test.ts` verifies:
+- Required directories exist
+- Expected example files are present
+- Proper structure is maintained
+
+## Common Misconceptions
+
+❌ "data/ should be in .gitignore" - **NO**, these are bundled examples, not user data
+❌ "This is test data" - **NO**, this is production starter content
+❌ "This is my local portfolio" - **NO**, your portfolio is in `~/.dollhouse/`
+
+## Contributing New Examples
+
+When adding new bundled elements:
+
+1. Follow existing element structure (YAML frontmatter + Markdown)
+2. Keep examples simple and educational
+3. Test that DefaultElementProvider can load them
+4. Update this README if adding new element types

--- a/data/README.md
+++ b/data/README.md
@@ -12,6 +12,18 @@ On first run, DollhouseMCP copies these example elements to the user's local por
 2. **Learning material** - See proper element structure and metadata
 3. **Quick start** - No empty portfolio on first install
 
+### First-Run Process
+
+When a user installs DollhouseMCP via NPM:
+
+1. **User installs**: `npm install @dollhousemcp/mcp-server`
+2. **First launch**: User starts DollhouseMCP for the first time
+3. **Empty portfolio detected**: System checks `~/.dollhouse/portfolio/` and finds it empty
+4. **Bundled elements copied**: DefaultElementProvider copies files from `data/` → user portfolio
+5. **User customizes**: User can now modify their local copies without affecting the originals
+
+**Important**: The bundled elements in `data/` remain unchanged. Users work with *copies* in their portfolio.
+
 ## Directory Structure
 
 ```
@@ -52,16 +64,37 @@ These files are explicitly included in package.json:
 
 ### Loading Mechanism
 
-See `src/portfolio/DefaultElementProvider.ts` for the implementation that:
-- Locates bundled data in NPM installation or git repo
-- Copies elements to user portfolio on first run
-- Handles development vs production modes
+See `src/portfolio/DefaultElementProvider.ts` for the implementation:
+
+- **Population logic** (`populateDefaultElements()` around line 947): Main function that orchestrates copying bundled elements to user portfolio
+- **File copying** (`copyElementFiles()` around line 679): Copies individual files while preserving existing user modifications
+- **Directory detection** (`findDataDirectory()` around line 190): Locates bundled data in NPM installation or git repository
+- **Development vs production mode** (lines 35-122): See below for detailed explanation
+
+#### Development vs Production Modes
+
+The loading mechanism behaves differently based on the environment:
+
+**Production Mode** (NPM installation, no `.git` directory):
+- ✅ Bundled elements ARE loaded by default
+- Users get starter examples on first run
+- Provides immediate value for new installations
+
+**Development Mode** (Git clone, `.git` directory present):
+- ❌ Bundled elements are NOT loaded by default
+- Prevents test/example data from polluting developer's portfolio
+- Developers can override with `DOLLHOUSE_LOAD_TEST_DATA=true` environment variable
+
+This distinction ensures:
+- End users get a great first-run experience with examples
+- Developers working on the codebase don't get unwanted test data in their personal portfolio
+- Test elements (marked with metadata) are blocked in production for security
 
 ### Testing
 
-`test/__tests__/basic.test.ts` verifies:
-- Required directories exist
-- Expected example files are present
+`test/__tests__/basic.test.ts` (lines 33-57) verifies:
+- Required directories exist (including `data/personas`)
+- Expected example files are present (e.g., `creative-writer.md`)
 - Proper structure is maintained
 
 ## Common Misconceptions


### PR DESCRIPTION
## Summary

Adds comprehensive README to `data/` directory to address developer confusion about its purpose.

**Problem**: Code review feedback suggested the `data/` directory should be in `.gitignore`, indicating confusion about whether it contains user-generated files or test data.

**Reality**: The `data/` directory contains **bundled starter elements** that ship with the NPM package. These are production assets, not user data.

## Changes

- Created `data/README.md` explaining:
  - Purpose: Bundled example elements for new users
  - Distinction from user portfolio (`~/.dollhouse/portfolio/`)
  - How DefaultElementProvider loads these elements
  - NPM package inclusion via `package.json`
  - Common misconceptions addressed

## Why This Matters

Without documentation, contributors may:
- ❌ Suggest `.gitignoring` production assets
- ❌ Confuse bundled examples with user data
- ❌ Question why test-like content is in the repo
- ❌ Not understand the DefaultElementProvider loading mechanism

With this README:
- ✅ Clear distinction between bundled and user content
- ✅ Explains the onboarding/starter pack purpose
- ✅ Documents the NPM packaging strategy
- ✅ Prevents future confusion

## Testing

- [x] README content reviewed
- [x] Markdown formatting verified
- [x] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)