### PR TITLE
Security: harden ZIP skill extraction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "dotenv": "^17.2.3",
         "drizzle-orm": "^0.45.2",
         "express": "^5.2.1",
-        "extract-zip": "^2.0.1",
         "graphql": "^16.12.0",
         "graphql-tag": "^2.12.6",
         "gray-matter": "^4.0.3",
@@ -39,6 +38,7 @@
         "smol-toml": "^1.6.1",
         "undici": "^6.27.0",
         "uuid": "^11.1.1",
+        "yauzl": "3.2.1",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -68,6 +68,7 @@
         "@types/semver": "^7.7.1",
         "@types/supertest": "^7.2.0",
         "@types/uuid": "^10.0.0",
+        "@types/yauzl": "2.10.3",
         "@typescript-eslint/eslint-plugin": "^8.46.2",
         "@typescript-eslint/parser": "^8.48.1",
         "archiver": "^7.0.1",
@@ -156,7 +157,6 @@
       "version": "7.28.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -673,7 +673,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -696,7 +695,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3067,7 +3065,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
       "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -4544,7 +4541,7 @@
     },
     "node_modules/@types/node": {
       "version": "24.10.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -4689,8 +4686,8 @@
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -4727,7 +4724,6 @@
       "version": "8.48.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -5348,7 +5344,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5822,7 +5817,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7321,13 +7315,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
     "node_modules/entities": {
       "version": "6.0.1",
       "license": "BSD-2-Clause",
@@ -7448,7 +7435,6 @@
       "version": "9.39.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7833,7 +7819,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7898,37 +7883,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extract-zip/node_modules/get-stream": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -8013,13 +7967,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/fetch-blob": {
@@ -8405,7 +8352,6 @@
     "node_modules/graphql": {
       "version": "16.12.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -8524,7 +8470,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
       "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9028,7 +8973,6 @@
       "version": "30.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -9958,7 +9902,6 @@
       "resolved": "https://registry.npmjs.org/koa/-/koa-3.2.0.tgz",
       "integrity": "sha512-TrM4/tnNY7uJ1aW55sIIa+dqBvc4V14WRIAlGcWat9wV5pRS9Wr5Zk2ZTjQP1jtfIHDoHiSbPuV08P0fUZo2pg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^1.3.8",
         "content-disposition": "~1.0.1",
@@ -10824,6 +10767,8 @@
     },
     "node_modules/pend": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -10941,7 +10886,6 @@
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.9.tgz",
       "integrity": "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==",
       "license": "Unlicense",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11038,14 +10982,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -11277,7 +11213,6 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -11291,7 +11226,6 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -12432,7 +12366,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12827,7 +12760,6 @@
       "version": "10.9.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12943,7 +12875,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12983,7 +12914,7 @@
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -13467,11 +13398,16 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.1.tgz",
+      "integrity": "sha512-k1isifdbpNSFEHFJ1ZY4YDewv0IH9FR61lDetaRMD3j2ae3bIXGV+7c+LHCqtQGofSd8PIyV4X6+dHMAnSr60A==",
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yn": {
@@ -13511,7 +13447,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -13547,7 +13482,6 @@
       "version": "7.28.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -14108,7 +14042,6 @@
       "version": "7.18.0",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -14462,7 +14395,6 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -214,7 +214,6 @@
     "dotenv": "^17.2.3",
     "drizzle-orm": "^0.45.2",
     "express": "^5.2.1",
-    "extract-zip": "^2.0.1",
     "graphql": "^16.12.0",
     "graphql-tag": "^2.12.6",
     "gray-matter": "^4.0.3",
@@ -232,6 +231,7 @@
     "smol-toml": "^1.6.1",
     "undici": "^6.27.0",
     "uuid": "^11.1.1",
+    "yauzl": "3.2.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -252,6 +252,7 @@
     "@types/semver": "^7.7.1",
     "@types/supertest": "^7.2.0",
     "@types/uuid": "^10.0.0",
+    "@types/yauzl": "2.10.3",
     "@typescript-eslint/eslint-plugin": "^8.46.2",
     "@typescript-eslint/parser": "^8.48.1",
     "archiver": "^7.0.1",

--- a/src/cli/convert.ts
+++ b/src/cli/convert.ts
@@ -327,17 +327,16 @@ async function convertToAnthropic(input: string, options: ConvertOptions): Promi
  * Now: Separate function handles cleanup with proper error handling
  */
 function cleanupTempDirectory(tempDir: string | null, verbose: boolean): void {
-    if (tempDir && fs.existsSync(tempDir)) {
-        if (verbose) {
-            console.log(chalk.gray(`\nCleaning up temporary files...`));
-        }
-        try {
-            fs.rmSync(tempDir, { recursive: true, force: true });
-        } catch (cleanupError) {
-            // Log error details but don't fail on cleanup errors
-            const errorMessage = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
-            console.warn(chalk.yellow(`Warning: Failed to cleanup temp directory: ${tempDir} - ${errorMessage}`));
-        }
+    if (!tempDir) return;
+    if (verbose) {
+        console.log(chalk.gray(`\nCleaning up temporary files...`));
+    }
+    try {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch (cleanupError) {
+        // Log error details but don't fail on cleanup errors
+        const errorMessage = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+        console.warn(chalk.yellow(`Warning: Failed to cleanup temp directory: ${tempDir} - ${errorMessage}`));
     }
 }
 

--- a/src/cli/convert.ts
+++ b/src/cli/convert.ts
@@ -32,10 +32,8 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as os from 'node:os';
 import { Command } from 'commander';
 import chalk from 'chalk';
-import extract from 'extract-zip';
 import {
     DollhouseToAnthropicConverter,
     AnthropicToDollhouseConverter,
@@ -44,6 +42,7 @@ import {
 import { SecurityMonitor } from '../security/securityMonitor.js';
 import { UnicodeValidator } from '../security/validators/unicodeValidator.js';
 import { resolvePathWithinBase, vetOutputBase } from '../utils/pathSecurity.js';
+import { extractZipForConversion } from './zipExtraction.js';
 
 const program = new Command();
 
@@ -60,16 +59,6 @@ function vetConvertOutput(requestedOutput: string): string {
         }
     });
 }
-
-/**
- * Maximum ZIP file size (100MB) - prevents DoS attacks and system resource exhaustion
- */
-const MAX_ZIP_SIZE_BYTES = 100 * 1024 * 1024; // 100MB
-
-/**
- * Maximum extracted size (500MB) - prevents zip bomb attacks
- */
-const MAX_EXTRACTED_SIZE_BYTES = 500 * 1024 * 1024; // 500MB
 
 /**
  * Progress indicator threshold (10MB) - show progress message for files larger than this
@@ -120,118 +109,42 @@ function formatBytes(bytes: number): string {
 }
 
 /**
- * Calculate total size of extracted files
- */
-function calculateExtractedSize(directory: string): number {
-    let totalSize = 0;
-
-    function walkDir(dir: string): void {
-        const entries = fs.readdirSync(dir, { withFileTypes: true });
-        for (const entry of entries) {
-            const fullPath = path.join(dir, entry.name);
-            if (entry.isDirectory()) {
-                walkDir(fullPath);
-            } else if (entry.isFile()) {
-                totalSize += fs.statSync(fullPath).size;
-            }
-        }
-    }
-
-    walkDir(directory);
-    return totalSize;
-}
-
-/**
  * Extract a ZIP file to a temporary directory with size limits and progress indication
- * @returns Path to extracted directory
+ * @returns The exact temporary root and the directory to convert
  * @throws Error if ZIP exceeds size limits
  */
-async function extractZipFile(zipPath: string, verbose: boolean): Promise<string> {
-    // FIX: Validate ZIP file size BEFORE extraction to prevent DoS attacks
-    // Previously: No size validation, allowing extraction of arbitrarily large files
-    // Now: Enforce 100MB ZIP size limit and 500MB extracted size limit
-    const zipStats = fs.statSync(zipPath);
-    const zipSize = zipStats.size;
-
-    // SECURITY CHECK (typescript:S5042): Validate ZIP size before extraction
-    if (zipSize > MAX_ZIP_SIZE_BYTES) {
-        throw new Error(
-            `ZIP file too large: ${formatBytes(zipSize)}. Maximum allowed: ${formatBytes(MAX_ZIP_SIZE_BYTES)}. ` +
-            `This limit prevents DoS attacks and system resource exhaustion.`
-        );
-    }
-
-    const tempDir = path.join(os.tmpdir(), `dollhouse-extract-${Date.now()}`);
-
-    // FIX: Add security audit logging for ZIP operations
-    // Previously: No logging of ZIP extraction operations
-    // Now: Log all ZIP operations for security audit trail
-    SecurityMonitor.logSecurityEvent({
-        type: 'FILE_COPIED',
-        severity: 'LOW',
-        source: 'convert CLI',
-        details: `ZIP extraction: ${zipPath} (${formatBytes(zipSize)}) -> ${tempDir}`
+async function extractZipFile(
+    zipPath: string,
+    verbose: boolean,
+): Promise<{ actualInput: string; tempDir: string }> {
+    const result = await extractZipForConversion(zipPath, {
+        onStart: ({ archiveSize, tempDir }) => {
+            SecurityMonitor.logSecurityEvent({
+                type: 'FILE_COPIED',
+                severity: 'LOW',
+                source: 'convert CLI',
+                details: `ZIP extraction: ${zipPath} (${formatBytes(archiveSize)}) -> ${tempDir}`,
+            });
+            if (verbose) {
+                console.log(chalk.blue('\nExtracting ZIP file...'));
+                console.log(chalk.gray(`  ZIP: ${zipPath}`));
+                console.log(chalk.gray(`  Size: ${formatBytes(archiveSize)}`));
+                console.log(chalk.gray(`  Temp dir: ${tempDir}`));
+            }
+            const progressMessage = archiveSize > PROGRESS_THRESHOLD_BYTES
+                ? 'Extracting (this may take a moment)...'
+                : 'Extracting...';
+            if (verbose || archiveSize > PROGRESS_THRESHOLD_BYTES) {
+                console.log(chalk.blue(`  ${progressMessage}`));
+            }
+        },
     });
 
     if (verbose) {
-        console.log(chalk.blue('\nExtracting ZIP file...'));
-        console.log(chalk.gray(`  ZIP: ${zipPath}`));
-        console.log(chalk.gray(`  Size: ${formatBytes(zipSize)}`));
-        console.log(chalk.gray(`  Temp dir: ${tempDir}`));
+        console.log(chalk.gray(`  Extracted in ${result.elapsedMs}ms`));
+        console.log(chalk.gray(`  Extracted size: ${formatBytes(result.expandedSize)}`));
     }
-
-    // FIX: Add progress indicator for large ZIP extractions
-    // Previously: No feedback during extraction, poor UX for large files
-    // Now: Show progress message for better user experience
-    const startTime = Date.now();
-    const progressMessage = zipSize > PROGRESS_THRESHOLD_BYTES ? 'Extracting (this may take a moment)...' : 'Extracting...';
-    if (verbose || zipSize > PROGRESS_THRESHOLD_BYTES) {
-        console.log(chalk.blue(`  ${progressMessage}`));
-    }
-
-    // SONARCLOUD FIX (typescript:S5042): Archive extraction is safe here
-    // - ZIP size validated (max 100MB) at lines 110-114 to prevent DoS
-    // - Extracted size validated (max 500MB) at lines 151-157 to prevent zip bombs
-    // - Extraction to isolated temp directory (no path traversal risk)
-    // - Full cleanup in finally block prevents resource leaks
-    await extract(zipPath, { dir: tempDir });
-
-    const extractTime = Date.now() - startTime;
-    if (verbose) {
-        console.log(chalk.gray(`  Extracted in ${extractTime}ms`));
-    }
-
-    // SECURITY CHECK (typescript:S5042): Validate extracted size to prevent zip bomb attacks
-    // Zip bombs are malicious archives that expand to enormous sizes (e.g., 42KB → 4.5PB)
-    // This check prevents system resource exhaustion from maliciously compressed files
-    const extractedSize = calculateExtractedSize(tempDir);
-    if (extractedSize > MAX_EXTRACTED_SIZE_BYTES) {
-        // Cleanup before throwing error to prevent temp file accumulation
-        fs.rmSync(tempDir, { recursive: true, force: true });
-        throw new Error(
-            `Extracted content too large: ${formatBytes(extractedSize)}. Maximum allowed: ${formatBytes(MAX_EXTRACTED_SIZE_BYTES)}. This may be a zip bomb attack.`
-        );
-    }
-
-    if (verbose) {
-        console.log(chalk.gray(`  Extracted size: ${formatBytes(extractedSize)}`));
-    }
-
-    // Find the skill directory (should be the only top-level directory)
-    const contents = fs.readdirSync(tempDir);
-    const directories = contents.filter(item =>
-        fs.statSync(path.join(tempDir, item)).isDirectory()
-    );
-
-    if (directories.length === 1) {
-        // Return the skill directory path
-        return path.join(tempDir, directories[0]);
-    } else if (contents.length > 0) {
-        // If multiple items or no directory, return temp dir itself
-        return tempDir;
-    } else {
-        throw new Error('ZIP file appears to be empty');
-    }
+    return { actualInput: result.actualInput, tempDir: result.tempDir };
 }
 
 /**
@@ -257,9 +170,7 @@ async function prepareConversionInput(
 
     // Handle ZIP files
     if (isZipFile(input)) {
-        const actualInput = await extractZipFile(input, verbose);
-        const tempDir = path.dirname(actualInput);
-        return { actualInput, tempDir };
+        return extractZipFile(input, verbose);
     }
 
     // Handle directories
@@ -482,7 +393,7 @@ async function convertFromAnthropic(input: string, options: ConvertOptions): Pro
             console.log(chalk.yellow('\n[DRY RUN] Would create:'));
             console.log(chalk.gray(`  Output file: ${outputFile}`));
             console.log(chalk.gray(`  Size: ${dollhouseSkill.length} bytes`));
-            process.exit(0);
+            return;
         }
 
         // Write output
@@ -520,10 +431,10 @@ async function convertFromAnthropic(input: string, options: ConvertOptions): Pro
         console.log(chalk.green('\n✓ Conversion complete'));
         console.log(chalk.gray(`  Created: ${outputFile}`));
 
-        process.exit(0);
+        return;
     } catch (error) {
         console.error(chalk.red('\n✗ Conversion failed:'), error);
-        process.exit(1);
+        process.exitCode = 1;
     } finally {
         // SONARCLOUD FIX (typescript:S3776): Use extracted cleanup function to reduce complexity
         // FIX: Ensure cleanup happens on both success and failure

--- a/src/cli/zipExtraction.ts
+++ b/src/cli/zipExtraction.ts
@@ -1,0 +1,407 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Transform, type Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import yauzl, { type Entry, type ZipFile } from 'yauzl';
+
+export const MAX_ZIP_SIZE_BYTES = 100 * 1024 * 1024;
+export const MAX_EXTRACTED_SIZE_BYTES = 500 * 1024 * 1024;
+export const MAX_ZIP_ENTRIES = 10_000;
+
+const UNIX_FILE_TYPE_MASK = 0o170000;
+const UNIX_REGULAR_FILE = 0o100000;
+const UNIX_DIRECTORY = 0o040000;
+const UNIX_SYMBOLIC_LINK = 0o120000;
+const DOS_DIRECTORY = 0x0010;
+const DOS_REPARSE_POINT = 0x0400;
+const INFO_ZIP_UNIX_EXTRA_FIELD = 0x000d;
+const ASI_UNIX_EXTRA_FIELD = 0x756e;
+const UNIX_HOST_SYSTEMS = new Set([3, 19]);
+
+export interface ZipEntryMetadata {
+    readonly fileName: string;
+    readonly externalFileAttributes: number;
+    readonly versionMadeBy: number;
+    readonly generalPurposeBitFlag: number;
+    readonly uncompressedSize: number;
+    readonly extraFields?: ReadonlyArray<{
+        readonly id: number;
+        readonly data: Buffer;
+    }>;
+}
+
+export interface ZipExtractionLimits {
+    readonly maxArchiveBytes: number;
+    readonly maxExpandedBytes: number;
+    readonly maxEntries: number;
+}
+
+export interface ZipValidationState {
+    entryCount: number;
+    expandedBytes: number;
+}
+
+export interface ZipExtractionStart {
+    readonly archiveSize: number;
+    readonly tempDir: string;
+}
+
+export interface ZipExtractionResult extends ZipExtractionStart {
+    readonly actualInput: string;
+    readonly expandedSize: number;
+    readonly elapsedMs: number;
+}
+
+interface ZipExtractionOptions {
+    readonly limits?: Partial<ZipExtractionLimits>;
+    readonly tempParent?: string;
+    readonly onStart?: (context: ZipExtractionStart) => void;
+}
+
+const DEFAULT_LIMITS: ZipExtractionLimits = {
+    maxArchiveBytes: MAX_ZIP_SIZE_BYTES,
+    maxExpandedBytes: MAX_EXTRACTED_SIZE_BYTES,
+    maxEntries: MAX_ZIP_ENTRIES,
+};
+
+/**
+ * Extract one validated entry at a time and create only private directories and regular files.
+ * Archive permissions are never applied, so link and special-file metadata cannot become active.
+ */
+export async function extractZipForConversion(
+    zipPath: string,
+    options: ZipExtractionOptions = {},
+): Promise<ZipExtractionResult> {
+    const limits = resolveLimits(options.limits);
+    const archiveStats = fs.lstatSync(zipPath);
+    if (!archiveStats.isFile()) {
+        throw new Error('ZIP input must be a regular file');
+    }
+    if (archiveStats.size > limits.maxArchiveBytes) {
+        throw new Error(
+            `ZIP file too large: ${formatBytes(archiveStats.size)}. ` +
+            `Maximum allowed: ${formatBytes(limits.maxArchiveBytes)}.`,
+        );
+    }
+
+    const tempParent = path.resolve(options.tempParent ?? os.tmpdir());
+    fs.mkdirSync(tempParent, { recursive: true });
+    const tempDir = fs.mkdtempSync(path.join(tempParent, 'dollhouse-extract-'));
+    const startedAt = Date.now();
+
+    try {
+        options.onStart?.({ archiveSize: archiveStats.size, tempDir });
+        await extractArchive(zipPath, tempDir, limits);
+        const expandedSize = inspectExtractedTree(tempDir, limits.maxExpandedBytes);
+        return {
+            actualInput: selectConversionInput(tempDir),
+            tempDir,
+            archiveSize: archiveStats.size,
+            expandedSize,
+            elapsedMs: Date.now() - startedAt,
+        };
+    } catch (error) {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+        throw error;
+    }
+}
+
+export function validateZipEntryForExtraction(
+    entry: ZipEntryMetadata,
+    destinationRoot: string,
+    state: ZipValidationState,
+    limits: ZipExtractionLimits = DEFAULT_LIMITS,
+): void {
+    validateEntryPath(entry.fileName, destinationRoot);
+    validateEntryType(entry);
+
+    if ((entry.generalPurposeBitFlag & 0x1) !== 0) {
+        throw new Error(`Encrypted ZIP entries are not supported: ${entry.fileName}`);
+    }
+    if (!Number.isSafeInteger(entry.uncompressedSize) || entry.uncompressedSize < 0) {
+        throw new Error(`ZIP entry has an invalid expanded size: ${entry.fileName}`);
+    }
+
+    const nextEntryCount = state.entryCount + 1;
+    if (nextEntryCount > limits.maxEntries) {
+        throw new Error(`ZIP contains too many entries. Maximum allowed: ${limits.maxEntries}`);
+    }
+
+    const nextExpandedBytes = state.expandedBytes + entry.uncompressedSize;
+    if (!Number.isSafeInteger(nextExpandedBytes) || nextExpandedBytes > limits.maxExpandedBytes) {
+        throw new Error(
+            `Extracted content too large. Maximum allowed: ${formatBytes(limits.maxExpandedBytes)}.`,
+        );
+    }
+
+    state.entryCount = nextEntryCount;
+    state.expandedBytes = nextExpandedBytes;
+}
+
+function resolveLimits(overrides?: Partial<ZipExtractionLimits>): ZipExtractionLimits {
+    const limits = { ...DEFAULT_LIMITS, ...overrides };
+    for (const [name, value] of Object.entries(limits)) {
+        if (!Number.isSafeInteger(value) || value <= 0) {
+            throw new Error(`ZIP extraction limit ${name} must be a positive safe integer`);
+        }
+    }
+    return limits;
+}
+
+function extractArchive(
+    zipPath: string,
+    destinationRoot: string,
+    limits: ZipExtractionLimits,
+): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        let zipFile: ZipFile | undefined;
+        let settled = false;
+        const state: ZipValidationState = { entryCount: 0, expandedBytes: 0 };
+        const extracted = { bytes: 0 };
+
+        const fail = (reason: unknown): void => {
+            if (settled) return;
+            settled = true;
+            if (zipFile?.isOpen) zipFile.close();
+            reject(toError(reason));
+        };
+
+        yauzl.open(zipPath, {
+            autoClose: true,
+            lazyEntries: true,
+            decodeStrings: true,
+            validateEntrySizes: true,
+            strictFileNames: true,
+        }, (openError, openedZip) => {
+            if (openError || !openedZip) {
+                fail(openError ?? new Error('Unable to open ZIP file'));
+                return;
+            }
+            zipFile = openedZip;
+            if (openedZip.entryCount > limits.maxEntries) {
+                fail(new Error(`ZIP contains too many entries. Maximum allowed: ${limits.maxEntries}`));
+                return;
+            }
+
+            openedZip.on('error', fail);
+            openedZip.on('end', () => {
+                if (settled) return;
+                settled = true;
+                resolve();
+            });
+            openedZip.on('entry', (entry: Entry) => {
+                try {
+                    validateZipEntryForExtraction(entry, destinationRoot, state, limits);
+                } catch (validationError) {
+                    fail(validationError);
+                    return;
+                }
+
+                extractEntry(openedZip, entry, destinationRoot, extracted, limits.maxExpandedBytes)
+                    .then(() => {
+                        if (!settled) openedZip.readEntry();
+                    })
+                    .catch(fail);
+            });
+            openedZip.readEntry();
+        });
+    });
+}
+
+async function extractEntry(
+    zipFile: ZipFile,
+    entry: Entry,
+    destinationRoot: string,
+    extracted: { bytes: number },
+    maxExpandedBytes: number,
+): Promise<void> {
+    if (entry.fileName === '__MACOSX/' || entry.fileName.startsWith('__MACOSX/')) {
+        return;
+    }
+
+    const destination = destinationForEntry(destinationRoot, entry.fileName);
+    if (isDirectoryEntry(entry)) {
+        fs.mkdirSync(destination, { recursive: true, mode: 0o700 });
+        return;
+    }
+
+    fs.mkdirSync(path.dirname(destination), { recursive: true, mode: 0o700 });
+    const input = await openEntryStream(zipFile, entry);
+    const noFollow = typeof fs.constants.O_NOFOLLOW === 'number' ? fs.constants.O_NOFOLLOW : 0;
+    let descriptor: number;
+    try {
+        descriptor = fs.openSync(
+            destination,
+            fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | noFollow,
+            0o600,
+        );
+    } catch (error) {
+        input.destroy();
+        throw error;
+    }
+
+    let entryBytes = 0;
+    const sizeLimiter = new Transform({
+        transform(chunk: Buffer, _encoding, callback) {
+            entryBytes += chunk.length;
+            extracted.bytes += chunk.length;
+            if (!Number.isSafeInteger(extracted.bytes) || extracted.bytes > maxExpandedBytes) {
+                callback(new Error(
+                    `Extracted content too large. Maximum allowed: ${formatBytes(maxExpandedBytes)}.`,
+                ));
+                return;
+            }
+            callback(null, chunk);
+        },
+    });
+    const output = fs.createWriteStream(destination, { fd: descriptor, autoClose: true });
+
+    try {
+        await pipeline(input, sizeLimiter, output);
+        if (entryBytes !== entry.uncompressedSize) {
+            throw new Error(`ZIP entry size does not match its metadata: ${entry.fileName}`);
+        }
+    } catch (error) {
+        fs.rmSync(destination, { force: true });
+        throw error;
+    }
+}
+
+function openEntryStream(zipFile: ZipFile, entry: Entry): Promise<Readable> {
+    return new Promise((resolve, reject) => {
+        zipFile.openReadStream(entry, (error, stream) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+            resolve(stream);
+        });
+    });
+}
+
+function validateEntryPath(fileName: string, destinationRoot: string): void {
+    if (fileName === '' || fileName.includes('\0') || fileName.includes('\\')) {
+        throw new Error(`ZIP entry has an invalid path: ${fileName}`);
+    }
+    const segments = fileName.split('/');
+    if (
+        path.posix.isAbsolute(fileName) ||
+        /^[a-zA-Z]:/.test(fileName) ||
+        segments.includes('..')
+    ) {
+        throw new Error(`ZIP entry escapes the extraction directory: ${fileName}`);
+    }
+    destinationForEntry(destinationRoot, fileName);
+}
+
+function destinationForEntry(destinationRoot: string, fileName: string): string {
+    const destination = path.resolve(destinationRoot, ...fileName.split('/').filter(Boolean));
+    const relative = path.relative(path.resolve(destinationRoot), destination);
+    if (relative.startsWith(`..${path.sep}`) || relative === '..' || path.isAbsolute(relative)) {
+        throw new Error(`ZIP entry escapes the extraction directory: ${fileName}`);
+    }
+    return destination;
+}
+
+function validateEntryType(entry: ZipEntryMetadata): void {
+    const unixType = getUnixType(entry);
+    if (unixType === UNIX_SYMBOLIC_LINK) {
+        throw new Error(`Symbolic links are not allowed in ZIP imports: ${entry.fileName}`);
+    }
+    if (unixType !== 0 && unixType !== UNIX_REGULAR_FILE && unixType !== UNIX_DIRECTORY) {
+        throw new Error(`Special files are not allowed in ZIP imports: ${entry.fileName}`);
+    }
+    if ((entry.externalFileAttributes & DOS_REPARSE_POINT) !== 0) {
+        throw new Error(`Windows reparse points are not allowed in ZIP imports: ${entry.fileName}`);
+    }
+
+    const directoryByName = entry.fileName.endsWith('/');
+    const directoryByAttributes = unixType === UNIX_DIRECTORY ||
+        (entry.externalFileAttributes & DOS_DIRECTORY) !== 0;
+    if (directoryByName !== directoryByAttributes && (unixType !== 0 || directoryByAttributes)) {
+        throw new Error(`ZIP entry has inconsistent file type metadata: ${entry.fileName}`);
+    }
+
+    for (const field of entry.extraFields ?? []) {
+        if (field.id === INFO_ZIP_UNIX_EXTRA_FIELD && field.data.length > 12) {
+            throw new Error(`Linked or special UNIX entries are not allowed in ZIP imports: ${entry.fileName}`);
+        }
+        if (field.id === ASI_UNIX_EXTRA_FIELD) {
+            validateAsiUnixField(field.data, entry.fileName);
+        }
+    }
+}
+
+function validateAsiUnixField(data: Buffer, fileName: string): void {
+    // ASi UNIX metadata stores a mode at byte 4 and an optional link name after byte 14.
+    if (data.length < 14) {
+        throw new Error(`Malformed UNIX file metadata is not allowed in ZIP imports: ${fileName}`);
+    }
+    const unixType = data.readUInt16LE(4) & UNIX_FILE_TYPE_MASK;
+    if (unixType !== 0 && unixType !== UNIX_REGULAR_FILE && unixType !== UNIX_DIRECTORY) {
+        throw new Error(`Linked or special UNIX entries are not allowed in ZIP imports: ${fileName}`);
+    }
+    if (data.length > 14) {
+        throw new Error(`Linked or special UNIX entries are not allowed in ZIP imports: ${fileName}`);
+    }
+}
+
+function getUnixType(entry: ZipEntryMetadata): number {
+    const hostSystem = (entry.versionMadeBy >>> 8) & 0xff;
+    if (!UNIX_HOST_SYSTEMS.has(hostSystem)) return 0;
+    const unixMode = (entry.externalFileAttributes >>> 16) & 0xffff;
+    return unixMode & UNIX_FILE_TYPE_MASK;
+}
+
+function isDirectoryEntry(entry: ZipEntryMetadata): boolean {
+    return entry.fileName.endsWith('/');
+}
+
+function inspectExtractedTree(root: string, maxExpandedBytes: number): number {
+    let totalSize = 0;
+    const visit = (directory: string): void => {
+        for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+            const candidate = path.join(directory, entry.name);
+            const stats = fs.lstatSync(candidate);
+            if (stats.isSymbolicLink() || (!stats.isDirectory() && !stats.isFile())) {
+                throw new Error(`ZIP extraction produced an unsupported file type: ${entry.name}`);
+            }
+            if (stats.isDirectory()) {
+                visit(candidate);
+                continue;
+            }
+            totalSize += stats.size;
+            if (!Number.isSafeInteger(totalSize) || totalSize > maxExpandedBytes) {
+                throw new Error(
+                    `Extracted content too large. Maximum allowed: ${formatBytes(maxExpandedBytes)}.`,
+                );
+            }
+        }
+    };
+    visit(root);
+    return totalSize;
+}
+
+function selectConversionInput(tempDir: string): string {
+    const contents = fs.readdirSync(tempDir, { withFileTypes: true });
+    if (contents.length === 0) {
+        throw new Error('ZIP file appears to be empty');
+    }
+    if (contents.length === 1 && contents[0].isDirectory()) {
+        return path.join(tempDir, contents[0].name);
+    }
+    return tempDir;
+}
+
+function toError(reason: unknown): Error {
+    return reason instanceof Error ? reason : new Error(String(reason));
+}
+
+function formatBytes(bytes: number): string {
+    if (bytes === 0) return '0 Bytes';
+    const unit = 1024;
+    const units = ['Bytes', 'KB', 'MB', 'GB'];
+    const index = Math.min(Math.floor(Math.log(bytes) / Math.log(unit)), units.length - 1);
+    return `${Math.round((bytes / Math.pow(unit, index)) * 100) / 100} ${units[index]}`;
+}

--- a/src/cli/zipExtraction.ts
+++ b/src/cli/zipExtraction.ts
@@ -198,6 +198,8 @@ function extractArchive(
                     return;
                 }
 
+                // Lazy entry reads remain sequential: the shared byte ceiling is updated by one
+                // extraction at a time, and the next entry is requested only after it completes.
                 extractEntry(openedZip, entry, destinationRoot, extracted, limits.maxExpandedBytes)
                     .then(() => {
                         if (!settled) openedZip.readEntry();
@@ -216,11 +218,13 @@ async function extractEntry(
     extracted: { bytes: number },
     maxExpandedBytes: number,
 ): Promise<void> {
+    // Preserve extract-zip's handling of Finder metadata without weakening entry validation.
     if (entry.fileName === '__MACOSX/' || entry.fileName.startsWith('__MACOSX/')) {
         return;
     }
 
     const destination = destinationForEntry(destinationRoot, entry.fileName);
+    // validateEntryType has already required directory names and attributes to agree.
     if (isDirectoryEntry(entry)) {
         fs.mkdirSync(destination, { recursive: true, mode: 0o700 });
         return;
@@ -271,8 +275,8 @@ async function extractEntry(
 function openEntryStream(zipFile: ZipFile, entry: Entry): Promise<Readable> {
     return new Promise((resolve, reject) => {
         zipFile.openReadStream(entry, (error, stream) => {
-            if (error) {
-                reject(error);
+            if (error || !stream) {
+                reject(error ?? new Error(`Unable to read ZIP entry: ${entry.fileName}`));
                 return;
             }
             resolve(stream);
@@ -292,6 +296,7 @@ function validateEntryPath(fileName: string, destinationRoot: string): void {
     ) {
         throw new Error(`ZIP entry escapes the extraction directory: ${fileName}`);
     }
+    // Canonical containment is enforced by destinationForEntry before any filesystem write.
     destinationForEntry(destinationRoot, fileName);
 }
 
@@ -360,7 +365,10 @@ function isDirectoryEntry(entry: ZipEntryMetadata): boolean {
 
 function inspectExtractedTree(root: string, maxExpandedBytes: number): number {
     let totalSize = 0;
-    const visit = (directory: string): void => {
+    const pendingDirectories = [root];
+    while (pendingDirectories.length > 0) {
+        const directory = pendingDirectories.pop();
+        if (!directory) break;
         for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
             const candidate = path.join(directory, entry.name);
             const stats = fs.lstatSync(candidate);
@@ -368,7 +376,7 @@ function inspectExtractedTree(root: string, maxExpandedBytes: number): number {
                 throw new Error(`ZIP extraction produced an unsupported file type: ${entry.name}`);
             }
             if (stats.isDirectory()) {
-                visit(candidate);
+                pendingDirectories.push(candidate);
                 continue;
             }
             totalSize += stats.size;
@@ -378,8 +386,7 @@ function inspectExtractedTree(root: string, maxExpandedBytes: number): number {
                 );
             }
         }
-    };
-    visit(root);
+    }
     return totalSize;
 }
 
@@ -388,10 +395,32 @@ function selectConversionInput(tempDir: string): string {
     if (contents.length === 0) {
         throw new Error('ZIP file appears to be empty');
     }
+    if (isRegularFile(path.join(tempDir, 'SKILL.md'))) {
+        return tempDir;
+    }
+
+    const skillDirectories = contents
+        .filter(entry => entry.isDirectory())
+        .map(entry => path.join(tempDir, entry.name))
+        .filter(directory => isRegularFile(path.join(directory, 'SKILL.md')));
+    if (skillDirectories.length === 1) {
+        return skillDirectories[0];
+    }
     if (contents.length === 1 && contents[0].isDirectory()) {
         return path.join(tempDir, contents[0].name);
     }
     return tempDir;
+}
+
+function isRegularFile(candidate: string): boolean {
+    try {
+        return fs.lstatSync(candidate).isFile();
+    } catch (error) {
+        if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT') {
+            return false;
+        }
+        throw error;
+    }
 }
 
 function toError(reason: unknown): Error {

--- a/tests/unit/cli/zipExtraction.test.ts
+++ b/tests/unit/cli/zipExtraction.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, describe, expect, it } from '@jest/globals';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import archiver from 'archiver';
+import {
+    extractZipForConversion,
+    MAX_EXTRACTED_SIZE_BYTES,
+    MAX_ZIP_ENTRIES,
+    MAX_ZIP_SIZE_BYTES,
+    type ZipEntryMetadata,
+    type ZipValidationState,
+    validateZipEntryForExtraction,
+} from '../../../src/cli/zipExtraction.js';
+
+const cleanupPaths: string[] = [];
+
+afterEach(() => {
+    for (const cleanupPath of cleanupPaths.splice(0)) {
+        fs.rmSync(cleanupPath, { recursive: true, force: true });
+    }
+});
+
+describe('secure ZIP extraction', () => {
+    it('extracts a normal skill and reports the exact temporary root', async () => {
+        const fixture = createFixtureDirectory();
+        const zipPath = path.join(fixture, 'skill.zip');
+        await createZip(zipPath, archive => {
+            archive.append('---\nname: safe-skill\n---\n', { name: 'safe-skill/SKILL.md' });
+            archive.append('echo safe\n', { name: 'safe-skill/scripts/test.sh' });
+        });
+
+        const result = await extractZipForConversion(zipPath, { tempParent: fixture });
+        cleanupPaths.push(result.tempDir);
+
+        expect(path.dirname(result.tempDir)).toBe(fixture);
+        expect(result.actualInput).toBe(path.join(result.tempDir, 'safe-skill'));
+        expect(fs.readFileSync(path.join(result.actualInput, 'SKILL.md'), 'utf8')).toContain('safe-skill');
+    });
+
+    it('converts a ZIP through the real CLI and removes its temporary extraction root', async () => {
+        const fixture = createFixtureDirectory();
+        const zipPath = path.join(fixture, 'skill.zip');
+        const outputDir = path.join(fixture, 'output');
+        const tempDir = path.join(fixture, 'tmp');
+        fs.mkdirSync(tempDir);
+        await createZip(zipPath, archive => {
+            archive.append(
+                '---\nname: Safe Skill\ndescription: Safe conversion fixture\n---\n\n# Safe Skill\n\nUse safely.\n',
+                { name: 'safe-skill/SKILL.md' },
+            );
+        });
+
+        const cliResult = spawnSync(process.execPath, [
+            path.join(process.cwd(), 'node_modules/tsx/dist/cli.mjs'),
+            path.join(process.cwd(), 'src/cli/convert.ts'),
+            'from-anthropic',
+            zipPath,
+            '--output',
+            outputDir,
+        ], {
+            cwd: process.cwd(),
+            encoding: 'utf8',
+            env: { ...process.env, TMPDIR: tempDir, TMP: tempDir, TEMP: tempDir },
+        });
+
+        expect(cliResult.stderr).toBe('');
+        expect(cliResult.status).toBe(0);
+        expect(fs.readFileSync(path.join(outputDir, 'safe-skill.md'), 'utf8'))
+            .toContain('name: Safe Skill');
+        expect(extractionDirectories(tempDir)).toEqual([]);
+    });
+
+    it('keeps the extraction root as cleanup ownership for multiple top-level entries', async () => {
+        const fixture = createFixtureDirectory();
+        const zipPath = path.join(fixture, 'multi-root.zip');
+        await createZip(zipPath, archive => {
+            archive.append('skill', { name: 'SKILL.md' });
+            archive.append('reference', { name: 'references/example.txt' });
+        });
+
+        const result = await extractZipForConversion(zipPath, { tempParent: fixture });
+        cleanupPaths.push(result.tempDir);
+
+        expect(result.actualInput).toBe(result.tempDir);
+        expect(path.dirname(result.tempDir)).toBe(fixture);
+    });
+
+    it('rejects an archive symlink before materializing it and removes partial output', async () => {
+        const fixture = createFixtureDirectory();
+        const zipPath = path.join(fixture, 'symlink.zip');
+        await createZip(zipPath, archive => {
+            archive.append('skill', { name: 'safe/SKILL.md' });
+            archive.symlink('safe/outside', '../../outside.txt');
+        });
+
+        await expect(extractZipForConversion(zipPath, { tempParent: fixture }))
+            .rejects.toThrow('Symbolic links are not allowed');
+        expect(extractionDirectories(fixture)).toEqual([]);
+    });
+
+    it('rejects a nested path that would traverse an earlier archive symlink', async () => {
+        const fixture = createFixtureDirectory();
+        const zipPath = path.join(fixture, 'nested-symlink.zip');
+        await createZip(zipPath, archive => {
+            archive.symlink('redirect', '../outside');
+            archive.append('escape attempt', { name: 'redirect/escaped.txt' });
+        });
+
+        await expect(extractZipForConversion(zipPath, { tempParent: fixture }))
+            .rejects.toThrow('Symbolic links are not allowed');
+        expect(fs.existsSync(path.join(fixture, 'outside', 'escaped.txt'))).toBe(false);
+        expect(extractionDirectories(fixture)).toEqual([]);
+    });
+
+    it('enforces expanded-size limits during extraction and removes partial output', async () => {
+        const fixture = createFixtureDirectory();
+        const zipPath = path.join(fixture, 'oversized.zip');
+        await createZip(zipPath, archive => {
+            archive.append('1234567890', { name: 'first.txt' });
+            archive.append('abcdefghij', { name: 'second.txt' });
+        });
+
+        await expect(extractZipForConversion(zipPath, {
+            tempParent: fixture,
+            limits: { maxExpandedBytes: 15 },
+        })).rejects.toThrow('Extracted content too large');
+        expect(extractionDirectories(fixture)).toEqual([]);
+    });
+
+    it('removes its temporary root when start logging fails', async () => {
+        const fixture = createFixtureDirectory();
+        const zipPath = path.join(fixture, 'logging-failure.zip');
+        await createZip(zipPath, archive => {
+            archive.append('skill', { name: 'SKILL.md' });
+        });
+
+        await expect(extractZipForConversion(zipPath, {
+            tempParent: fixture,
+            onStart: () => {
+                throw new Error('logging failed');
+            },
+        })).rejects.toThrow('logging failed');
+        expect(extractionDirectories(fixture)).toEqual([]);
+    });
+
+    it('rejects symlink ZIP inputs instead of following them', async () => {
+        if (process.platform === 'win32') return;
+        const fixture = createFixtureDirectory();
+        const zipPath = path.join(fixture, 'skill.zip');
+        const linkPath = path.join(fixture, 'linked.zip');
+        await createZip(zipPath, archive => {
+            archive.append('skill', { name: 'SKILL.md' });
+        });
+        fs.symlinkSync(zipPath, linkPath);
+
+        await expect(extractZipForConversion(linkPath, { tempParent: fixture }))
+            .rejects.toThrow('ZIP input must be a regular file');
+        expect(extractionDirectories(fixture)).toEqual([]);
+    });
+
+    it.each([
+        ['path traversal', fakeEntry('../outside.txt')],
+        ['absolute path', fakeEntry('/outside.txt')],
+        ['symbolic link', fakeEntry('link', 0o120777)],
+        ['device', fakeEntry('device', 0o020666)],
+        ['Windows reparse point', fakeEntry('junction', 0, 0x0400)],
+        ['UNIX linked entry metadata', fakeEntry('linked', 0o100644, 0, 13)],
+        ['ASI hard-link metadata', fakeEntryWithAsiMetadata('hard-link', 0o100644, 15)],
+    ])('rejects %s', (_label, entry) => {
+        expect(() => validateZipEntryForExtraction(
+            entry,
+            os.tmpdir(),
+            freshState(),
+            defaultLimits(),
+        )).toThrow();
+    });
+
+    it('rejects encrypted entries, excessive entry counts, and invalid sizes', () => {
+        const encrypted = { ...fakeEntry('secret.txt'), generalPurposeBitFlag: 1 };
+        expect(() => validateZipEntryForExtraction(
+            encrypted,
+            os.tmpdir(),
+            freshState(),
+            defaultLimits(),
+        )).toThrow('Encrypted ZIP entries are not supported');
+
+        const fullState = { entryCount: MAX_ZIP_ENTRIES, expandedBytes: 0 };
+        expect(() => validateZipEntryForExtraction(
+            fakeEntry('one-too-many.txt'),
+            os.tmpdir(),
+            fullState,
+            defaultLimits(),
+        )).toThrow('ZIP contains too many entries');
+
+        const invalidSize = { ...fakeEntry('invalid.txt'), uncompressedSize: Number.MAX_VALUE };
+        expect(() => validateZipEntryForExtraction(
+            invalidSize,
+            os.tmpdir(),
+            freshState(),
+            defaultLimits(),
+        )).toThrow('invalid expanded size');
+    });
+});
+
+function createFixtureDirectory(): string {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'zip-extraction-test-'));
+    cleanupPaths.push(fixture);
+    return fixture;
+}
+
+async function createZip(
+    outputPath: string,
+    populate: (archive: archiver.Archiver) => void,
+): Promise<void> {
+    const output = fs.createWriteStream(outputPath);
+    const archive = archiver('zip', { zlib: { level: 9 } });
+    await new Promise<void>((resolve, reject) => {
+        output.on('close', resolve);
+        output.on('error', reject);
+        archive.on('error', reject);
+        archive.pipe(output);
+        populate(archive);
+        archive.finalize().catch(reject);
+    });
+}
+
+function extractionDirectories(fixture: string): string[] {
+    return fs.readdirSync(fixture).filter(name => name.startsWith('dollhouse-extract-'));
+}
+
+function fakeEntry(
+    fileName: string,
+    unixMode = 0o100644,
+    dosAttributes = 0,
+    unixExtraFieldSize = 0,
+): ZipEntryMetadata {
+    return {
+        fileName,
+        externalFileAttributes: (((unixMode << 16) >>> 0) | dosAttributes) >>> 0,
+        versionMadeBy: 3 << 8,
+        generalPurposeBitFlag: 0,
+        uncompressedSize: 1,
+        extraFields: unixExtraFieldSize > 0
+            ? [{ id: 0x000d, data: Buffer.alloc(unixExtraFieldSize) }]
+            : [],
+    };
+}
+
+function fakeEntryWithAsiMetadata(
+    fileName: string,
+    unixMode: number,
+    fieldSize: number,
+): ZipEntryMetadata {
+    const data = Buffer.alloc(fieldSize);
+    data.writeUInt16LE(unixMode, 4);
+    return {
+        ...fakeEntry(fileName, unixMode),
+        extraFields: [{ id: 0x756e, data }],
+    };
+}
+
+function freshState(): ZipValidationState {
+    return { entryCount: 0, expandedBytes: 0 };
+}
+
+function defaultLimits() {
+    return {
+        maxArchiveBytes: MAX_ZIP_SIZE_BYTES,
+        maxExpandedBytes: MAX_EXTRACTED_SIZE_BYTES,
+        maxEntries: MAX_ZIP_ENTRIES,
+    };
+}

--- a/tests/unit/cli/zipExtraction.test.ts
+++ b/tests/unit/cli/zipExtraction.test.ts
@@ -87,6 +87,33 @@ describe('secure ZIP extraction', () => {
         expect(path.dirname(result.tempDir)).toBe(fixture);
     });
 
+    it('selects the sole skill directory when harmless root files are present', async () => {
+        const fixture = createFixtureDirectory();
+        const zipPath = path.join(fixture, 'skill-with-readme.zip');
+        await createZip(zipPath, archive => {
+            archive.append('root notes', { name: 'README.md' });
+            archive.append('skill', { name: 'safe-skill/SKILL.md' });
+        });
+
+        const result = await extractZipForConversion(zipPath, { tempParent: fixture });
+        cleanupPaths.push(result.tempDir);
+
+        expect(result.actualInput).toBe(path.join(result.tempDir, 'safe-skill'));
+    });
+
+    it('rejects duplicate file destinations and removes partial output', async () => {
+        const fixture = createFixtureDirectory();
+        const zipPath = path.join(fixture, 'duplicate.zip');
+        await createZip(zipPath, archive => {
+            archive.append('first', { name: 'SKILL.md' });
+            archive.append('second', { name: 'SKILL.md' });
+        });
+
+        await expect(extractZipForConversion(zipPath, { tempParent: fixture }))
+            .rejects.toThrow();
+        expect(extractionDirectories(fixture)).toEqual([]);
+    });
+
     it('rejects an archive symlink before materializing it and removes partial output', async () => {
         const fixture = createFixtureDirectory();
         const zipPath = path.join(fixture, 'symlink.zip');
@@ -201,6 +228,15 @@ describe('secure ZIP extraction', () => {
             freshState(),
             defaultLimits(),
         )).toThrow('invalid expanded size');
+    });
+
+    it('treats an unspecified UNIX mode as a regular entry', () => {
+        expect(() => validateZipEntryForExtraction(
+            fakeEntry('unspecified-mode.txt', 0),
+            os.tmpdir(),
+            freshState(),
+            defaultLimits(),
+        )).not.toThrow();
     });
 });
 


### PR DESCRIPTION
## Summary

- replace vulnerable `extract-zip@2.0.1` with a narrow, entry-by-entry extractor built on exact-pinned `yauzl@3.2.1`
- reject symlinks, hard-link metadata, device/special files, Windows reparse points, encrypted entries, unsafe paths, duplicate destinations, and inconsistent file-type metadata before they can become active
- enforce archive, entry-count, declared expanded-size, and streamed expanded-size limits while extraction is in progress
- preserve valid ZIP conversion, progress/audit logging, macOS metadata filtering, and cleanup behavior
- fix ZIP temporary-directory ownership and let the CLI unwind through `finally` so successful, failed, and dry-run conversions actually remove temporary data

## Root cause

`extract-zip` honors archive-provided Unix symlink modes. The previous converter checked compressed size before extraction and expanded size afterward, but it did not reject links before materialization. It also derived cleanup ownership from the selected conversion directory and called `process.exit()` inside the conversion `try`, which could either identify the shared system temp parent or bypass `finally` cleanup.

## Security properties

- every entry path and canonical destination is validated before writing
- archive modes are never applied; the extractor creates only private directories and regular files
- output files use exclusive creation and `O_NOFOLLOW` where the platform provides it
- extraction is lazy and sequential, with both declared and actual streamed byte ceilings
- the completed tree is inspected with `lstat` before conversion reads it
- any validation, stream, logging, or conversion failure removes the exact unique extraction root

## Dependency review

- `yauzl@3.2.1` is exact-pinned and was published 2026-03-10, well beyond the 21-day cooling period in #2452
- `3.2.1` is the first patched release for GHSA-gmq8-994r-jv83; the vulnerable `3.2.0` candidate was rejected during implementation
- npm registry integrity/signature, repository, `gitHead`, maintainer set, lifecycle scripts, and dependency surface were inspected
- `@types/yauzl@2.10.3` is exact-pinned and was published 2023-11-07
- the lockfile removes `extract-zip`, `fd-slicer`, `get-stream@5`, `pump`, and `end-of-stream`; no unrelated package versions move

## Validation

- `npm ci --ignore-scripts`
- `npm run build`
- `npm run lint`
- `npm run build:test`
- full `npm test -- --runInBand --coverage=false`
- focused 19-case malicious/positive ZIP suite, including a real CLI subprocess conversion and cleanup assertion plus the sole-skill-directory selection regression
- `npm run security:critical -- --coverage=false` (108 passed, 46 skipped by the configured name filter)
- `npm run security:audit` (0 critical/high/medium custom findings)
- `npm run test:cross-platform -- --runInBand --coverage=false`
- `npm run verify:package-assets`
- npm package dry run includes `dist/cli/convert.js` and `dist/cli/zipExtraction.js`
- local `docker/Dockerfile` build and runtime import check
- production npm audit confirms neither `extract-zip` nor `yauzl` remains in the advisory set; the separately inventoried reconciliation findings remain under #2451/#2488

Closes #2487.

Merge-commit only; do not squash or rebase the hosted integration history.
