### PR TITLE
test: cover legacy DangerZone notification scope

### DIFF
--- a/src/handlers/mcp-aql/AgentExecutionHandler.ts
+++ b/src/handlers/mcp-aql/AgentExecutionHandler.ts
@@ -888,7 +888,10 @@ export class AgentExecutionHandler {
     const blockCheck = enforcer.check(agentName);
     const sessionId = this.contextTracker?.getSessionContext?.()?.sessionId;
     // Execution responses are not a global operator feed: only return the block
-    // created for this agent's active goal in this exact session.
+    // created for this agent's active goal in this exact session. Undefined
+    // session IDs match for stdio, but a session-owned block is suppressed when
+    // runtime context is unavailable. Legacy blocks without goal ownership are
+    // likewise enforced without being replayed as fresh goal notifications.
     if (
       !blockCheck.blocked ||
       blockCheck.sessionId !== sessionId ||

--- a/tests/unit/handlers/mcp-aql/AgentExecutionHandler.notifications.test.ts
+++ b/tests/unit/handlers/mcp-aql/AgentExecutionHandler.notifications.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import type { AgentManager } from '../../../../src/elements/agents/AgentManager.js';
+import type { BlockCheckResult } from '../../../../src/security/DangerZoneEnforcer.js';
+import { AgentExecutionHandler } from '../../../../src/handlers/mcp-aql/AgentExecutionHandler.js';
+import type {
+  CorrelationIdProvider,
+  HandlerRegistry,
+} from '../../../../src/handlers/mcp-aql/MCPAQLHandler.js';
+import type { ExecutingAgentEntry } from '../../../../src/handlers/mcp-aql/shared.js';
+
+const AGENT_NAME = 'test-agent';
+const GOAL_ID = 'goal-1';
+
+function executionEntry(): ExecutingAgentEntry {
+  return {
+    name: AGENT_NAME,
+    goalIds: [GOAL_ID],
+    metadata: {},
+    startedAt: Date.now(),
+    continuationCount: 0,
+    retryCount: 0,
+    recentBlocks: [],
+  };
+}
+
+function blockedResult(overrides: Partial<BlockCheckResult>): BlockCheckResult {
+  return {
+    blocked: true,
+    eventId: 'event-1',
+    reason: 'Beetlejuice test trigger',
+    verificationId: 'verification-1',
+    blockedAt: '2026-08-12T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function createHarness(
+  block: BlockCheckResult,
+  contextTracker?: CorrelationIdProvider,
+) {
+  const check = jest.fn<(agentName: string) => BlockCheckResult>()
+    .mockReturnValueOnce({ blocked: false })
+    .mockReturnValue(block);
+  const recordAgentStep = jest.fn().mockResolvedValue({
+    success: true,
+    autonomy: { continue: true },
+  });
+  const manager = {
+    canonicalizeExecutionName: jest.fn((name: string) => name),
+    recordAgentStep,
+  } as unknown as AgentManager;
+  const handlers = {
+    agentManager: manager,
+    dangerZoneEnforcer: { check },
+  } as unknown as HandlerRegistry;
+  const executingAgents = new Map<string, ExecutingAgentEntry>([
+    [`default:${AGENT_NAME}`, executionEntry()],
+  ]);
+  const handler = new AgentExecutionHandler(
+    handlers,
+    executingAgents,
+    new Set<string>(),
+    name => `default:${name}`,
+    contextTracker,
+  );
+
+  return { check, handler, recordAgentStep };
+}
+
+async function recordStep(handler: AgentExecutionHandler): Promise<Record<string, unknown>> {
+  return handler.dispatch('updateState', {
+    element_name: AGENT_NAME,
+    stepDescription: 'Recorded a safe test step',
+    outcome: 'success',
+    confidence: 1,
+  }) as Promise<Record<string, unknown>>;
+}
+
+function expectNoDangerZoneNotification(result: Record<string, unknown>): void {
+  const autonomy = result.autonomy as { notifications?: Array<{ type: string }> };
+  expect(autonomy.notifications?.some(notification => notification.type === 'danger_zone'))
+    .not.toBe(true);
+}
+
+describe('AgentExecutionHandler DangerZone notification compatibility', () => {
+  it('suppresses a session-owned notification when runtime session context is unavailable', async () => {
+    const contextTracker = {
+      getCorrelationId: () => undefined,
+      getSessionContext: () => undefined,
+    } as CorrelationIdProvider;
+    const { handler, recordAgentStep } = createHarness(
+      blockedResult({ sessionId: 'http-session-a', goalId: GOAL_ID }),
+      contextTracker,
+    );
+
+    expectNoDangerZoneNotification(await recordStep(handler));
+    expect(recordAgentStep).toHaveBeenCalledTimes(1);
+    await expect(recordStep(handler)).rejects.toThrow('blocked due to danger zone trigger');
+    expect(recordAgentStep).toHaveBeenCalledTimes(1);
+  });
+
+  it('enforces a legacy block without replaying it as a fresh goal notification', async () => {
+    const { handler, recordAgentStep } = createHarness(
+      blockedResult({ sessionId: undefined, goalId: undefined }),
+    );
+
+    expectNoDangerZoneNotification(await recordStep(handler));
+    expect(recordAgentStep).toHaveBeenCalledTimes(1);
+    await expect(recordStep(handler)).rejects.toThrow('blocked due to danger zone trigger');
+    expect(recordAgentStep).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- document the exact compatibility semantics for stdio, degraded session context, and legacy blocks without goal ownership
- add direct regression coverage for suppressing a session-owned notification when runtime session context is unavailable
- add direct regression coverage showing a legacy goal-less block remains enforced without being replayed as a fresh goal notification

## Behavior

This PR does not change production behavior. It records and tests the conservative boundary established by #2484:

- notification delivery requires matching agent, session, and active goal ownership
- missing runtime ownership suppresses notification delivery
- suppression never removes or bypasses the underlying DangerZone block
- stdio contexts may match blocks that also have no session ID, but legacy blocks without goal ownership are not replayed as current-goal notifications

The regression tests use sequenced mock block checks and the Beetlejuice sentinel; they do not submit command-shaped destructive fixtures.

## Validation

- 83 focused unit tests passed
- `npx tsc --noEmit`
- `npm run lint -- --quiet`
- `git diff --check`

Closes #2485
