### PR TITLE
fix: isolate DangerZone execution notifications

### DIFF
--- a/src/elements/agents/types.ts
+++ b/src/elements/agents/types.ts
@@ -696,6 +696,8 @@ export interface AgentNotification {
   message: string;
   /** Structured metadata for programmatic consumption */
   metadata?: {
+    /** Stable source event identifier */
+    eventId?: string;
     /** The MCP-AQL operation that was blocked */
     operation?: string;
     /** Element type involved in the block */
@@ -706,8 +708,10 @@ export interface AgentNotification {
     level?: string;
     /** Verification ID (for danger_zone blocks) */
     verificationId?: string;
-    /** Agent name (used in danger_zone broadcasts to identify which agent is blocked) */
+    /** Agent name associated with a danger_zone notification */
     agentName?: string;
+    /** Goal that produced the notification */
+    goalId?: string;
   };
   /** ISO 8601 timestamp when the event occurred */
   timestamp: string;

--- a/src/handlers/mcp-aql/AgentExecutionHandler.ts
+++ b/src/handlers/mcp-aql/AgentExecutionHandler.ts
@@ -378,7 +378,7 @@ export class AgentExecutionHandler {
     });
 
     const finalResult = this.evaluateResilience(elementName, updateResult, params.outcome as string) ?? updateResult;
-    this.attachNotifications(elementName, finalResult);
+    this.attachNotifications(elementName, ownedGoalId, finalResult);
     return { _type: 'StepResult', ...finalResult };
   }
 
@@ -402,12 +402,16 @@ export class AgentExecutionHandler {
     return value;
   }
 
-  private attachNotifications(agentName: string, result: Record<string, unknown>): void {
+  private attachNotifications(
+    agentName: string,
+    goalId: string,
+    result: Record<string, unknown>,
+  ): void {
     const autonomy = result.autonomy as Record<string, unknown> | undefined;
     if (!autonomy) {
       return;
     }
-    const notifications = this.collectNotifications(agentName, autonomy);
+    const notifications = this.collectNotifications(agentName, goalId, autonomy);
     if (notifications.length > 0) {
       autonomy.notifications = notifications;
     }
@@ -824,11 +828,15 @@ export class AgentExecutionHandler {
     };
   }
 
-  private collectNotifications(agentName: string, autonomy: Record<string, unknown>): AgentNotification[] {
+  private collectNotifications(
+    agentName: string,
+    goalId: string,
+    autonomy: Record<string, unknown>,
+  ): AgentNotification[] {
     return [
       ...this.collectGatekeeperNotifications(agentName),
       ...this.collectAutonomyNotifications(autonomy),
-      ...this.collectDangerZoneNotifications(),
+      ...this.collectDangerZoneNotifications(agentName, goalId),
     ];
   }
 
@@ -871,24 +879,37 @@ export class AgentExecutionHandler {
     }] : [];
   }
 
-  private collectDangerZoneNotifications(): AgentNotification[] {
+  private collectDangerZoneNotifications(agentName: string, goalId: string): AgentNotification[] {
     const enforcer = this.handlers.dangerZoneEnforcer;
-    if (!enforcer?.hasBlockedAgents()) {
+    if (!enforcer) {
       return [];
     }
-    return enforcer.getBlockedAgents().flatMap(blockedAgent => {
-      const blockCheck = enforcer.check(blockedAgent);
-      return blockCheck.blocked ? [{
-        type: 'danger_zone',
-        message: `Agent '${blockedAgent}' is blocked due to danger zone trigger: ${blockCheck.reason}`,
-        metadata: {
-          agentName: blockedAgent,
-          reason: blockCheck.reason,
-          verificationId: blockCheck.verificationId,
-        },
-        timestamp: new Date().toISOString(),
-      }] : [];
-    });
+
+    const blockCheck = enforcer.check(agentName);
+    const sessionId = this.contextTracker?.getSessionContext?.()?.sessionId;
+    // Execution responses are not a global operator feed: only return the block
+    // created for this agent's active goal in this exact session.
+    if (
+      !blockCheck.blocked ||
+      blockCheck.sessionId !== sessionId ||
+      blockCheck.goalId !== goalId ||
+      !blockCheck.blockedAt
+    ) {
+      return [];
+    }
+
+    return [{
+      type: 'danger_zone',
+      message: `Agent '${agentName}' is blocked due to danger zone trigger: ${blockCheck.reason}`,
+      metadata: {
+        agentName,
+        eventId: blockCheck.eventId,
+        goalId,
+        reason: blockCheck.reason,
+        verificationId: blockCheck.verificationId,
+      },
+      timestamp: blockCheck.blockedAt,
+    }];
   }
 
   private evaluateResilience(

--- a/src/security/DangerZoneEnforcer.ts
+++ b/src/security/DangerZoneEnforcer.ts
@@ -19,6 +19,7 @@
 import os from 'os';
 import path from 'path';
 import fs from 'fs/promises';
+import { randomUUID } from 'node:crypto';
 import { logger } from '../utils/logger.js';
 import { SecurityMonitor } from './securityMonitor.js';
 import { EvictingQueue } from '../utils/EvictingQueue.js';
@@ -31,6 +32,8 @@ const METRICS_WINDOW_SIZE = 1000;
  * Blocked execution context
  */
 interface BlockedContext {
+  /** Stable identity for this block event */
+  eventId?: string;
   /** Agent name that triggered danger zone */
   agentName: string;
   /** Reason for blocking */
@@ -43,6 +46,8 @@ interface BlockedContext {
   verificationId?: string;
   /** Issue #1947: Session that created this block. Undefined = globally verifiable (backward compat). */
   sessionId?: string;
+  /** Goal whose autonomy evaluation created this block. */
+  goalId?: string;
 }
 
 /**
@@ -51,11 +56,13 @@ interface BlockedContext {
 interface PersistedBlocks {
   version: number;
   blocks: Record<string, {
+    eventId?: string;
     reason: string;
     triggeredPatterns: string[];
     blockedAt: string;
     verificationId?: string;
     sessionId?: string;
+    goalId?: string;
   }>;
 }
 
@@ -83,6 +90,8 @@ export interface DangerZoneAuditContext {
 export interface BlockCheckResult {
   /** Whether the context is blocked */
   blocked: boolean;
+  /** Stable identity for this block event */
+  eventId?: string;
   /** Reason for blocking (if blocked) */
   reason?: string;
   /** How to resolve the block */
@@ -91,6 +100,10 @@ export interface BlockCheckResult {
   verificationId?: string;
   /** Issue #1947: Session that created this block (undefined = globally verifiable) */
   sessionId?: string;
+  /** Goal whose autonomy evaluation created this block */
+  goalId?: string;
+  /** Original ISO-8601 time when the block was created */
+  blockedAt?: string;
 }
 
 /**
@@ -186,12 +199,14 @@ export class DangerZoneEnforcer {
       if (data.version === 1 && data.blocks && typeof data.blocks === 'object') {
         for (const [name, block] of Object.entries(data.blocks)) {
           this.blockedContexts.set(name, {
+            eventId: block.eventId ?? block.verificationId,
             agentName: name,
             reason: block.reason,
             triggeredPatterns: block.triggeredPatterns ?? [],
             blockedAt: new Date(block.blockedAt),
             verificationId: block.verificationId,
             sessionId: block.sessionId,
+            goalId: block.goalId,
           });
         }
 
@@ -255,12 +270,14 @@ export class DangerZoneEnforcer {
 
     const trimmed = agentName.trim();
     const context: BlockedContext = {
+      eventId: randomUUID(),
       agentName: trimmed,
       reason,
       triggeredPatterns,
       blockedAt: new Date(),
       verificationId,
       sessionId,
+      goalId: auditContext?.goalId,
     };
 
     this.blockedContexts.set(trimmed, context);
@@ -273,6 +290,7 @@ export class DangerZoneEnforcer {
         reason,
         triggeredPatterns,
         verificationId,
+        eventId: context.eventId,
       }
     );
 
@@ -436,6 +454,7 @@ export class DangerZoneEnforcer {
 
     return {
       blocked: true,
+      eventId: context.eventId,
       reason: context.reason,
       // Issue #142 / #405: Actionable verify_challenge instructions
       resolution: context.verificationId
@@ -443,6 +462,8 @@ export class DangerZoneEnforcer {
         : 'Contact administrator to enable danger zone operations',
       verificationId: context.verificationId,
       sessionId: context.sessionId,
+      goalId: context.goalId,
+      blockedAt: context.blockedAt.toISOString(),
     };
   }
 
@@ -610,11 +631,13 @@ export class DangerZoneEnforcer {
 
     for (const [name, ctx] of this.blockedContexts) {
       data.blocks[name] = {
+        eventId: ctx.eventId,
         reason: ctx.reason,
         triggeredPatterns: ctx.triggeredPatterns,
         blockedAt: ctx.blockedAt.toISOString(),
         verificationId: ctx.verificationId,
         sessionId: ctx.sessionId,
+        goalId: ctx.goalId,
       };
     }
 

--- a/src/security/DangerZoneEnforcer.ts
+++ b/src/security/DangerZoneEnforcer.ts
@@ -55,15 +55,17 @@ interface BlockedContext {
  */
 interface PersistedBlocks {
   version: number;
-  blocks: Record<string, {
-    eventId?: string;
-    reason: string;
-    triggeredPatterns: string[];
-    blockedAt: string;
-    verificationId?: string;
-    sessionId?: string;
-    goalId?: string;
-  }>;
+  blocks: Record<string, PersistedBlock>;
+}
+
+interface PersistedBlock {
+  eventId?: string;
+  reason: string;
+  triggeredPatterns: string[];
+  blockedAt: string;
+  verificationId?: string;
+  sessionId?: string;
+  goalId?: string;
 }
 
 /**
@@ -198,23 +200,7 @@ export class DangerZoneEnforcer {
 
       if (data.version === 1 && data.blocks && typeof data.blocks === 'object') {
         for (const [name, block] of Object.entries(data.blocks)) {
-          const parsedBlockedAt = new Date(block.blockedAt);
-          const blockedAt = Number.isNaN(parsedBlockedAt.getTime())
-            ? new Date(0)
-            : parsedBlockedAt;
-          if (blockedAt.getTime() === 0 && block.blockedAt !== blockedAt.toISOString()) {
-            logger.warn(`Invalid persisted blockedAt for agent '${name}'; preserving block with epoch timestamp`);
-          }
-          this.blockedContexts.set(name, {
-            eventId: block.eventId ?? block.verificationId,
-            agentName: name,
-            reason: block.reason,
-            triggeredPatterns: block.triggeredPatterns ?? [],
-            blockedAt,
-            verificationId: block.verificationId,
-            sessionId: block.sessionId,
-            goalId: block.goalId,
-          });
+          this.blockedContexts.set(name, this.restoreBlockedContext(name, block));
         }
 
         if (this.blockedContexts.size > 0) {
@@ -247,6 +233,30 @@ export class DangerZoneEnforcer {
         });
       }
     }
+  }
+
+  private restoreBlockedContext(agentName: string, block: PersistedBlock): BlockedContext {
+    return {
+      // Legacy records predate eventId; their challenge ID is the only stable identity available.
+      eventId: block.eventId ?? block.verificationId,
+      agentName,
+      reason: block.reason,
+      triggeredPatterns: block.triggeredPatterns ?? [],
+      blockedAt: this.restoreBlockedAt(agentName, block.blockedAt),
+      verificationId: block.verificationId,
+      sessionId: block.sessionId,
+      goalId: block.goalId,
+    };
+  }
+
+  private restoreBlockedAt(agentName: string, value: string): Date {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+
+    logger.warn(`Invalid persisted blockedAt for agent '${agentName}'; preserving block with epoch timestamp`);
+    return new Date(0);
   }
 
   /**

--- a/src/security/DangerZoneEnforcer.ts
+++ b/src/security/DangerZoneEnforcer.ts
@@ -198,12 +198,19 @@ export class DangerZoneEnforcer {
 
       if (data.version === 1 && data.blocks && typeof data.blocks === 'object') {
         for (const [name, block] of Object.entries(data.blocks)) {
+          const parsedBlockedAt = new Date(block.blockedAt);
+          const blockedAt = Number.isNaN(parsedBlockedAt.getTime())
+            ? new Date(0)
+            : parsedBlockedAt;
+          if (blockedAt.getTime() === 0 && block.blockedAt !== blockedAt.toISOString()) {
+            logger.warn(`Invalid persisted blockedAt for agent '${name}'; preserving block with epoch timestamp`);
+          }
           this.blockedContexts.set(name, {
             eventId: block.eventId ?? block.verificationId,
             agentName: name,
             reason: block.reason,
             triggeredPatterns: block.triggeredPatterns ?? [],
-            blockedAt: new Date(block.blockedAt),
+            blockedAt,
             verificationId: block.verificationId,
             sessionId: block.sessionId,
             goalId: block.goalId,

--- a/tests/integration/mcp-aql/agent-notifications.test.ts
+++ b/tests/integration/mcp-aql/agent-notifications.test.ts
@@ -9,7 +9,7 @@
  * @since v2.1.0 - Agent Notification System
  */
 
-import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import { DollhouseMCPServer } from '../../../src/index.js';
 import { DollhouseContainer } from '../../../src/di/Container.js';
 import { MCPAQLHandler } from '../../../src/handlers/mcp-aql/MCPAQLHandler.js';
@@ -88,7 +88,12 @@ describe('Agent Notification System', () => {
     });
   }
 
-  async function recordStep(name: string, step: string, outcome: 'success' | 'failure' | 'partial' = 'success') {
+  async function recordStep(
+    name: string,
+    step: string,
+    outcome: 'success' | 'failure' | 'partial' = 'success',
+    overrides: Record<string, unknown> = {},
+  ) {
     return mcpAqlHandler.handleCreate({
       operation: 'record_execution_step',
       params: {
@@ -97,7 +102,28 @@ describe('Agent Notification System', () => {
         outcome,
         findings: `Results for: ${step}`,
         confidence: 0.85,
+        ...overrides,
       },
+    });
+  }
+
+  function injectBeetlejuiceBlockOnNextStep(options: {
+    readonly goalId?: string;
+    readonly sessionId?: string;
+  } = {}) {
+    const dangerZone = container.resolve<DangerZoneEnforcer>('DangerZoneEnforcer');
+    const recordAgentStep = agentManager.recordAgentStep.bind(agentManager);
+    return jest.spyOn(agentManager, 'recordAgentStep').mockImplementationOnce(async params => {
+      const result = await recordAgentStep(params);
+      dangerZone.block(
+        params.agentName,
+        'Beetlejuice test trigger',
+        ['beetlejuice_beetlejuice_beetlejuice'],
+        'beetlejuice-verification-id',
+        { goalId: options.goalId ?? params.goalId },
+        options.sessionId,
+      );
+      return result;
     });
   }
 
@@ -314,8 +340,8 @@ describe('Agent Notification System', () => {
     });
   });
 
-  describe('DangerZone broadcast', () => {
-    it('should broadcast danger_zone notification to other executing agents', async () => {
+  describe('DangerZone notification isolation', () => {
+    it('should not leak a danger_zone notification to another agent', async () => {
       const dangerZone = container.resolve<DangerZoneEnforcer>('DangerZoneEnforcer');
 
       // Ensure no stale blocks from prior runs
@@ -340,32 +366,116 @@ describe('Agent Notification System', () => {
         // Block the first agent via DangerZoneEnforcer directly
         dangerZone.block(
           'dz-blocked-agent',
-          'Dangerous pattern detected in agent actions',
-          ['rm -rf /'],
+          'Beetlejuice test trigger',
+          ['beetlejuice_beetlejuice_beetlejuice'],
           'verify-test-123'
         );
 
-        // Record step on the OBSERVER agent — should receive danger_zone notification
+        // Record a clean step on the observer. The other agent's block remains
+        // enforced, but it is not part of this execution response.
         const stepResult = await recordStep('dz-observer-agent', 'Checking for alerts');
         expect(stepResult.success).toBe(true);
 
         const notifications = getNotifications(stepResult);
-        expect(notifications).toBeDefined();
-
-        const dangerNotification = notifications!.find(
+        const dangerNotification = notifications?.find(
           (n: Record<string, unknown>) => n.type === 'danger_zone'
         );
-        expect(dangerNotification).toBeDefined();
-        expect(dangerNotification!.message).toContain('dz-blocked-agent');
-        expect(dangerNotification!.message).toContain('danger zone');
-
-        const metadata = dangerNotification!.metadata as Record<string, unknown>;
-        expect(metadata.agentName).toBe('dz-blocked-agent');
-        expect(metadata.reason).toContain('Dangerous pattern');
-        expect(metadata.verificationId).toBe('verify-test-123');
+        expect(dangerNotification).toBeUndefined();
+        expect(dangerZone.check('dz-blocked-agent').blocked).toBe(true);
       } finally {
         // Always clean up the block regardless of test outcome
-        dangerZone.unblock('dz-blocked-agent');
+        dangerZone.unblock('dz-blocked-agent', 'verify-test-123');
+      }
+    });
+
+    it('should report a current-agent danger_zone event with its source timestamp', async () => {
+      const dangerZone = container.resolve<DangerZoneEnforcer>('DangerZoneEnforcer');
+      await createAgent('dz-current-agent', {
+        gatekeeper: { allow: ['*'] },
+        autonomy: { maxAutonomousSteps: 0 },
+      });
+      const execResult = await executeAgent('dz-current-agent');
+      expect(execResult.success).toBe(true);
+
+      const recordSpy = injectBeetlejuiceBlockOnNextStep();
+
+      try {
+        const stepResult = await recordStep(
+          'dz-current-agent',
+          'Recorded a safe test step',
+          'success',
+        );
+        expect(stepResult.success).toBe(true);
+
+        const notifications = getNotifications(stepResult);
+        const dangerNotification = notifications?.find(
+          (notification: Record<string, unknown>) => notification.type === 'danger_zone',
+        );
+        expect(dangerNotification).toBeDefined();
+
+        const blockCheck = dangerZone.check('dz-current-agent');
+        const metadata = dangerNotification!.metadata as Record<string, unknown>;
+        const resultData = stepResult.data as Record<string, unknown>;
+        const decision = resultData.decision as Record<string, unknown>;
+        expect(blockCheck.blocked).toBe(true);
+        expect(dangerNotification!.timestamp).toBe(blockCheck.blockedAt);
+        expect(metadata.agentName).toBe('dz-current-agent');
+        expect(metadata.eventId).toBe(blockCheck.eventId);
+        expect(metadata.goalId).toBe(decision.goalId);
+        expect(metadata.verificationId).toBe(blockCheck.verificationId);
+      } finally {
+        recordSpy.mockRestore();
+        dangerZone.unblock('dz-current-agent', 'beetlejuice-verification-id');
+      }
+    });
+
+    it('should not report a block owned by another goal', async () => {
+      const dangerZone = container.resolve<DangerZoneEnforcer>('DangerZoneEnforcer');
+      await createAgent('dz-goal-scope-agent', {
+        gatekeeper: { allow: ['*'] },
+        autonomy: { maxAutonomousSteps: 0 },
+      });
+      expect((await executeAgent('dz-goal-scope-agent')).success).toBe(true);
+      const recordSpy = injectBeetlejuiceBlockOnNextStep({ goalId: 'another-goal' });
+
+      try {
+        const stepResult = await recordStep('dz-goal-scope-agent', 'Recorded a safe test step');
+        const dangerNotification = getNotifications(stepResult)?.find(
+          notification => notification.type === 'danger_zone',
+        );
+        expect(stepResult.success).toBe(true);
+        expect(dangerNotification).toBeUndefined();
+        expect(dangerZone.check('dz-goal-scope-agent').blocked).toBe(true);
+      } finally {
+        recordSpy.mockRestore();
+        dangerZone.unblock('dz-goal-scope-agent', 'beetlejuice-verification-id');
+      }
+    });
+
+    it('should not report a block owned by another session', async () => {
+      const dangerZone = container.resolve<DangerZoneEnforcer>('DangerZoneEnforcer');
+      await createAgent('dz-session-scope-agent', {
+        gatekeeper: { allow: ['*'] },
+        autonomy: { maxAutonomousSteps: 0 },
+      });
+      expect((await executeAgent('dz-session-scope-agent')).success).toBe(true);
+      const recordSpy = injectBeetlejuiceBlockOnNextStep({ sessionId: 'another-session' });
+
+      try {
+        const stepResult = await recordStep('dz-session-scope-agent', 'Recorded a safe test step');
+        const dangerNotification = getNotifications(stepResult)?.find(
+          notification => notification.type === 'danger_zone',
+        );
+        expect(stepResult.success).toBe(true);
+        expect(dangerNotification).toBeUndefined();
+        expect(dangerZone.check('dz-session-scope-agent').blocked).toBe(true);
+      } finally {
+        recordSpy.mockRestore();
+        dangerZone.unblock(
+          'dz-session-scope-agent',
+          'beetlejuice-verification-id',
+          'another-session',
+        );
       }
     });
   });

--- a/tests/integration/transport/leak-proofs/challengestore-cross-user-leak.test.ts
+++ b/tests/integration/transport/leak-proofs/challengestore-cross-user-leak.test.ts
@@ -213,7 +213,7 @@ describe('challengestore-cross-user-leak: ChallengeStore and DangerZoneEnforcer 
         element_name: agentName,
         stepDescription: 'Completed setup',
         outcome: 'success',
-        nextActionHint: 'rm -rf /tmp/session-a-autonomy-danger',
+        nextActionHint: 'beetlejuice_beetlejuice_beetlejuice',
         riskScore: 100,
       },
     });

--- a/tests/unit/handlers/mcp-aql/GatekeeperSessionIsolation.test.ts
+++ b/tests/unit/handlers/mcp-aql/GatekeeperSessionIsolation.test.ts
@@ -281,7 +281,7 @@ describe('DangerZoneEnforcer session guard', () => {
     const enforcer = new DangerZoneEnforcer(mockFileOps);
 
     // Block from Session A
-    enforcer.block('agent-1', 'danger', ['rm -rf'], 'challenge-123', undefined, 'session-a');
+    enforcer.block('agent-1', 'danger', ['beetlejuice_beetlejuice_beetlejuice'], 'challenge-123', undefined, 'session-a');
 
     // Try to unblock from Session B — should be rejected
     const result = enforcer.unblock('agent-1', 'challenge-123', 'session-b');
@@ -301,7 +301,7 @@ describe('DangerZoneEnforcer session guard', () => {
 
     const enforcer = new DangerZoneEnforcer(mockFileOps);
 
-    enforcer.block('agent-1', 'danger', ['rm -rf'], 'challenge-123', undefined, 'session-a');
+    enforcer.block('agent-1', 'danger', ['beetlejuice_beetlejuice_beetlejuice'], 'challenge-123', undefined, 'session-a');
 
     const result = enforcer.unblock('agent-1', 'challenge-123', 'session-a');
     expect(result).toBe(true);
@@ -319,7 +319,7 @@ describe('DangerZoneEnforcer session guard', () => {
     const enforcer = new DangerZoneEnforcer(mockFileOps);
 
     // Block without sessionId (old format)
-    enforcer.block('agent-1', 'danger', ['rm -rf'], 'challenge-123');
+    enforcer.block('agent-1', 'danger', ['beetlejuice_beetlejuice_beetlejuice'], 'challenge-123');
 
     // Any session can unblock
     const result = enforcer.unblock('agent-1', 'challenge-123', 'session-b');
@@ -334,7 +334,7 @@ describe('DangerZoneEnforcer session guard', () => {
 
     const enforcer = new DangerZoneEnforcer(mockFileOps);
 
-    enforcer.block('agent-1', 'danger', ['rm -rf'], 'challenge-123', undefined, 'session-a');
+    enforcer.block('agent-1', 'danger', ['beetlejuice_beetlejuice_beetlejuice'], 'challenge-123', undefined, 'session-a');
 
     // Caller with no sessionId — should be rejected because block has one
     const result = enforcer.unblock('agent-1', 'challenge-123', undefined);
@@ -348,7 +348,7 @@ describe('DangerZoneEnforcer session guard', () => {
     } as any;
 
     const enforcer = new DangerZoneEnforcer(mockFileOps);
-    enforcer.block('agent-1', 'danger', ['rm -rf'], 'challenge-123', undefined, 'session-a');
+    enforcer.block('agent-1', 'danger', ['beetlejuice_beetlejuice_beetlejuice'], 'challenge-123', undefined, 'session-a');
 
     const check = enforcer.check('agent-1');
     expect(check.sessionId).toBe('session-a');

--- a/tests/unit/security/DangerZoneEnforcer.test.ts
+++ b/tests/unit/security/DangerZoneEnforcer.test.ts
@@ -464,6 +464,30 @@ describe('DangerZoneEnforcer', () => {
       expect(result.blockedAt).toBe('2026-01-01T00:00:00.000Z');
     });
 
+    it('should preserve a block with a safe timestamp when persisted blockedAt is invalid', async () => {
+      const persistedData = JSON.stringify({
+        version: 1,
+        blocks: {
+          'agent-invalid-time': {
+            reason: 'Previous session block',
+            triggeredPatterns: ['beetlejuice_beetlejuice_beetlejuice'],
+            blockedAt: 'not-a-timestamp',
+            verificationId: 'v-invalid-time',
+          },
+        },
+      });
+
+      const fileOps = createMockFileOps({ readFileResult: persistedData });
+      const instance = new DangerZoneEnforcer(fileOps, '/tmp/test-security');
+      await instance.initialize();
+
+      expect(instance.check('agent-invalid-time')).toEqual(expect.objectContaining({
+        blocked: true,
+        blockedAt: '1970-01-01T00:00:00.000Z',
+        verificationId: 'v-invalid-time',
+      }));
+    });
+
     it('should start with empty blocks when file is missing', async () => {
       const fileOps = createMockFileOps({
         readFileError: Object.assign(new Error('ENOENT'), { code: 'ENOENT' }),

--- a/tests/unit/security/DangerZoneEnforcer.test.ts
+++ b/tests/unit/security/DangerZoneEnforcer.test.ts
@@ -80,12 +80,14 @@ describe('DangerZoneEnforcer', () => {
       enforcer.block(
         'test-agent',
         'Danger zone pattern matched',
-        ['rm -rf', 'drop database']
+        ['beetlejuice_beetlejuice_beetlejuice']
       );
 
       const result = enforcer.check('test-agent');
       expect(result.blocked).toBe(true);
       expect(result.reason).toBe('Danger zone pattern matched');
+      expect(result.eventId).toMatch(/^[0-9a-f-]{36}$/);
+      expect(new Date(result.blockedAt ?? '').toISOString()).toBe(result.blockedAt);
     });
 
     it('should include verification ID if provided', () => {
@@ -103,7 +105,12 @@ describe('DangerZoneEnforcer', () => {
     });
 
     it('should log enriched security event on block', () => {
-      enforcer.block('my-agent', 'test reason', ['rm -rf', 'drop db'], 'v-1');
+      enforcer.block(
+        'my-agent',
+        'test reason',
+        ['beetlejuice_beetlejuice_beetlejuice'],
+        'v-1',
+      );
 
       expect(mockLogSecurityEvent).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -114,7 +121,7 @@ describe('DangerZoneEnforcer', () => {
           additionalData: expect.objectContaining({
             agentName: 'my-agent',
             reason: 'test reason',
-            triggeredPatterns: ['rm -rf', 'drop db'],
+            triggeredPatterns: ['beetlejuice_beetlejuice_beetlejuice'],
             verificationId: 'v-1',
             totalActiveBlocks: 1,
           }),
@@ -436,9 +443,10 @@ describe('DangerZoneEnforcer', () => {
         blocks: {
           'agent-x': {
             reason: 'Previous session block',
-            triggeredPatterns: ['rm -rf'],
+            triggeredPatterns: ['beetlejuice_beetlejuice_beetlejuice'],
             blockedAt: '2026-01-01T00:00:00.000Z',
             verificationId: 'v-abc',
+            goalId: 'goal-abc',
           },
         },
       });
@@ -451,6 +459,9 @@ describe('DangerZoneEnforcer', () => {
       expect(result.blocked).toBe(true);
       expect(result.reason).toBe('Previous session block');
       expect(result.verificationId).toBe('v-abc');
+      expect(result.eventId).toBe('v-abc');
+      expect(result.goalId).toBe('goal-abc');
+      expect(result.blockedAt).toBe('2026-01-01T00:00:00.000Z');
     });
 
     it('should start with empty blocks when file is missing', async () => {
@@ -502,7 +513,13 @@ describe('DangerZoneEnforcer', () => {
         });
 
       const instance1 = new DangerZoneEnforcer(writeFileOps, '/tmp/test-security');
-      instance1.block('agent-survive', 'Persist test', ['pattern-a'], 'verify-survive');
+      instance1.block(
+        'agent-survive',
+        'Persist test',
+        ['pattern-a'],
+        'verify-survive',
+        { goalId: 'goal-survive' },
+      );
 
       // Wait for fire-and-forget persist
       await new Promise(resolve => setTimeout(resolve, 50));
@@ -518,6 +535,9 @@ describe('DangerZoneEnforcer', () => {
       expect(result.blocked).toBe(true);
       expect(result.reason).toBe('Persist test');
       expect(result.verificationId).toBe('verify-survive');
+      expect(result.eventId).toBeDefined();
+      expect(result.goalId).toBe('goal-survive');
+      expect(result.blockedAt).toBeDefined();
     });
   });
 
@@ -626,13 +646,13 @@ describe('DangerZoneEnforcer', () => {
       enforcer.block(
         'audit-agent',
         'Danger zone pattern matched',
-        ['rm -rf'],
+        ['beetlejuice_beetlejuice_beetlejuice'],
         'v-audit',
         {
           stepNumber: 3,
           currentStepDescription: 'Execute shell command',
           currentStepOutcome: 'success',
-          nextActionHint: 'rm -rf /tmp/data',
+          nextActionHint: 'beetlejuice_beetlejuice_beetlejuice',
           riskScore: 92,
           goalDescription: 'Clean up temporary files',
           goalId: 'goal-abc-123',
@@ -648,13 +668,13 @@ describe('DangerZoneEnforcer', () => {
           additionalData: expect.objectContaining({
             agentName: 'audit-agent',
             reason: 'Danger zone pattern matched',
-            triggeredPatterns: ['rm -rf'],
+            triggeredPatterns: ['beetlejuice_beetlejuice_beetlejuice'],
             verificationId: 'v-audit',
             totalActiveBlocks: 1,
             stepNumber: 3,
             currentStepDescription: 'Execute shell command',
             currentStepOutcome: 'success',
-            nextActionHint: 'rm -rf /tmp/data',
+            nextActionHint: 'beetlejuice_beetlejuice_beetlejuice',
             riskScore: 92,
             goalDescription: 'Clean up temporary files',
             goalId: 'goal-abc-123',


### PR DESCRIPTION
## Summary

- scope DangerZone notifications returned by `record_execution_step` to the current agent, session, and active goal
- preserve the original block timestamp and a stable event ID across persistence and restart
- retain durable DangerZone enforcement while preventing unrelated or restored blocks from appearing as fresh execution notifications
- replace command-shaped DangerZone fixtures in the affected validation set with the official `beetlejuice_beetlejuice_beetlejuice` test trigger

## Root cause

`AgentExecutionHandler` enumerated every blocked agent whenever it assembled execution notifications. It then wrapped every restored or unrelated block in a new notification carrying the current time. A clean step could therefore appear to receive a fresh DangerZone event from another agent or session.

## Security behavior

This does not relax blocking or verification. Blocks remain durable and agent-wide. It only limits what is attached to a particular execution response: the block must belong to the response's exact agent, current session, and active goal.

Legacy persisted blocks remain enforceable. If an older record has no event ID, its verification ID is used as a stable compatibility identity; records without matching session/goal ownership are not replayed as current execution notifications.

## Validation

- `npx tsc --noEmit`
- `npm run lint -- --quiet`
- `npm run build`
- 93 focused unit tests passed
- 17 focused integration tests passed
- cross-agent, cross-goal, cross-session, persistence/restoration, and positive current-agent coverage
- `git diff --check`

Non-blocking legacy/degraded-context documentation and test enhancements are tracked in #2485.

Closes #2454
