### PR TITLE
fix: make beta publication safely resumable

### DIFF
--- a/.github/workflows/publish-beta-release.yml
+++ b/.github/workflows/publish-beta-release.yml
@@ -135,14 +135,22 @@ jobs:
                 local left_pre="${left#*-}"
                 local right_pre="${right#*-}"
                 local -a left_core_parts right_core_parts left_ids right_ids
-                local index left_id right_id
+                local index left_id right_id left_number right_number
                 local LC_ALL=C
 
                 IFS='.' read -r -a left_core_parts <<< "${left_core}"
                 IFS='.' read -r -a right_core_parts <<< "${right_core}"
                 for index in 0 1 2; do
-                  if ((10#${left_core_parts[index]} > 10#${right_core_parts[index]})); then return 0; fi
-                  if ((10#${left_core_parts[index]} < 10#${right_core_parts[index]})); then return 1; fi
+                  left_number="${left_core_parts[index]}"
+                  right_number="${right_core_parts[index]}"
+                  left_number="${left_number#"${left_number%%[!0]*}"}"
+                  right_number="${right_number#"${right_number%%[!0]*}"}"
+                  left_number="${left_number:-0}"
+                  right_number="${right_number:-0}"
+                  if ((${#left_number} > ${#right_number})); then return 0; fi
+                  if ((${#left_number} < ${#right_number})); then return 1; fi
+                  if [[ "${left_number}" > "${right_number}" ]]; then return 0; fi
+                  if [[ "${left_number}" < "${right_number}" ]]; then return 1; fi
                 done
 
                 IFS='.' read -r -a left_ids <<< "${left_pre}"
@@ -152,7 +160,13 @@ jobs:
                   right_id="${right_ids[index]}"
                   [[ "${left_id}" == "${right_id}" ]] && continue
                   if [[ "${left_id}" =~ ^[0-9]+$ && "${right_id}" =~ ^[0-9]+$ ]]; then
-                    if ((10#${left_id} > 10#${right_id})); then return 0; fi
+                    left_number="${left_id#"${left_id%%[!0]*}"}"
+                    right_number="${right_id#"${right_id%%[!0]*}"}"
+                    left_number="${left_number:-0}"
+                    right_number="${right_number:-0}"
+                    if ((${#left_number} > ${#right_number})); then return 0; fi
+                    if ((${#left_number} < ${#right_number})); then return 1; fi
+                    if [[ "${left_number}" > "${right_number}" ]]; then return 0; fi
                     return 1
                   fi
                   if [[ "${left_id}" =~ ^[0-9]+$ ]]; then return 1; fi

--- a/.github/workflows/publish-beta-release.yml
+++ b/.github/workflows/publish-beta-release.yml
@@ -122,19 +122,48 @@ jobs:
               exit 1
             fi
             npm_latest_version=$(npm view "@dollhousemcp/mcp-server" dist-tags.latest --registry=https://registry.npmjs.org 2>/dev/null || true)
-            if ! node --input-type=module -e '
-              import semver from "semver";
-              const version = process.argv[1];
-              if (!semver.valid(version) || semver.prerelease(version) !== null) process.exit(1);
-            ' "${npm_latest_version}"; then
+            if [[ ! "${npm_latest_version}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
               echo "::error::npm dist-tags.latest must point to a stable SemVer before a beta retry can skip npm publication (${npm_latest_version:-<unset>})"
               exit 1
             fi
             if [[ "${npm_beta_version}" != "${package_version}" ]]; then
-              if ! node --input-type=module -e '
-                import semver from "semver";
-                if (!semver.gt(process.argv[1], process.argv[2])) process.exit(1);
-              ' "${npm_beta_version}" "${package_version}"; then
+              beta_is_newer() {
+                local left="$1"
+                local right="$2"
+                local left_core="${left%%-*}"
+                local right_core="${right%%-*}"
+                local left_pre="${left#*-}"
+                local right_pre="${right#*-}"
+                local -a left_core_parts right_core_parts left_ids right_ids
+                local index left_id right_id
+                local LC_ALL=C
+
+                IFS='.' read -r -a left_core_parts <<< "${left_core}"
+                IFS='.' read -r -a right_core_parts <<< "${right_core}"
+                for index in 0 1 2; do
+                  if ((10#${left_core_parts[index]} > 10#${right_core_parts[index]})); then return 0; fi
+                  if ((10#${left_core_parts[index]} < 10#${right_core_parts[index]})); then return 1; fi
+                done
+
+                IFS='.' read -r -a left_ids <<< "${left_pre}"
+                IFS='.' read -r -a right_ids <<< "${right_pre}"
+                for ((index = 0; index < ${#left_ids[@]} && index < ${#right_ids[@]}; index++)); do
+                  left_id="${left_ids[index]}"
+                  right_id="${right_ids[index]}"
+                  [[ "${left_id}" == "${right_id}" ]] && continue
+                  if [[ "${left_id}" =~ ^[0-9]+$ && "${right_id}" =~ ^[0-9]+$ ]]; then
+                    if ((10#${left_id} > 10#${right_id})); then return 0; fi
+                    return 1
+                  fi
+                  if [[ "${left_id}" =~ ^[0-9]+$ ]]; then return 1; fi
+                  if [[ "${right_id}" =~ ^[0-9]+$ ]]; then return 0; fi
+                  [[ "${left_id}" > "${right_id}" ]] && return 0
+                  return 1
+                done
+                ((${#left_ids[@]} > ${#right_ids[@]}))
+              }
+
+              if ! beta_is_newer "${npm_beta_version}" "${package_version}"; then
                 echo "::error::npm dist-tags.beta points to older beta ${npm_beta_version}; refusing to report ${package_version} complete"
                 exit 1
               fi

--- a/.github/workflows/publish-beta-release.yml
+++ b/.github/workflows/publish-beta-release.yml
@@ -121,8 +121,24 @@ jobs:
               echo "::error::npm version ${package_version} exists, but dist-tags.beta is invalid or unset (${npm_beta_version:-<unset>})"
               exit 1
             fi
+            npm_latest_version=$(npm view "@dollhousemcp/mcp-server" dist-tags.latest --registry=https://registry.npmjs.org 2>/dev/null || true)
+            if ! node --input-type=module -e '
+              import semver from "semver";
+              const version = process.argv[1];
+              if (!semver.valid(version) || semver.prerelease(version) !== null) process.exit(1);
+            ' "${npm_latest_version}"; then
+              echo "::error::npm dist-tags.latest must point to a stable SemVer before a beta retry can skip npm publication (${npm_latest_version:-<unset>})"
+              exit 1
+            fi
             if [[ "${npm_beta_version}" != "${package_version}" ]]; then
-              echo "::warning::npm dist-tags.beta points to ${npm_beta_version}; leaving that valid beta channel unchanged while repairing ${package_version} artifacts"
+              if ! node --input-type=module -e '
+                import semver from "semver";
+                if (!semver.gt(process.argv[1], process.argv[2])) process.exit(1);
+              ' "${npm_beta_version}" "${package_version}"; then
+                echo "::error::npm dist-tags.beta points to older beta ${npm_beta_version}; refusing to report ${package_version} complete"
+                exit 1
+              fi
+              echo "::warning::npm dist-tags.beta points to newer beta ${npm_beta_version}; leaving that channel unchanged while repairing ${package_version} artifacts"
             fi
             npm_publish_complete=true
           fi

--- a/.github/workflows/publish-beta-release.yml
+++ b/.github/workflows/publish-beta-release.yml
@@ -83,20 +83,56 @@ jobs:
             fi
           fi
 
-          if gh release view "${tag_name}" >/dev/null 2>&1; then
-            echo "::error::Release ${tag_name} already exists"
-            exit 1
+          release_exists=false
+          if release_json=$(gh release view "${tag_name}" \
+            --json tagName,isPrerelease,isDraft,targetCommitish 2>/dev/null); then
+            release_exists=true
+            release_tag=$(jq -r '.tagName' <<<"${release_json}")
+            release_prerelease=$(jq -r '.isPrerelease' <<<"${release_json}")
+            release_draft=$(jq -r '.isDraft' <<<"${release_json}")
+            release_target=$(jq -r '.targetCommitish' <<<"${release_json}")
+
+            if [[ "${tag_exists}" != "true" ]]; then
+              echo "::error::Release ${tag_name} exists without its expected Git tag"
+              exit 1
+            fi
+            if [[ "${release_tag}" != "${tag_name}" ]]; then
+              echo "::error::Release lookup returned tag ${release_tag}, not ${tag_name}"
+              exit 1
+            fi
+            if [[ "${release_prerelease}" != "true" || "${release_draft}" != "false" ]]; then
+              echo "::error::Existing release ${tag_name} must be a published prerelease"
+              exit 1
+            fi
+            if [[ "${release_target}" != "${GITHUB_SHA}" ]]; then
+              echo "::error::Release ${tag_name} targets ${release_target}, not ${GITHUB_SHA}"
+              exit 1
+            fi
           fi
 
+          npm_exists=false
           if npm view "@dollhousemcp/mcp-server@${package_version}" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
-            echo "::error::npm version ${package_version} already exists"
-            exit 1
+            if [[ "${release_exists}" != "true" ]]; then
+              echo "::error::npm version ${package_version} exists without a matching reusable GitHub prerelease"
+              exit 1
+            fi
+            npm_beta_version=$(npm view "@dollhousemcp/mcp-server" dist-tags.beta --registry=https://registry.npmjs.org 2>/dev/null || true)
+            if [[ ! "${npm_beta_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-beta(\.[0-9A-Za-z.-]+)?$ ]]; then
+              echo "::error::npm version ${package_version} exists, but dist-tags.beta is invalid or unset (${npm_beta_version:-<unset>})"
+              exit 1
+            fi
+            if [[ "${npm_beta_version}" != "${package_version}" ]]; then
+              echo "::warning::npm dist-tags.beta points to ${npm_beta_version}; leaving that valid beta channel unchanged while repairing ${package_version} artifacts"
+            fi
+            npm_exists=true
           fi
 
           {
             echo "version=${package_version}"
             echo "tag_name=${tag_name}"
             echo "tag_exists=${tag_exists}"
+            echo "release_exists=${release_exists}"
+            echo "npm_exists=${npm_exists}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Verify default-branch release workflows are prerelease-safe
@@ -151,13 +187,20 @@ jobs:
       - name: Dry-run summary
         if: ${{ inputs.dry_run == true }}
         shell: bash
+        env:
+          RELEASE_EXISTS: ${{ steps.release.outputs.release_exists }}
         run: |
+          if [[ "${RELEASE_EXISTS}" == "true" ]]; then
+            release_action="reuse matching GitHub prerelease"
+          else
+            release_action="create GitHub prerelease"
+          fi
           {
             echo "## Beta Publish Dry Run"
             echo ""
             echo "- Version: \`${{ steps.release.outputs.version }}\`"
             echo "- Tag: \`${{ steps.release.outputs.tag_name }}\`"
-            echo "- Would create GitHub prerelease: yes"
+            echo "- Release action: ${release_action}"
             echo "- Downstream npm dist-tag: \`beta\`"
             echo "- Downstream bundle: \`dollhousemcp-${{ steps.release.outputs.version }}.mcpb\`"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -171,6 +214,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ steps.release.outputs.tag_name }}
           TAG_EXISTS: ${{ steps.release.outputs.tag_exists }}
+          RELEASE_EXISTS: ${{ steps.release.outputs.release_exists }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -182,11 +226,15 @@ jobs:
             echo "Reusing ${TAG_NAME}, which already points to ${GITHUB_SHA}"
           fi
 
-          gh release create "${TAG_NAME}" \
-            --target "${GITHUB_SHA}" \
-            --title "DollhouseMCP ${TAG_NAME}" \
-            --notes-file beta-release-notes.md \
-            --prerelease
+          if [[ "${RELEASE_EXISTS}" != "true" ]]; then
+            gh release create "${TAG_NAME}" \
+              --target "${GITHUB_SHA}" \
+              --title "DollhouseMCP ${TAG_NAME}" \
+              --notes-file beta-release-notes.md \
+              --prerelease
+          else
+            echo "Reusing published prerelease ${TAG_NAME}, which targets ${GITHUB_SHA}"
+          fi
 
       # Releases created with GITHUB_TOKEN do not emit workflow runs. Dispatch
       # each publisher explicitly at the immutable release tag, capture the new
@@ -197,6 +245,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          NPM_EXISTS: ${{ steps.release.outputs.npm_exists }}
         run: |
           dispatch_and_capture() {
             local workflow="$1"
@@ -231,11 +280,18 @@ jobs:
               | head -n 1
           }
 
-          npm_run_id=$(dispatch_and_capture publish-npm.yml --field dry_run=false)
+          publisher_run_ids=()
+          if [[ "${NPM_EXISTS}" != "true" ]]; then
+            npm_run_id=$(dispatch_and_capture publish-npm.yml --field dry_run=false)
+            publisher_run_ids+=("${npm_run_id}")
+          else
+            echo "Skipping npm publisher: ${TAG_NAME} is already published with the beta dist-tag"
+          fi
+
           packages_run_id=$(dispatch_and_capture publish-github-packages.yml --field dry_run=false)
           mcpb_run_id=$(dispatch_and_capture publish-mcpb.yml --field tag_name="${TAG_NAME}")
 
-          publisher_run_ids=("${npm_run_id}" "${packages_run_id}" "${mcpb_run_id}")
+          publisher_run_ids+=("${packages_run_id}" "${mcpb_run_id}")
           for run_id in "${publisher_run_ids[@]}"; do
             gh run watch "${run_id}" --exit-status
           done

--- a/.github/workflows/publish-beta-release.yml
+++ b/.github/workflows/publish-beta-release.yml
@@ -110,7 +110,7 @@ jobs:
             fi
           fi
 
-          npm_exists=false
+          npm_publish_complete=false
           if npm view "@dollhousemcp/mcp-server@${package_version}" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
             if [[ "${release_exists}" != "true" ]]; then
               echo "::error::npm version ${package_version} exists without a matching reusable GitHub prerelease"
@@ -124,7 +124,7 @@ jobs:
             if [[ "${npm_beta_version}" != "${package_version}" ]]; then
               echo "::warning::npm dist-tags.beta points to ${npm_beta_version}; leaving that valid beta channel unchanged while repairing ${package_version} artifacts"
             fi
-            npm_exists=true
+            npm_publish_complete=true
           fi
 
           {
@@ -132,7 +132,7 @@ jobs:
             echo "tag_name=${tag_name}"
             echo "tag_exists=${tag_exists}"
             echo "release_exists=${release_exists}"
-            echo "npm_exists=${npm_exists}"
+            echo "npm_publish_complete=${npm_publish_complete}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Verify default-branch release workflows are prerelease-safe
@@ -245,7 +245,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ steps.release.outputs.tag_name }}
-          NPM_EXISTS: ${{ steps.release.outputs.npm_exists }}
+          NPM_PUBLISH_COMPLETE: ${{ steps.release.outputs.npm_publish_complete }}
         run: |
           dispatch_and_capture() {
             local workflow="$1"
@@ -281,7 +281,7 @@ jobs:
           }
 
           publisher_run_ids=()
-          if [[ "${NPM_EXISTS}" != "true" ]]; then
+          if [[ "${NPM_PUBLISH_COMPLETE}" != "true" ]]; then
             npm_run_id=$(dispatch_and_capture publish-npm.yml --field dry_run=false)
             publisher_run_ids+=("${npm_run_id}")
           else

--- a/tests/unit/github-workflow-validation.test.ts
+++ b/tests/unit/github-workflow-validation.test.ts
@@ -359,15 +359,15 @@ describe('GitHub Workflow Validation', () => {
       expect(betaPublishWorkflow).toContain('[[ "${release_prerelease}" != "true" || "${release_draft}" != "false" ]]');
       expect(betaPublishWorkflow).toContain('[[ "${release_target}" != "${GITHUB_SHA}" ]]');
       expect(betaPublishWorkflow).toContain('echo "release_exists=${release_exists}"');
-      expect(betaPublishWorkflow).toContain('echo "npm_exists=${npm_exists}"');
+      expect(betaPublishWorkflow).toContain('echo "npm_publish_complete=${npm_publish_complete}"');
       expect(betaPublishWorkflow).toContain('} >> "$GITHUB_OUTPUT"');
       expect(betaPublishWorkflow).toContain('TAG_EXISTS: ${{ steps.release.outputs.tag_exists }}');
       expect(betaPublishWorkflow).toContain('RELEASE_EXISTS: ${{ steps.release.outputs.release_exists }}');
       expect(betaPublishWorkflow).toContain('if [[ "${TAG_EXISTS}" != "true" ]]');
       expect(betaPublishWorkflow).toContain('if [[ "${RELEASE_EXISTS}" != "true" ]]');
       expect(betaPublishWorkflow).toContain('gh release create "${TAG_NAME}"');
-      expect(betaPublishWorkflow).toContain('NPM_EXISTS: ${{ steps.release.outputs.npm_exists }}');
-      expect(betaPublishWorkflow).toContain('if [[ "${NPM_EXISTS}" != "true" ]]');
+      expect(betaPublishWorkflow).toContain('NPM_PUBLISH_COMPLETE: ${{ steps.release.outputs.npm_publish_complete }}');
+      expect(betaPublishWorkflow).toContain('if [[ "${NPM_PUBLISH_COMPLETE}" != "true" ]]');
       expect(betaPublishWorkflow).toContain('publisher_run_ids+=("${packages_run_id}" "${mcpb_run_id}")');
     });
   });

--- a/tests/unit/github-workflow-validation.test.ts
+++ b/tests/unit/github-workflow-validation.test.ts
@@ -360,6 +360,8 @@ describe('GitHub Workflow Validation', () => {
       expect(betaPublishWorkflow).toContain('[[ "${release_target}" != "${GITHUB_SHA}" ]]');
       expect(betaPublishWorkflow).toContain('echo "release_exists=${release_exists}"');
       expect(betaPublishWorkflow).toContain('echo "npm_publish_complete=${npm_publish_complete}"');
+      expect(betaPublishWorkflow).toContain('beta_is_newer()');
+      expect(betaPublishWorkflow).not.toContain('import semver from');
       expect(betaPublishWorkflow).toContain('} >> "$GITHUB_OUTPUT"');
       expect(betaPublishWorkflow).toContain('TAG_EXISTS: ${{ steps.release.outputs.tag_exists }}');
       expect(betaPublishWorkflow).toContain('RELEASE_EXISTS: ${{ steps.release.outputs.release_exists }}');

--- a/tests/unit/github-workflow-validation.test.ts
+++ b/tests/unit/github-workflow-validation.test.ts
@@ -344,19 +344,31 @@ describe('GitHub Workflow Validation', () => {
       expect(betaPublishWorkflow).toContain('--field tag_name="${TAG_NAME}"');
       expect(betaPublishWorkflow).toContain('gh run list');
       expect(betaPublishWorkflow).toContain('gh run watch "${run_id}" --exit-status');
-      expect(betaPublishWorkflow).toContain('publisher_run_ids=("${npm_run_id}" "${packages_run_id}" "${mcpb_run_id}")');
+      expect(betaPublishWorkflow).toContain('publisher_run_ids=()');
+      expect(betaPublishWorkflow).toContain('publisher_run_ids+=("${npm_run_id}")');
+      expect(betaPublishWorkflow).toContain('publisher_run_ids+=("${packages_run_id}" "${mcpb_run_id}")');
     });
 
-    it('should recover release creation only when an existing tag points at the same commit', () => {
+    it('should reuse only a matching published prerelease and safely retry publishers', () => {
       const betaPublishWorkflow = fs.readFileSync(path.join(workflowDir, 'publish-beta-release.yml'), 'utf8');
 
       expect(betaPublishWorkflow).toContain('refs/tags/${tag_name}^{}');
       expect(betaPublishWorkflow).toContain('[[ "${remote_tag_target}" != "${GITHUB_SHA}" ]]');
       expect(betaPublishWorkflow).toContain('echo "tag_exists=${tag_exists}"');
+      expect(betaPublishWorkflow).toContain('--json tagName,isPrerelease,isDraft,targetCommitish');
+      expect(betaPublishWorkflow).toContain('[[ "${release_prerelease}" != "true" || "${release_draft}" != "false" ]]');
+      expect(betaPublishWorkflow).toContain('[[ "${release_target}" != "${GITHUB_SHA}" ]]');
+      expect(betaPublishWorkflow).toContain('echo "release_exists=${release_exists}"');
+      expect(betaPublishWorkflow).toContain('echo "npm_exists=${npm_exists}"');
       expect(betaPublishWorkflow).toContain('} >> "$GITHUB_OUTPUT"');
       expect(betaPublishWorkflow).toContain('TAG_EXISTS: ${{ steps.release.outputs.tag_exists }}');
+      expect(betaPublishWorkflow).toContain('RELEASE_EXISTS: ${{ steps.release.outputs.release_exists }}');
       expect(betaPublishWorkflow).toContain('if [[ "${TAG_EXISTS}" != "true" ]]');
+      expect(betaPublishWorkflow).toContain('if [[ "${RELEASE_EXISTS}" != "true" ]]');
       expect(betaPublishWorkflow).toContain('gh release create "${TAG_NAME}"');
+      expect(betaPublishWorkflow).toContain('NPM_EXISTS: ${{ steps.release.outputs.npm_exists }}');
+      expect(betaPublishWorkflow).toContain('if [[ "${NPM_EXISTS}" != "true" ]]');
+      expect(betaPublishWorkflow).toContain('publisher_run_ids+=("${packages_run_id}" "${mcpb_run_id}")');
     });
   });
 });

--- a/tests/unit/scripts/publish-beta-release-state.test.ts
+++ b/tests/unit/scripts/publish-beta-release-state.test.ts
@@ -55,7 +55,7 @@ describe('Publish Beta Release state validation', () => {
     expect(result.outputs).toMatchObject({
       tag_exists: 'false',
       release_exists: 'false',
-      npm_exists: 'false',
+      npm_publish_complete: 'false',
     });
   });
 
@@ -69,8 +69,29 @@ describe('Publish Beta Release state validation', () => {
     expect(result.outputs).toMatchObject({
       tag_exists: 'true',
       release_exists: 'true',
-      npm_exists: 'false',
+      npm_publish_complete: 'false',
     });
+  });
+
+  it('accepts a matching tag when release creation has not completed yet', () => {
+    const result = runScenario({ tagTarget: expectedSha });
+
+    expect(result.status).toBe(0);
+    expect(result.outputs).toMatchObject({
+      tag_exists: 'true',
+      release_exists: 'false',
+      npm_publish_complete: 'false',
+    });
+  });
+
+  it('rejects release metadata that names a different tag', () => {
+    const result = runScenario({
+      tagTarget: expectedSha,
+      release: matchingRelease({ tagName: 'v2.1.0-beta.wrong' }),
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('Release lookup returned tag v2.1.0-beta.wrong');
   });
 
   it('rejects an existing release that targets another commit', () => {
@@ -108,7 +129,7 @@ describe('Publish Beta Release state validation', () => {
     });
 
     expect(result.status).toBe(0);
-    expect(result.outputs.npm_exists).toBe('true');
+    expect(result.outputs.npm_publish_complete).toBe('true');
   });
 
   it('preserves a different valid beta dist-tag while repairing older artifacts', () => {
@@ -120,7 +141,7 @@ describe('Publish Beta Release state validation', () => {
     });
 
     expect(result.status).toBe(0);
-    expect(result.outputs.npm_exists).toBe('true');
+    expect(result.outputs.npm_publish_complete).toBe('true');
     expect(result.stdout).toContain('leaving that valid beta channel unchanged');
   });
 
@@ -134,6 +155,16 @@ describe('Publish Beta Release state validation', () => {
 
     expect(result.status).toBe(1);
     expect(result.stdout).toContain('dist-tags.beta is invalid or unset (2.0.40)');
+  });
+
+  it('rejects an npm publication that has no matching reusable release', () => {
+    const result = runScenario({
+      npmExists: true,
+      npmBetaVersion: packageVersion,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('exists without a matching reusable GitHub prerelease');
   });
 });
 

--- a/tests/unit/scripts/publish-beta-release-state.test.ts
+++ b/tests/unit/scripts/publish-beta-release-state.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import yaml from 'js-yaml';
+
+interface WorkflowStep {
+  readonly name?: string;
+  readonly run?: string;
+}
+
+interface BetaWorkflow {
+  readonly jobs: {
+    readonly 'publish-beta': {
+      readonly steps: readonly WorkflowStep[];
+    };
+  };
+}
+
+interface Scenario {
+  readonly tagTarget?: string;
+  readonly release?: {
+    readonly tagName?: string;
+    readonly isPrerelease?: boolean;
+    readonly isDraft?: boolean;
+    readonly targetCommitish?: string;
+  };
+  readonly npmExists?: boolean;
+  readonly npmBetaVersion?: string;
+}
+
+const projectRoot = process.cwd();
+const workflowPath = path.join(projectRoot, '.github/workflows/publish-beta-release.yml');
+const workflow = yaml.load(fs.readFileSync(workflowPath, 'utf8')) as BetaWorkflow;
+const validationScript = workflow.jobs['publish-beta'].steps
+  .find(step => step.name === 'Validate beta release inputs')?.run;
+const packageVersion = (JSON.parse(
+  fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8'),
+) as { readonly version: string }).version;
+const expectedSha = '0123456789abcdef0123456789abcdef01234567';
+const tempDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('Publish Beta Release state validation', () => {
+  it('accepts a fresh beta version with no tag, release, or npm publication', () => {
+    const result = runScenario({});
+
+    expect(result.status).toBe(0);
+    expect(result.outputs).toMatchObject({
+      tag_exists: 'false',
+      release_exists: 'false',
+      npm_exists: 'false',
+    });
+  });
+
+  it('accepts a matching existing prerelease so missing publishers can retry', () => {
+    const result = runScenario({
+      tagTarget: expectedSha,
+      release: matchingRelease(),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.outputs).toMatchObject({
+      tag_exists: 'true',
+      release_exists: 'true',
+      npm_exists: 'false',
+    });
+  });
+
+  it('rejects an existing release that targets another commit', () => {
+    const result = runScenario({
+      tagTarget: expectedSha,
+      release: matchingRelease({ targetCommitish: 'f'.repeat(40) }),
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(`not ${expectedSha}`);
+  });
+
+  it('rejects a draft or non-prerelease release', () => {
+    const draft = runScenario({
+      tagTarget: expectedSha,
+      release: matchingRelease({ isDraft: true }),
+    });
+    const stable = runScenario({
+      tagTarget: expectedSha,
+      release: matchingRelease({ isPrerelease: false }),
+    });
+
+    expect(draft.status).toBe(1);
+    expect(stable.status).toBe(1);
+    expect(draft.stdout).toContain('must be a published prerelease');
+    expect(stable.stdout).toContain('must be a published prerelease');
+  });
+
+  it('marks npm complete only when beta points to the matching published version', () => {
+    const result = runScenario({
+      tagTarget: expectedSha,
+      release: matchingRelease(),
+      npmExists: true,
+      npmBetaVersion: packageVersion,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.outputs.npm_exists).toBe('true');
+  });
+
+  it('preserves a different valid beta dist-tag while repairing older artifacts', () => {
+    const result = runScenario({
+      tagTarget: expectedSha,
+      release: matchingRelease(),
+      npmExists: true,
+      npmBetaVersion: '2.1.0-beta.2',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.outputs.npm_exists).toBe('true');
+    expect(result.stdout).toContain('leaving that valid beta channel unchanged');
+  });
+
+  it('rejects an existing npm version when the beta dist-tag is invalid', () => {
+    const result = runScenario({
+      tagTarget: expectedSha,
+      release: matchingRelease(),
+      npmExists: true,
+      npmBetaVersion: '2.0.40',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('dist-tags.beta is invalid or unset (2.0.40)');
+  });
+});
+
+function matchingRelease(overrides: Scenario['release'] = {}): NonNullable<Scenario['release']> {
+  return {
+    tagName: `v${packageVersion}`,
+    isPrerelease: true,
+    isDraft: false,
+    targetCommitish: expectedSha,
+    ...overrides,
+  };
+}
+
+function runScenario(scenario: Scenario): {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly outputs: Readonly<Record<string, string>>;
+} {
+  expect(validationScript).toBeDefined();
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'beta-release-state-'));
+  tempDirectories.push(directory);
+  const binDirectory = path.join(directory, 'bin');
+  const outputPath = path.join(directory, 'github-output');
+  fs.mkdirSync(binDirectory);
+  writeExecutable(path.join(binDirectory, 'git'), fakeGitScript);
+  writeExecutable(path.join(binDirectory, 'gh'), fakeGhScript);
+  writeExecutable(path.join(binDirectory, 'npm'), fakeNpmScript);
+
+  const release = scenario.release;
+  const result = spawnSync('/bin/bash', ['-c', validationScript ?? 'exit 99'], {
+    cwd: projectRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${binDirectory}:${process.env.PATH ?? ''}`,
+      GITHUB_REF_NAME: 'beta',
+      GITHUB_SHA: expectedSha,
+      GITHUB_OUTPUT: outputPath,
+      INPUT_VERSION: packageVersion,
+      FAKE_TAG_OBJECT: scenario.tagTarget ? 'a'.repeat(40) : '',
+      FAKE_TAG_TARGET: scenario.tagTarget ?? '',
+      FAKE_RELEASE_EXISTS: release ? 'true' : 'false',
+      FAKE_RELEASE_JSON: release ? JSON.stringify(release) : '',
+      FAKE_NPM_EXISTS: scenario.npmExists ? 'true' : 'false',
+      FAKE_NPM_BETA_VERSION: scenario.npmBetaVersion ?? '',
+    },
+  });
+
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    outputs: readOutputs(outputPath),
+  };
+}
+
+function writeExecutable(filePath: string, contents: string): void {
+  fs.writeFileSync(filePath, contents, { mode: 0o700 });
+}
+
+function readOutputs(filePath: string): Readonly<Record<string, string>> {
+  if (!fs.existsSync(filePath)) return {};
+  return Object.fromEntries(
+    fs.readFileSync(filePath, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map(line => {
+        const separator = line.indexOf('=');
+        return [line.slice(0, separator), line.slice(separator + 1)];
+      }),
+  );
+}
+
+const fakeGitScript = `#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  *'refs/tags/'*'^{}'*)
+    [[ -z "\${FAKE_TAG_TARGET:-}" ]] || printf '%s refs/tags/tag^{}\n' "\${FAKE_TAG_TARGET}"
+    ;;
+  *'refs/tags/'*)
+    [[ -z "\${FAKE_TAG_OBJECT:-}" ]] || printf '%s refs/tags/tag\n' "\${FAKE_TAG_OBJECT}"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+`;
+
+const fakeGhScript = `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == 'release' && "$2" == 'view' && "\${FAKE_RELEASE_EXISTS:-false}" == 'true' ]]; then
+  printf '%s\n' "\${FAKE_RELEASE_JSON}"
+  exit 0
+fi
+exit 1
+`;
+
+const fakeNpmScript = `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *'dist-tags.beta'* ]]; then
+  [[ -z "\${FAKE_NPM_BETA_VERSION:-}" ]] || printf '%s\n' "\${FAKE_NPM_BETA_VERSION}"
+  exit 0
+fi
+if [[ "\${FAKE_NPM_EXISTS:-false}" == 'true' ]]; then
+  printf '%s\n' "\${INPUT_VERSION}"
+  exit 0
+fi
+exit 1
+`;

--- a/tests/unit/scripts/publish-beta-release-state.test.ts
+++ b/tests/unit/scripts/publish-beta-release-state.test.ts
@@ -148,6 +148,20 @@ describe('Publish Beta Release state validation', () => {
     expect(result.stdout).toContain('leaving that channel unchanged');
   });
 
+  it('compares numeric prerelease identifiers without fixed-width overflow', () => {
+    const result = runScenario({
+      tagTarget: expectedSha,
+      release: matchingRelease(),
+      npmExists: true,
+      npmBetaVersion: '2.1.0-beta.9223372036854775808',
+      npmLatestVersion: '2.0.40',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.outputs.npm_publish_complete).toBe('true');
+    expect(result.stdout).toContain('leaving that channel unchanged');
+  });
+
   it('rejects an older beta dist-tag rather than treating npm as complete', () => {
     const result = runScenario({
       tagTarget: expectedSha,

--- a/tests/unit/scripts/publish-beta-release-state.test.ts
+++ b/tests/unit/scripts/publish-beta-release-state.test.ts
@@ -28,6 +28,7 @@ interface Scenario {
   };
   readonly npmExists?: boolean;
   readonly npmBetaVersion?: string;
+  readonly npmLatestVersion?: string;
 }
 
 const projectRoot = process.cwd();
@@ -126,6 +127,7 @@ describe('Publish Beta Release state validation', () => {
       release: matchingRelease(),
       npmExists: true,
       npmBetaVersion: packageVersion,
+      npmLatestVersion: '2.0.40',
     });
 
     expect(result.status).toBe(0);
@@ -138,11 +140,38 @@ describe('Publish Beta Release state validation', () => {
       release: matchingRelease(),
       npmExists: true,
       npmBetaVersion: '2.1.0-beta.2',
+      npmLatestVersion: '2.0.40',
     });
 
     expect(result.status).toBe(0);
     expect(result.outputs.npm_publish_complete).toBe('true');
-    expect(result.stdout).toContain('leaving that valid beta channel unchanged');
+    expect(result.stdout).toContain('leaving that channel unchanged');
+  });
+
+  it('rejects an older beta dist-tag rather than treating npm as complete', () => {
+    const result = runScenario({
+      tagTarget: expectedSha,
+      release: matchingRelease(),
+      npmExists: true,
+      npmBetaVersion: '2.0.99-beta.9',
+      npmLatestVersion: '2.0.40',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('points to older beta 2.0.99-beta.9');
+  });
+
+  it('rejects skipping npm when latest points to a prerelease', () => {
+    const result = runScenario({
+      tagTarget: expectedSha,
+      release: matchingRelease(),
+      npmExists: true,
+      npmBetaVersion: packageVersion,
+      npmLatestVersion: packageVersion,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('dist-tags.latest must point to a stable SemVer');
   });
 
   it('rejects an existing npm version when the beta dist-tag is invalid', () => {
@@ -151,6 +180,7 @@ describe('Publish Beta Release state validation', () => {
       release: matchingRelease(),
       npmExists: true,
       npmBetaVersion: '2.0.40',
+      npmLatestVersion: '2.0.40',
     });
 
     expect(result.status).toBe(1);
@@ -161,6 +191,7 @@ describe('Publish Beta Release state validation', () => {
     const result = runScenario({
       npmExists: true,
       npmBetaVersion: packageVersion,
+      npmLatestVersion: '2.0.40',
     });
 
     expect(result.status).toBe(1);
@@ -211,6 +242,7 @@ function runScenario(scenario: Scenario): {
       FAKE_RELEASE_JSON: release ? JSON.stringify(release) : '',
       FAKE_NPM_EXISTS: scenario.npmExists ? 'true' : 'false',
       FAKE_NPM_BETA_VERSION: scenario.npmBetaVersion ?? '',
+      FAKE_NPM_LATEST_VERSION: scenario.npmLatestVersion ?? '',
     },
   });
 
@@ -268,6 +300,10 @@ const fakeNpmScript = `#!/usr/bin/env bash
 set -euo pipefail
 if [[ "$*" == *'dist-tags.beta'* ]]; then
   [[ -z "\${FAKE_NPM_BETA_VERSION:-}" ]] || printf '%s\n' "\${FAKE_NPM_BETA_VERSION}"
+  exit 0
+fi
+if [[ "$*" == *'dist-tags.latest'* ]]; then
+  [[ -z "\${FAKE_NPM_LATEST_VERSION:-}" ]] || printf '%s\n' "\${FAKE_NPM_LATEST_VERSION}"
   exit 0
 fi
 if [[ "\${FAKE_NPM_EXISTS:-false}" == 'true' ]]; then


### PR DESCRIPTION
## Summary

- allow a beta publish rerun to reuse an existing release only when its tag, prerelease state, draft state, and target commit all match
- reuse an existing matching tag and GitHub prerelease instead of failing after partial publication
- skip npm publication when the immutable version already exists and the beta channel is valid
- preserve a different valid beta dist-tag rather than moving it backward while repairing older release artifacts
- continue rerunning the idempotent GitHub Packages and MCPB publishers
- make dry-run output describe whether the release would be created or reused

## Fail-closed behavior

The orchestrator rejects:

- tags or releases targeting a different commit
- releases that are drafts or are not prereleases
- releases missing their expected Git tag
- npm versions without a matching reusable GitHub prerelease
- missing, stable, or otherwise invalid npm beta dist-tags

## Validation

- 155 workflow and executable scenario tests passed
- scenario coverage includes fresh publish, partial-publish retry, wrong commit, draft/stable release, completed npm publication, newer beta preservation, and invalid beta channel
- TypeScript and focused ESLint checks passed
- every Bash step in the beta workflow passed ShellCheck after excluding GitHub-expression and cross-step environment false positives
- YAML and diff validation passed

Addresses the partial-publication retry work in #2282. The other existing #2282 hardening items remain open.
