### PR TITLE
fix: accept symbolic beta release targets

### DIFF
--- a/.github/workflows/publish-beta-release.yml
+++ b/.github/workflows/publish-beta-release.yml
@@ -104,9 +104,11 @@ jobs:
               echo "::error::Existing release ${tag_name} must be a published prerelease"
               exit 1
             fi
+            # The dereferenced remote tag above is the authoritative release identity.
+            # GitHub ignores targetCommitish when the tag already exists, and this
+            # metadata may retain a symbolic branch name that advances after release.
             if [[ "${release_target}" != "${GITHUB_SHA}" ]]; then
-              echo "::error::Release ${tag_name} targets ${release_target}, not ${GITHUB_SHA}"
-              exit 1
+              echo "::warning::Release ${tag_name} records a different targetCommitish; verified tag ${tag_name} resolves to ${GITHUB_SHA}"
             fi
           fi
 

--- a/tests/unit/github-workflow-validation.test.ts
+++ b/tests/unit/github-workflow-validation.test.ts
@@ -358,6 +358,8 @@ describe('GitHub Workflow Validation', () => {
       expect(betaPublishWorkflow).toContain('--json tagName,isPrerelease,isDraft,targetCommitish');
       expect(betaPublishWorkflow).toContain('[[ "${release_prerelease}" != "true" || "${release_draft}" != "false" ]]');
       expect(betaPublishWorkflow).toContain('[[ "${release_target}" != "${GITHUB_SHA}" ]]');
+      expect(betaPublishWorkflow).toContain('::warning::Release ${tag_name} records a different targetCommitish');
+      expect(betaPublishWorkflow).not.toContain('::error::Release ${tag_name} targets');
       expect(betaPublishWorkflow).toContain('echo "release_exists=${release_exists}"');
       expect(betaPublishWorkflow).toContain('echo "npm_publish_complete=${npm_publish_complete}"');
       expect(betaPublishWorkflow).toContain('beta_is_newer()');

--- a/tests/unit/scripts/publish-beta-release-state.test.ts
+++ b/tests/unit/scripts/publish-beta-release-state.test.ts
@@ -20,6 +20,7 @@ interface BetaWorkflow {
 
 interface Scenario {
   readonly tagTarget?: string;
+  readonly branchTarget?: string;
   readonly release?: {
     readonly tagName?: string;
     readonly isPrerelease?: boolean;
@@ -85,6 +86,18 @@ describe('Publish Beta Release state validation', () => {
     });
   });
 
+  it('rejects a tag that resolves to another commit without mutating release state', () => {
+    const result = runScenario({
+      tagTarget: 'f'.repeat(40),
+      release: matchingRelease({ targetCommitish: 'beta' }),
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(`Tag v${packageVersion} already exists at ${'f'.repeat(40)}`);
+    expect(result.commands).toHaveLength(2);
+    expect(result.commands.every(command => command.startsWith('git ls-remote --tags '))).toBe(true);
+  });
+
   it('rejects release metadata that names a different tag', () => {
     const result = runScenario({
       tagTarget: expectedSha,
@@ -95,14 +108,41 @@ describe('Publish Beta Release state validation', () => {
     expect(result.stdout).toContain('Release lookup returned tag v2.1.0-beta.wrong');
   });
 
-  it('rejects an existing release that targets another commit', () => {
+  it('accepts a symbolic release target when the immutable tag matches', () => {
+    const result = runScenario({
+      tagTarget: expectedSha,
+      branchTarget: expectedSha,
+      release: matchingRelease({ targetCommitish: 'beta' }),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('records a different targetCommitish');
+    expect(result.outputs.release_exists).toBe('true');
+  });
+
+  it('accepts a symbolic release target after the branch advances', () => {
+    const result = runScenario({
+      tagTarget: expectedSha,
+      branchTarget: 'f'.repeat(40),
+      release: matchingRelease({ targetCommitish: 'beta' }),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      `verified tag v${packageVersion} resolves to ${expectedSha}`,
+    );
+    expect(result.outputs.release_exists).toBe('true');
+  });
+
+  it('treats non-authoritative release target metadata as audit-only', () => {
     const result = runScenario({
       tagTarget: expectedSha,
       release: matchingRelease({ targetCommitish: 'f'.repeat(40) }),
     });
 
-    expect(result.status).toBe(1);
-    expect(result.stdout).toContain(`not ${expectedSha}`);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('records a different targetCommitish');
+    expect(result.stdout).not.toContain('f'.repeat(40));
   });
 
   it('rejects a draft or non-prerelease release', () => {
@@ -228,12 +268,14 @@ function runScenario(scenario: Scenario): {
   readonly stdout: string;
   readonly stderr: string;
   readonly outputs: Readonly<Record<string, string>>;
+  readonly commands: readonly string[];
 } {
   expect(validationScript).toBeDefined();
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'beta-release-state-'));
   tempDirectories.push(directory);
   const binDirectory = path.join(directory, 'bin');
   const outputPath = path.join(directory, 'github-output');
+  const commandLogPath = path.join(directory, 'commands.log');
   fs.mkdirSync(binDirectory);
   writeExecutable(path.join(binDirectory, 'git'), fakeGitScript);
   writeExecutable(path.join(binDirectory, 'gh'), fakeGhScript);
@@ -252,6 +294,8 @@ function runScenario(scenario: Scenario): {
       INPUT_VERSION: packageVersion,
       FAKE_TAG_OBJECT: scenario.tagTarget ? 'a'.repeat(40) : '',
       FAKE_TAG_TARGET: scenario.tagTarget ?? '',
+      FAKE_BRANCH_TARGET: scenario.branchTarget ?? '',
+      FAKE_COMMAND_LOG: commandLogPath,
       FAKE_RELEASE_EXISTS: release ? 'true' : 'false',
       FAKE_RELEASE_JSON: release ? JSON.stringify(release) : '',
       FAKE_NPM_EXISTS: scenario.npmExists ? 'true' : 'false',
@@ -265,6 +309,7 @@ function runScenario(scenario: Scenario): {
     stdout: result.stdout,
     stderr: result.stderr,
     outputs: readOutputs(outputPath),
+    commands: readLines(commandLogPath),
   };
 }
 
@@ -286,14 +331,23 @@ function readOutputs(filePath: string): Readonly<Record<string, string>> {
   );
 }
 
+function readLines(filePath: string): readonly string[] {
+  if (!fs.existsSync(filePath)) return [];
+  return fs.readFileSync(filePath, 'utf8').trim().split('\n').filter(Boolean);
+}
+
 const fakeGitScript = `#!/usr/bin/env bash
 set -euo pipefail
+printf 'git %s\n' "$*" >> "\${FAKE_COMMAND_LOG}"
 case "$*" in
   *'refs/tags/'*'^{}'*)
     [[ -z "\${FAKE_TAG_TARGET:-}" ]] || printf '%s refs/tags/tag^{}\n' "\${FAKE_TAG_TARGET}"
     ;;
   *'refs/tags/'*)
     [[ -z "\${FAKE_TAG_OBJECT:-}" ]] || printf '%s refs/tags/tag\n' "\${FAKE_TAG_OBJECT}"
+    ;;
+  *'refs/heads/'*)
+    [[ -z "\${FAKE_BRANCH_TARGET:-}" ]] || printf '%s refs/heads/branch\n' "\${FAKE_BRANCH_TARGET}"
     ;;
   *)
     exit 2
@@ -303,6 +357,7 @@ esac
 
 const fakeGhScript = `#!/usr/bin/env bash
 set -euo pipefail
+printf 'gh %s\n' "$*" >> "\${FAKE_COMMAND_LOG}"
 if [[ "$1" == 'release' && "$2" == 'view' && "\${FAKE_RELEASE_EXISTS:-false}" == 'true' ]]; then
   printf '%s\n' "\${FAKE_RELEASE_JSON}"
   exit 0
@@ -312,6 +367,7 @@ exit 1
 
 const fakeNpmScript = `#!/usr/bin/env bash
 set -euo pipefail
+printf 'npm %s\n' "$*" >> "\${FAKE_COMMAND_LOG}"
 if [[ "$*" == *'dist-tags.beta'* ]]; then
   [[ -z "\${FAKE_NPM_BETA_VERSION:-}" ]] || printf '%s\n' "\${FAKE_NPM_BETA_VERSION}"
   exit 0


### PR DESCRIPTION
## Summary

- make the dereferenced remote release tag the authoritative commit identity during beta retries
- treat differing `targetCommitish` metadata as audit-only because GitHub ignores it when the tag already exists
- avoid echoing untrusted release metadata verbatim into workflow command output
- cover literal SHA, symbolic branch, advanced branch, mismatched tag, and validation non-mutation cases

## Rationale

GitHub documents `target_commitish` as unused when the supplied Git tag already exists. A release may therefore retain `beta` or another symbolic branch after that branch advances. Re-resolving or textually comparing that metadata causes a valid partial release retry to fail even though the immutable tag still identifies the reviewed commit.

The workflow continues to fail closed when the remote tag resolves anywhere other than `GITHUB_SHA`, and it still rejects missing tags, mismatched release tags, drafts, and non-prereleases.

## Validation

- 164 focused Jest tests passed
- ESLint passed for the changed TypeScript tests
- ShellCheck 0.11.0 passed for the embedded validation script
- `git diff --check` passed

Closes #2482
