### PR TITLE
[Integrations][Security] Canonicalize descriptor API hosts

### DIFF
--- a/src/web-console/modules/integrations/ConfiguredOAuthIntegrationProvider.ts
+++ b/src/web-console/modules/integrations/ConfiguredOAuthIntegrationProvider.ts
@@ -22,6 +22,10 @@ import {
 } from './IntegrationPublicHostGuard.js';
 import { createPinnedOutboundFactory, type PinnedOutboundFactory } from './PinnedOutboundFactory.js';
 import { logger } from '../../../utils/logger.js';
+import {
+  canonicalizeIntegrationApiHost,
+  IntegrationApiHostValidationError,
+} from '../../security/IntegrationApiHosts.js';
 
 const DEFAULT_OUTBOUND_TIMEOUT_MS = 10_000;
 
@@ -207,10 +211,19 @@ export class ConfiguredOAuthIntegrationProvider implements IIntegrationProvider 
     init: RequestInit,
   ): Promise<TokenEndpointResponse> {
     const url = new URL(urlValue);
+    let canonicalHostname: string;
     let vetted: DnsLookupAddress;
     try {
-      vetted = await assertPublicResolvedHost(url.hostname, this.dnsLookupImpl);
+      canonicalHostname = canonicalizeIntegrationApiHost(url.hostname, `oauth.${endpoint} endpoint host`);
+      vetted = await assertPublicResolvedHost(canonicalHostname, this.dnsLookupImpl);
     } catch (error) {
+      if (error instanceof IntegrationApiHostValidationError) {
+        logger.warn('Configured OAuth endpoint host rejected by canonical host policy', {
+          provider: this.descriptor.id,
+          endpoint,
+        });
+        throw new Error('configured_oauth_endpoint_not_allowed');
+      }
       if (error instanceof PublicHostGuardError) {
         logger.warn('Configured OAuth endpoint host rejected by public-host guard', {
           provider: this.descriptor.id,
@@ -224,7 +237,7 @@ export class ConfiguredOAuthIntegrationProvider implements IIntegrationProvider 
       throw error;
     }
     const outbound = this.pinnedOutboundFactory({
-      hostname: url.hostname,
+      hostname: canonicalHostname,
       address: vetted.address,
       family: vetted.family,
     });

--- a/src/web-console/modules/integrations/IntegrationDescriptorAuthoringService.ts
+++ b/src/web-console/modules/integrations/IntegrationDescriptorAuthoringService.ts
@@ -6,6 +6,10 @@ import type {
 } from '../../platform/ConsolePlatformTypes.js';
 import type { ISecretEncryptionService } from '../../security/SecretEncryption.js';
 import {
+  canonicalizeIntegrationApiHosts,
+  IntegrationApiHostValidationError,
+} from '../../security/IntegrationApiHosts.js';
+import {
   ConsoleStoreValidationError,
   isUniqueViolation,
   isValidDisplayString,
@@ -331,7 +335,7 @@ function parseDescriptorBody(body: unknown, mode: 'create' | 'patch'): ParsedDes
     }
   }
   if (mode === 'create' || input.api_hosts !== undefined) {
-    parsed.apiHosts = requireStringArray(input.api_hosts, 'api_hosts');
+    parsed.apiHosts = parseApiHosts(input.api_hosts);
   }
   if (input.oauth !== undefined) {
     const { oauth, clientSecret } = parseOAuthBody(input.oauth);
@@ -345,6 +349,18 @@ function parseDescriptorBody(body: unknown, mode: 'create' | 'patch'): ParsedDes
     parsed.operationPromotion = requireRecord(input.operation_promotion, 'operation_promotion');
   }
   return parsed;
+}
+
+function parseApiHosts(value: unknown): readonly string[] {
+  const hosts = requireStringArray(value, 'api_hosts');
+  try {
+    return canonicalizeIntegrationApiHosts(hosts, 'api_hosts');
+  } catch (error) {
+    if (error instanceof IntegrationApiHostValidationError) {
+      throw new DescriptorBodyError(error.message);
+    }
+    throw error;
+  }
 }
 
 function parseOAuthBody(value: unknown): {

--- a/src/web-console/modules/integrations/IntegrationDescriptorSeedLoader.ts
+++ b/src/web-console/modules/integrations/IntegrationDescriptorSeedLoader.ts
@@ -272,5 +272,9 @@ function readStringArray(value: unknown, key: string): readonly string[] {
 
 function readStringArrayField(value: Readonly<Record<string, unknown>>, key: string): readonly string[] {
   const field = value[key];
-  return Array.isArray(field) ? field.filter((entry): entry is string => typeof entry === 'string') : [];
+  if (!Array.isArray(field)) return [];
+  if (field.some(entry => typeof entry !== 'string')) {
+    throw new Error(`descriptor seed field '${key}' must contain only strings`);
+  }
+  return field as string[];
 }

--- a/src/web-console/modules/integrations/IntegrationDescriptorSeedLoader.ts
+++ b/src/web-console/modules/integrations/IntegrationDescriptorSeedLoader.ts
@@ -23,6 +23,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
 import { logger } from '../../../utils/logger.js';
+import { canonicalizeIntegrationApiHosts } from '../../security/IntegrationApiHosts.js';
 import type { ISecretEncryptionService } from '../../security/SecretEncryption.js';
 import {
   type IIntegrationDescriptorStore,
@@ -179,7 +180,7 @@ export class IntegrationDescriptorSeedLoader {
       ownerUserId: null,
       displayName: readString(seed, 'displayName') ?? '',
       category: readString(seed, 'category') ?? '',
-      apiHosts: readStringArray(seed, 'apiHosts'),
+      apiHosts: canonicalizeIntegrationApiHosts(readStringArray(seed, 'apiHosts')),
       operationPromotion: readRecord(seed, 'operationPromotion'),
       createdAt: timestamp,
       updatedAt: timestamp,

--- a/src/web-console/modules/integrations/IntegrationOperationCatalog.ts
+++ b/src/web-console/modules/integrations/IntegrationOperationCatalog.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 
 import type { ContextTracker } from '../../../security/encryption/ContextTracker.js';
+import { isIntegrationApiHostAllowed } from '../../security/IntegrationApiHosts.js';
 import type { IIntegrationDescriptorStore, IntegrationDescriptorRecord } from '../../stores/IIntegrationDescriptorStore.js';
 import type { IIntegrationOpenApiSpecStore } from '../../stores/IIntegrationOpenApiSpecStore.js';
 import {
@@ -747,7 +748,6 @@ function normalizePathItem(
 }
 
 function assertSpecHostsAllowed(spec: Readonly<Record<string, unknown>>, descriptor: IntegrationDescriptorRecord): void {
-  const allowed = new Set(descriptor.apiHosts);
   const servers = Array.isArray(spec.servers) ? spec.servers : [];
   for (const serverValue of servers) {
     const url = readString(asRecord(serverValue).url);
@@ -758,7 +758,7 @@ function assertSpecHostsAllowed(spec: Readonly<Record<string, unknown>>, descrip
     } catch {
       continue;
     }
-    if (parsed.protocol !== 'https:' || !allowed.has(parsed.hostname)) {
+    if (parsed.protocol !== 'https:' || !isIntegrationApiHostAllowed(parsed.hostname, descriptor.apiHosts)) {
       throw new IntegrationOperationCatalogError(
         'invalid_openapi_spec',
         'OpenAPI servers must use HTTPS hosts present in the descriptor apiHosts allowlist.',

--- a/src/web-console/modules/integrations/IntegrationRemoteMcpBridge.ts
+++ b/src/web-console/modules/integrations/IntegrationRemoteMcpBridge.ts
@@ -6,6 +6,7 @@ import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 
 import type { ContextTracker } from '../../../security/encryption/ContextTracker.js';
 import { logger } from '../../../utils/logger.js';
+import { isIntegrationApiHostAllowed } from '../../security/IntegrationApiHosts.js';
 import type { ISecretEncryptionService } from '../../security/SecretEncryption.js';
 import type { IIntegrationDescriptorStore, IntegrationDescriptorRecord } from '../../stores/IIntegrationDescriptorStore.js';
 import { type IUserIntegrationStore, type UserIntegrationProvider, type UserIntegrationRecord, isIntegrationConnected } from '../../stores/IUserIntegrationStore.js';
@@ -329,7 +330,7 @@ function parseAllowedServerUrl(value: string, descriptor: IntegrationDescriptorR
   } catch {
     throw new IntegrationRemoteMcpBridgeError('remote_mcp_invalid_server_url', 'Remote MCP server URL is invalid.', 400);
   }
-  if (url.protocol !== 'https:' || !descriptor.apiHosts.includes(url.hostname)) {
+  if (url.protocol !== 'https:' || !isIntegrationApiHostAllowed(url.hostname, descriptor.apiHosts)) {
     throw new IntegrationRemoteMcpBridgeError(
       'remote_mcp_server_not_allowed',
       'Remote MCP server URL must use HTTPS and a descriptor apiHosts host.',

--- a/src/web-console/modules/integrations/IntegrationRequestGateway.ts
+++ b/src/web-console/modules/integrations/IntegrationRequestGateway.ts
@@ -2,6 +2,7 @@ import { lookup as dnsLookup } from 'node:dns/promises';
 
 import type { IRateLimitStore, RateLimitUpdate } from '../../../auth/embedded-as/storage/IRateLimitStore.js';
 import type { ContextTracker } from '../../../security/encryption/ContextTracker.js';
+import { isIntegrationApiHostAllowed } from '../../security/IntegrationApiHosts.js';
 import type { ISecretEncryptionService } from '../../security/SecretEncryption.js';
 import type { IIntegrationDescriptorStore, IntegrationDescriptorRecord } from '../../stores/IIntegrationDescriptorStore.js';
 import { type IUserIntegrationStore, type UserIntegrationProvider, type UserIntegrationRecord, isIntegrationConnected } from '../../stores/IUserIntegrationStore.js';
@@ -542,7 +543,7 @@ function buildAllowedUrl(
   }
   const base = `https://${descriptor.apiHosts[0]}`;
   const url = new URL(path, base);
-  if (url.protocol !== 'https:' || !descriptor.apiHosts.includes(url.hostname)) {
+  if (url.protocol !== 'https:' || !isIntegrationApiHostAllowed(url.hostname, descriptor.apiHosts)) {
     throw new IntegrationRequestError('integration_host_not_allowed', 'Integration request host is not allowed.', 403);
   }
   url.username = '';

--- a/src/web-console/security/IntegrationApiHosts.ts
+++ b/src/web-console/security/IntegrationApiHosts.ts
@@ -2,7 +2,7 @@ import { isIP } from 'node:net';
 
 const MAX_HOST_INPUT_LENGTH = 1024;
 const MAX_CANONICAL_HOST_LENGTH = 253;
-const FORBIDDEN_HOST_SYNTAX = /[\\/:@?#%\[\]]/u;
+const FORBIDDEN_HOST_SYNTAX = /[\\/:@?#%\u005B\u005D]/u;
 const UNSAFE_HOST_UNICODE = /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u;
 const CANONICAL_DNS_HOST = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/;
 

--- a/src/web-console/security/IntegrationApiHosts.ts
+++ b/src/web-console/security/IntegrationApiHosts.ts
@@ -81,9 +81,14 @@ export function isIntegrationApiHostAllowed(
 function isPrivateDnsName(hostname: string): boolean {
   return !hostname.includes('.') ||
     hostname === 'localhost' ||
+    hostname === 'home.arpa' ||
     hostname.endsWith('.localhost') ||
     hostname.endsWith('.local') ||
-    hostname.endsWith('.internal');
+    hostname.endsWith('.internal') ||
+    hostname.endsWith('.home.arpa') ||
+    hostname.endsWith('.corp') ||
+    hostname.endsWith('.home') ||
+    hostname.endsWith('.lan');
 }
 
 function invalidHost(name: string): IntegrationApiHostValidationError {

--- a/src/web-console/security/IntegrationApiHosts.ts
+++ b/src/web-console/security/IntegrationApiHosts.ts
@@ -8,12 +8,21 @@ const CANONICAL_DNS_HOST = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?
 
 export class IntegrationApiHostValidationError extends Error {}
 
+export interface IntegrationApiHostCanonicalizationOptions {
+  /** Read-only compatibility for suffixes accepted before #2494; never use for new writes or egress checks. */
+  readonly allowLegacyPrivateSuffixes?: boolean;
+}
+
 /**
  * Convert a user-supplied DNS hostname to the representation used by URL.hostname:
  * lowercase ASCII with IDNs encoded as punycode. A single DNS root dot is accepted
  * and removed so equivalent URL spellings compare consistently.
  */
-export function canonicalizeIntegrationApiHost(value: string, name = 'API host'): string {
+export function canonicalizeIntegrationApiHost(
+  value: string,
+  name = 'API host',
+  options: IntegrationApiHostCanonicalizationOptions = {},
+): string {
   if (typeof value !== 'string' || value === '' || value.length > MAX_HOST_INPUT_LENGTH) {
     throw invalidHost(name);
   }
@@ -39,7 +48,9 @@ export function canonicalizeIntegrationApiHost(value: string, name = 'API host')
 
   const canonical = parsed.hostname;
   if (canonical.length === 0 || canonical.length > MAX_CANONICAL_HOST_LENGTH ||
-      !CANONICAL_DNS_HOST.test(canonical) || isIP(canonical) !== 0 || isPrivateDnsName(canonical)) {
+      !CANONICAL_DNS_HOST.test(canonical) || isIP(canonical) !== 0 ||
+      isAlwaysPrivateDnsName(canonical) ||
+      (!options.allowLegacyPrivateSuffixes && isRestrictedPrivateDnsName(canonical))) {
     throw new IntegrationApiHostValidationError(`${name} must be a public DNS hostname`);
   }
   return canonical;
@@ -49,6 +60,7 @@ export function canonicalizeIntegrationApiHost(value: string, name = 'API host')
 export function canonicalizeIntegrationApiHosts(
   values: readonly string[],
   name = 'apiHosts',
+  options: IntegrationApiHostCanonicalizationOptions = {},
 ): readonly string[] {
   if (!Array.isArray(values) || values.length === 0 || values.length > 25) {
     throw new IntegrationApiHostValidationError(`${name} must contain 1-25 hosts`);
@@ -56,7 +68,7 @@ export function canonicalizeIntegrationApiHosts(
   const canonical: string[] = [];
   const seen = new Set<string>();
   for (const [index, value] of values.entries()) {
-    const host = canonicalizeIntegrationApiHost(value, `${name}[${index}]`);
+    const host = canonicalizeIntegrationApiHost(value, `${name}[${index}]`, options);
     if (!seen.has(host)) {
       seen.add(host);
       canonical.push(host);
@@ -78,13 +90,16 @@ export function isIntegrationApiHostAllowed(
   }
 }
 
-function isPrivateDnsName(hostname: string): boolean {
+function isAlwaysPrivateDnsName(hostname: string): boolean {
   return !hostname.includes('.') ||
     hostname === 'localhost' ||
-    hostname === 'home.arpa' ||
     hostname.endsWith('.localhost') ||
     hostname.endsWith('.local') ||
-    hostname.endsWith('.internal') ||
+    hostname.endsWith('.internal');
+}
+
+function isRestrictedPrivateDnsName(hostname: string): boolean {
+  return hostname === 'home.arpa' ||
     hostname.endsWith('.home.arpa') ||
     hostname.endsWith('.corp') ||
     hostname.endsWith('.home') ||

--- a/src/web-console/security/IntegrationApiHosts.ts
+++ b/src/web-console/security/IntegrationApiHosts.ts
@@ -1,0 +1,93 @@
+import { isIP } from 'node:net';
+
+const MAX_HOST_INPUT_LENGTH = 1024;
+const MAX_CANONICAL_HOST_LENGTH = 253;
+const FORBIDDEN_HOST_SYNTAX = /[\\/:@?#%\[\]]/u;
+const UNSAFE_HOST_UNICODE = /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u;
+const CANONICAL_DNS_HOST = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/;
+
+export class IntegrationApiHostValidationError extends Error {}
+
+/**
+ * Convert a user-supplied DNS hostname to the representation used by URL.hostname:
+ * lowercase ASCII with IDNs encoded as punycode. A single DNS root dot is accepted
+ * and removed so equivalent URL spellings compare consistently.
+ */
+export function canonicalizeIntegrationApiHost(value: string, name = 'API host'): string {
+  if (typeof value !== 'string' || value === '' || value.length > MAX_HOST_INPUT_LENGTH) {
+    throw invalidHost(name);
+  }
+  if (value.trim() !== value || UNSAFE_HOST_UNICODE.test(value) || FORBIDDEN_HOST_SYNTAX.test(value)) {
+    throw invalidHost(name);
+  }
+
+  const withoutRootDot = value.endsWith('.') ? value.slice(0, -1) : value;
+  if (withoutRootDot === '' || withoutRootDot.endsWith('.')) {
+    throw invalidHost(name);
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(`https://${withoutRootDot}/`);
+  } catch {
+    throw invalidHost(name);
+  }
+
+  if (parsed.username || parsed.password || parsed.port || parsed.pathname !== '/' || parsed.search || parsed.hash) {
+    throw invalidHost(name);
+  }
+
+  const canonical = parsed.hostname;
+  if (canonical.length === 0 || canonical.length > MAX_CANONICAL_HOST_LENGTH ||
+      !CANONICAL_DNS_HOST.test(canonical) || isIP(canonical) !== 0 || isPrivateDnsName(canonical)) {
+    throw new IntegrationApiHostValidationError(`${name} must be a public DNS hostname`);
+  }
+  return canonical;
+}
+
+/** Canonicalize and de-duplicate a descriptor host list while preserving order. */
+export function canonicalizeIntegrationApiHosts(
+  values: readonly string[],
+  name = 'apiHosts',
+): readonly string[] {
+  if (!Array.isArray(values) || values.length === 0 || values.length > 25) {
+    throw new IntegrationApiHostValidationError(`${name} must contain 1-25 hosts`);
+  }
+  const canonical: string[] = [];
+  const seen = new Set<string>();
+  for (const [index, value] of values.entries()) {
+    const host = canonicalizeIntegrationApiHost(value, `${name}[${index}]`);
+    if (!seen.has(host)) {
+      seen.add(host);
+      canonical.push(host);
+    }
+  }
+  return canonical;
+}
+
+/** Compare a URL parser hostname against a canonical descriptor allowlist. */
+export function isIntegrationApiHostAllowed(
+  hostname: string,
+  canonicalAllowedHosts: readonly string[],
+): boolean {
+  try {
+    return canonicalAllowedHosts.includes(canonicalizeIntegrationApiHost(hostname));
+  } catch (error) {
+    if (error instanceof IntegrationApiHostValidationError) return false;
+    throw error;
+  }
+}
+
+function isPrivateDnsName(hostname: string): boolean {
+  return !hostname.includes('.') ||
+    hostname === 'localhost' ||
+    hostname.endsWith('.localhost') ||
+    hostname.endsWith('.local') ||
+    hostname.endsWith('.internal');
+}
+
+function invalidHost(name: string): IntegrationApiHostValidationError {
+  return new IntegrationApiHostValidationError(
+    `${name} must be a hostname without a scheme, credentials, port, path, query, or fragment`,
+  );
+}

--- a/src/web-console/security/index.ts
+++ b/src/web-console/security/index.ts
@@ -1,2 +1,3 @@
 export * from './ConsoleOpaqueValues.js';
+export * from './IntegrationApiHosts.js';
 export * from './SecretEncryption.js';

--- a/src/web-console/stores/IIntegrationDescriptorStore.ts
+++ b/src/web-console/stores/IIntegrationDescriptorStore.ts
@@ -1,5 +1,3 @@
-import { isIP } from 'node:net';
-
 import {
   ConsoleStoreValidationError,
   assertDisplayString,
@@ -13,6 +11,11 @@ import {
   assertUserIntegrationProvider,
   type UserIntegrationProvider,
 } from './IUserIntegrationStore.js';
+import {
+  canonicalizeIntegrationApiHost,
+  canonicalizeIntegrationApiHosts,
+  IntegrationApiHostValidationError,
+} from '../security/IntegrationApiHosts.js';
 
 export type IntegrationDescriptorOwnership = 'curated' | 'byo';
 export type IntegrationAuthStrategy = 'oauth2_authorization_code' | 'static_api_key' | 'coded';
@@ -334,14 +337,17 @@ function validateStaticApiKeyDescriptor(staticApiKey: IntegrationStaticApiKeyDes
 }
 
 function validateApiHosts(hosts: readonly string[]): void {
-  if (!Array.isArray(hosts) || hosts.length === 0 || hosts.length > 25) {
-    throw new ConsoleStoreValidationError('apiHosts must contain 1-25 hosts');
-  }
-  const seen = new Set<string>();
-  for (const host of hosts) {
-    validatePublicDnsHost(host, 'apiHosts entry');
-    if (seen.has(host)) throw new ConsoleStoreValidationError('apiHosts must not contain duplicates');
-    seen.add(host);
+  try {
+    const canonical = canonicalizeIntegrationApiHosts(hosts);
+    if (canonical.length !== hosts.length || canonical.some((host, index) => host !== hosts[index])) {
+      throw new ConsoleStoreValidationError('apiHosts must contain unique canonical hostnames');
+    }
+  } catch (error) {
+    if (error instanceof ConsoleStoreValidationError) throw error;
+    if (error instanceof IntegrationApiHostValidationError) {
+      throw new ConsoleStoreValidationError(error.message);
+    }
+    throw error;
   }
 }
 
@@ -368,19 +374,17 @@ function validatePublicHttpsUrl(value: string, name: string): void {
 }
 
 function validatePublicDnsHost(host: string, name: string): void {
-  const normalized = host.toLowerCase();
-  if (host !== normalized) throw new ConsoleStoreValidationError(`${name} must be lowercase`);
-  assertDisplayString(normalized, name, 253);
-  if (!normalized.includes('.') ||
-      normalized === 'localhost' ||
-      normalized.endsWith('.localhost') ||
-      normalized.endsWith('.local') ||
-      normalized.endsWith('.internal') ||
-      isIP(normalized) !== 0) {
-    throw new ConsoleStoreValidationError(`${name} must be a public DNS hostname`);
-  }
-  if (!/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/.test(normalized)) {
-    throw new ConsoleStoreValidationError(`${name} must be a valid DNS hostname`);
+  try {
+    const canonical = canonicalizeIntegrationApiHost(host, name);
+    if (host !== canonical) {
+      throw new ConsoleStoreValidationError(`${name} must use its canonical hostname`);
+    }
+  } catch (error) {
+    if (error instanceof ConsoleStoreValidationError) throw error;
+    if (error instanceof IntegrationApiHostValidationError) {
+      throw new ConsoleStoreValidationError(error.message);
+    }
+    throw error;
   }
 }
 

--- a/src/web-console/stores/IIntegrationDescriptorStore.ts
+++ b/src/web-console/stores/IIntegrationDescriptorStore.ts
@@ -187,7 +187,10 @@ export function isAfterDescriptorPageCursor(
 
 export function validateIntegrationDescriptorRecord(record: IntegrationDescriptorRecord): void {
   assertUuid(record.id, 'id');
-  validateIntegrationDescriptorShape(record);
+  // Rows written before #2494 may contain private suffixes that were valid at
+  // the time. Keep them readable so one row cannot break list/provider reads;
+  // runtime allowlist checks still reject egress and every new write is strict.
+  validateIntegrationDescriptorShape(record, true);
 }
 
 export function validateIntegrationDescriptorInput(input: IntegrationDescriptorCreateInput): void {
@@ -207,7 +210,7 @@ export function validateIntegrationDescriptorInput(input: IntegrationDescriptorC
     operationPromotion: input.operationPromotion ?? {},
     createdAt: input.createdAt,
     updatedAt: input.updatedAt,
-  });
+  }, false);
 }
 
 export function cloneIntegrationDescriptorRecord(
@@ -241,6 +244,7 @@ const RESERVED_DESCRIPTOR_PROVIDER_IDS = new Set(['descriptors', 'github']);
 
 function validateIntegrationDescriptorShape(
   record: Omit<IntegrationDescriptorRecord, 'id'> & { readonly id?: string },
+  allowLegacyPrivateSuffixes: boolean,
 ): void {
   assertUserIntegrationProvider(record.provider);
   if (RESERVED_DESCRIPTOR_PROVIDER_IDS.has(record.provider)) {
@@ -261,8 +265,8 @@ function validateIntegrationDescriptorShape(
   }
   assertDisplayString(record.displayName, 'displayName', 120);
   assertDisplayString(record.category, 'category', 80);
-  validateAuthStrategy(record);
-  validateApiHosts(record.apiHosts);
+  validateAuthStrategy(record, allowLegacyPrivateSuffixes);
+  validateApiHosts(record.apiHosts, allowLegacyPrivateSuffixes);
   validateOptionalCredential(record.clientSecretCiphertext, record.credentialKeyVersion);
   validateJsonRecord(record.operationPromotion, 'operationPromotion', 8192);
   if (record.updatedAt < record.createdAt) {
@@ -273,12 +277,12 @@ function validateIntegrationDescriptorShape(
 function validateAuthStrategy(record: Pick<
   IntegrationDescriptorRecord,
   'authStrategy' | 'oauth' | 'staticApiKey' | 'clientSecretCiphertext'
->): void {
+>, allowLegacyPrivateSuffixes: boolean): void {
   switch (record.authStrategy) {
     case 'oauth2_authorization_code':
       if (!record.oauth) throw new ConsoleStoreValidationError('oauth descriptor is required');
       if (record.staticApiKey) throw new ConsoleStoreValidationError('oauth descriptor cannot include staticApiKey');
-      validateOAuthDescriptor(record.oauth);
+      validateOAuthDescriptor(record.oauth, allowLegacyPrivateSuffixes);
       return;
     case 'static_api_key':
       if (!record.staticApiKey) throw new ConsoleStoreValidationError('staticApiKey descriptor is required');
@@ -295,10 +299,10 @@ function validateAuthStrategy(record: Pick<
   }
 }
 
-function validateOAuthDescriptor(oauth: IntegrationOAuthDescriptor): void {
+function validateOAuthDescriptor(oauth: IntegrationOAuthDescriptor, allowLegacyPrivateSuffixes: boolean): void {
   assertDisplayString(oauth.clientId, 'oauth.clientId', 200);
-  validatePublicHttpsUrl(oauth.authorizationUrl, 'oauth.authorizationUrl');
-  validatePublicHttpsUrl(oauth.tokenUrl, 'oauth.tokenUrl');
+  validatePublicHttpsUrl(oauth.authorizationUrl, 'oauth.authorizationUrl', allowLegacyPrivateSuffixes);
+  validatePublicHttpsUrl(oauth.tokenUrl, 'oauth.tokenUrl', allowLegacyPrivateSuffixes);
   const pkce: string = oauth.pkce;
   if (pkce !== 'required' && pkce !== 'supported' && pkce !== 'unsupported') {
     throw new ConsoleStoreValidationError('oauth.pkce must be required, supported, or unsupported');
@@ -336,9 +340,9 @@ function validateStaticApiKeyDescriptor(staticApiKey: IntegrationStaticApiKeyDes
   }
 }
 
-function validateApiHosts(hosts: readonly string[]): void {
+function validateApiHosts(hosts: readonly string[], allowLegacyPrivateSuffixes: boolean): void {
   try {
-    const canonical = canonicalizeIntegrationApiHosts(hosts);
+    const canonical = canonicalizeIntegrationApiHosts(hosts, 'apiHosts', { allowLegacyPrivateSuffixes });
     if (canonical.length !== hosts.length || canonical.some((host, index) => host !== hosts[index])) {
       throw new ConsoleStoreValidationError('apiHosts must contain unique canonical hostnames');
     }
@@ -359,7 +363,7 @@ function validateOptionalCredential(ciphertext: Buffer | null, keyVersion: strin
   }
 }
 
-function validatePublicHttpsUrl(value: string, name: string): void {
+function validatePublicHttpsUrl(value: string, name: string, allowLegacyPrivateSuffixes: boolean): void {
   let url;
   try {
     url = new URL(value);
@@ -370,12 +374,12 @@ function validatePublicHttpsUrl(value: string, name: string): void {
   if (url.username || url.password || url.hash) {
     throw new ConsoleStoreValidationError(`${name} must not include credentials or fragments`);
   }
-  validatePublicDnsHost(url.hostname, name);
+  validatePublicDnsHost(url.hostname, name, allowLegacyPrivateSuffixes);
 }
 
-function validatePublicDnsHost(host: string, name: string): void {
+function validatePublicDnsHost(host: string, name: string, allowLegacyPrivateSuffixes: boolean): void {
   try {
-    const canonical = canonicalizeIntegrationApiHost(host, name);
+    const canonical = canonicalizeIntegrationApiHost(host, name, { allowLegacyPrivateSuffixes });
     if (host !== canonical) {
       throw new ConsoleStoreValidationError(`${name} must use its canonical hostname`);
     }

--- a/src/web-console/ui/integration-descriptors.js
+++ b/src/web-console/ui/integration-descriptors.js
@@ -139,7 +139,7 @@ function renderEditor(manager) {
             ${field('Category', 'category', descriptor?.category ?? '', 'Example: Project management', true)}
             ${field('Allowed API hosts', 'api_hosts', descriptor?.api_hosts?.join(', ') ?? '', 'api.example.com, uploads.example.com', true)}
           </div>
-          <p class="int-field-help">Provider IDs use lowercase letters, numbers, and hyphens. Hosts must be exact API hostnames; URLs and paths are not accepted.</p>
+          <p class="int-field-help">Provider IDs use lowercase letters, numbers, and hyphens. Hosts must be exact API hostnames; URLs and paths are not accepted. Saved hosts are shown as lowercase ASCII, with international domains displayed as punycode.</p>
         </section>
         <section class="int-form-section">
           <h3>Authentication</h3>

--- a/tests/unit/web-console/modules/ConfiguredOAuthIntegrationProvider.test.ts
+++ b/tests/unit/web-console/modules/ConfiguredOAuthIntegrationProvider.test.ts
@@ -47,6 +47,7 @@ function lookupReturning(address: string): DnsLookup {
 function providerWith(input: {
   readonly dnsLookup: DnsLookup;
   readonly fetch?: PinnedFetch;
+  readonly descriptor?: IntegrationDescriptorRecord;
 }): {
   readonly provider: ConfiguredOAuthIntegrationProvider;
   readonly factory: jest.Mock;
@@ -73,7 +74,7 @@ function providerWith(input: {
     return { fetch: fetchImpl, close: () => Promise.resolve() };
   });
   const provider = new ConfiguredOAuthIntegrationProvider({
-    descriptor: descriptor(),
+    descriptor: input.descriptor ?? descriptor(),
     clientSecret: 'gmail-client-secret',
     pinnedOutbound: factory as unknown as PinnedOutboundFactory,
     dnsLookup: input.dnsLookup,
@@ -91,6 +92,43 @@ const EXCHANGE_REQUEST = {
 };
 
 describe('ConfiguredOAuthIntegrationProvider token-endpoint host guard', () => {
+  it.each([
+    ['token exchange', 'exchange'],
+    ['token refresh', 'refresh'],
+    ['token revocation', 'revoke'],
+  ] as const)('rejects a legacy private-suffix host before DNS or %s egress', async (_label, operation) => {
+    const restrictedHost = 'auth.company.corp';
+    const base = descriptor();
+    if (!base.oauth) throw new Error('fixture oauth missing');
+    const restrictedDescriptor: IntegrationDescriptorRecord = {
+      ...base,
+      oauth: {
+        ...base.oauth,
+        tokenUrl: operation === 'revoke'
+          ? base.oauth.tokenUrl
+          : `https://${restrictedHost}/oauth/token`,
+        tokenExchange: operation === 'revoke'
+          ? { ...base.oauth.tokenExchange, revocationUrl: `https://${restrictedHost}/oauth/revoke` }
+          : base.oauth.tokenExchange,
+      },
+    };
+    const lookup = jest.fn(lookupReturning(PUBLIC_ADDRESS));
+    const { provider, factory } = providerWith({
+      descriptor: restrictedDescriptor,
+      dnsLookup: lookup,
+    });
+
+    const request = operation === 'exchange'
+      ? provider.exchangeAuthorizationCode(EXCHANGE_REQUEST)
+      : operation === 'refresh'
+        ? provider.refreshCredentials({ refreshToken: 'refresh-token' })
+        : provider.revokeCredentials({ accessToken: 'access-token' });
+
+    await expect(request).rejects.toThrow('configured_oauth_endpoint_not_allowed');
+    expect(lookup).not.toHaveBeenCalled();
+    expect(factory).not.toHaveBeenCalled();
+  });
+
   it('fails closed on token exchange when tokenUrl resolves to a private address, before any secret is sent', async () => {
     const { provider, factory } = providerWith({ dnsLookup: lookupReturning(PRIVATE_ADDRESS) });
     await expect(provider.exchangeAuthorizationCode(EXCHANGE_REQUEST))

--- a/tests/unit/web-console/modules/IntegrationDescriptorAuthoring.test.ts
+++ b/tests/unit/web-console/modules/IntegrationDescriptorAuthoring.test.ts
@@ -189,6 +189,41 @@ describe('IntegrationDescriptorAuthoringService', () => {
     });
   });
 
+  it('persists and returns canonical de-duplicated API hosts', async () => {
+    const { service, descriptorStore } = fixture();
+
+    const result = await service.create(consoleRequest({
+      body: oauthBody({
+        api_hosts: [
+          'API.MyCRM.Example',
+          'api.mycrm.example.',
+          'bücher.example',
+          'xn--bcher-kva.example',
+        ],
+      }),
+    }));
+
+    expect(result.status).toBe(201);
+    expect(bodyOf(result).api_hosts).toEqual(['api.mycrm.example', 'xn--bcher-kva.example']);
+    const stored = await descriptorStore.findById(bodyOf(result).id as string, USER_ID);
+    expect(stored?.apiHosts).toEqual(['api.mycrm.example', 'xn--bcher-kva.example']);
+  });
+
+  it.each([
+    'https://api.mycrm.example',
+    'user@api.mycrm.example',
+    'api.mycrm.example:443',
+    'api.mycrm.example/path',
+    'api\u200B.mycrm.example',
+  ])('rejects API host syntax that is not a bare hostname: %s', async apiHost => {
+    const { service } = fixture();
+
+    const result = await service.create(consoleRequest({ body: oauthBody({ api_hosts: [apiHost] }) }));
+
+    expect(result.status).toBe(422);
+    expect(String(bodyOf(result).detail)).toContain('must be a hostname');
+  });
+
   it('rejects provider ids colliding with any visible descriptor', async () => {
     const { service } = fixture();
     await service.create(consoleRequest({ body: oauthBody() }));

--- a/tests/unit/web-console/modules/IntegrationDescriptorSeedLoader.test.ts
+++ b/tests/unit/web-console/modules/IntegrationDescriptorSeedLoader.test.ts
@@ -141,6 +141,51 @@ describe('IntegrationDescriptorSeedLoader', () => {
     expect(record?.clientSecretCiphertext).toBeNull();
   });
 
+  it('canonicalizes curated API hosts before persistence', async () => {
+    const dir = await seedDirWith({
+      'examplekey.json': {
+        ...STATIC_SEED,
+        apiHosts: ['API.ExampleKey.Test.', 'api.examplekey.test'],
+      },
+    });
+    const store = new InMemoryIntegrationDescriptorStore();
+    const loader = new IntegrationDescriptorSeedLoader(
+      dir,
+      store,
+      newEncryption(),
+      credentials({}),
+      { now: () => FIXED_NOW },
+    );
+
+    const result = await loader.loadSeeds();
+
+    expect(result).toMatchObject({ loaded: 1, failed: 0 });
+    const record = await store.findVisibleByProvider(VISIBLE_USER, 'examplekey');
+    expect(record?.apiHosts).toEqual(['api.examplekey.test']);
+  });
+
+  it('fails a curated seed instead of silently dropping non-string host entries', async () => {
+    const dir = await seedDirWith({
+      'examplekey.json': {
+        ...STATIC_SEED,
+        apiHosts: [42, 'api.examplekey.test'],
+      },
+    });
+    const store = new InMemoryIntegrationDescriptorStore();
+    const loader = new IntegrationDescriptorSeedLoader(
+      dir,
+      store,
+      newEncryption(),
+      credentials({}),
+      { now: () => FIXED_NOW },
+    );
+
+    const result = await loader.loadSeeds();
+
+    expect(result).toMatchObject({ loaded: 0, failed: 1 });
+    expect(await store.findVisibleByProvider(VISIBLE_USER, 'examplekey')).toBeNull();
+  });
+
   it('skips the reserved github provider id', async () => {
     const dir = await seedDirWith({ 'github.json': { ...OAUTH_SEED, provider: 'github' } });
     const store = new InMemoryIntegrationDescriptorStore();

--- a/tests/unit/web-console/modules/IntegrationOperationCatalog.test.ts
+++ b/tests/unit/web-console/modules/IntegrationOperationCatalog.test.ts
@@ -307,6 +307,27 @@ describe('IntegrationOperationCatalog', () => {
     }))).rejects.toMatchObject({ code: 'invalid_openapi_spec' });
   });
 
+  it('accepts an equivalent canonical spelling of an allowlisted OpenAPI server host', async () => {
+    const { catalog, contextTracker } = createCatalog({
+      descriptor: descriptor({
+        ownership: 'byo',
+        ownerUserId: USER_ID,
+        apiHosts: ['gmail.googleapis.com'],
+      }),
+      scopes: [GMAIL_READONLY],
+    });
+
+    const result = await runAsUser(contextTracker, () => catalog.ingestOpenApiSpec({
+      provider: 'gmail',
+      spec: {
+        ...openApiSpec(),
+        servers: [{ url: 'https://GMAIL.GOOGLEAPIS.COM./' }],
+      },
+    }));
+
+    expect(result.operationCount).toBeGreaterThan(0);
+  });
+
   it('rejects specs nested past the external-ref scan depth instead of skipping the check', async () => {
     const { catalog, contextTracker } = createCatalog({
       descriptor: descriptor({ ownership: 'byo', ownerUserId: USER_ID }),

--- a/tests/unit/web-console/modules/IntegrationRemoteMcpBridge.test.ts
+++ b/tests/unit/web-console/modules/IntegrationRemoteMcpBridge.test.ts
@@ -57,6 +57,34 @@ describe('IntegrationRemoteMcpBridge', () => {
     }]);
   });
 
+  it('accepts an equivalent canonical spelling of an allowlisted remote MCP host', async () => {
+    const clientFactory = jest.fn<RemoteMcpClientFactory>().mockResolvedValue({
+      listTools: jest.fn().mockResolvedValue({
+        tools: [{ name: 'search', description: 'Search', inputSchema: { type: 'object', properties: {} } }],
+      }),
+      callTool: jest.fn(),
+      close: jest.fn(() => Promise.resolve()),
+    });
+    const { bridge, contextTracker } = fixture({
+      clientFactory,
+      descriptor: descriptor({
+        operationPromotion: {
+          remoteMcp: {
+            serverUrl: 'https://MCP.EXAMPLE.COM./mcp',
+            tools: ['search'],
+          },
+        },
+      }),
+    });
+
+    const tools = await runAsUser(contextTracker, () => bridge.listAllowedTools());
+
+    expect(tools).toHaveLength(1);
+    expect(clientFactory).toHaveBeenCalledWith(expect.objectContaining({
+      serverUrl: new URL('https://mcp.example.com./mcp'),
+    }));
+  });
+
   it('skips discovery for providers the discovery gate refuses, before any credential use', async () => {
     const clientFactory = jest.fn<RemoteMcpClientFactory>();
     const discoveryGate = jest.fn<(provider: string) => Promise<boolean>>().mockResolvedValue(false);

--- a/tests/unit/web-console/security/IntegrationApiHosts.test.ts
+++ b/tests/unit/web-console/security/IntegrationApiHosts.test.ts
@@ -58,11 +58,25 @@ describe('IntegrationApiHosts', () => {
     'api.localhost',
     'service.local',
     'service.internal',
+    'router.home.arpa',
+    'service.corp',
+    'service.home',
+    'service.lan',
     '127.0.0.1',
     '[::1]',
     'singlelabel',
   ])('rejects non-public host %s', input => {
     expect(() => canonicalizeIntegrationApiHost(input)).toThrow(/public DNS hostname|must be a hostname/);
+  });
+
+  it('accepts the DNS maximum and rejects a hostname beyond it', () => {
+    const atLimit = [63, 63, 63, 61].map(length => 'a'.repeat(length)).join('.');
+    const beyondLimit = [63, 63, 63, 62].map(length => 'a'.repeat(length)).join('.');
+
+    expect(atLimit).toHaveLength(253);
+    expect(canonicalizeIntegrationApiHost(atLimit)).toBe(atLimit);
+    expect(beyondLimit).toHaveLength(254);
+    expect(() => canonicalizeIntegrationApiHost(beyondLimit)).toThrow('must be a public DNS hostname');
   });
 
   it('requires a bounded non-empty source list even when entries would deduplicate', () => {

--- a/tests/unit/web-console/security/IntegrationApiHosts.test.ts
+++ b/tests/unit/web-console/security/IntegrationApiHosts.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  canonicalizeIntegrationApiHost,
+  canonicalizeIntegrationApiHosts,
+  IntegrationApiHostValidationError,
+  isIntegrationApiHostAllowed,
+} from '../../../../src/web-console/security/IntegrationApiHosts.js';
+
+describe('IntegrationApiHosts', () => {
+  it.each([
+    ['API.Example.COM', 'api.example.com'],
+    ['api.example.com.', 'api.example.com'],
+    ['bücher.example', 'xn--bcher-kva.example'],
+    ['api．example.com', 'api.example.com'],
+    ['аpi.example.com', 'xn--pi-6kc.example.com'],
+  ])('canonicalizes %s to an unambiguous hostname', (input, expected) => {
+    expect(canonicalizeIntegrationApiHost(input)).toBe(expected);
+  });
+
+  it('deduplicates equivalent canonical hosts while preserving first-seen order', () => {
+    expect(canonicalizeIntegrationApiHosts([
+      'API.Example.COM',
+      'api.example.com.',
+      'bücher.example',
+      'xn--bcher-kva.example',
+      'uploads.example.com',
+    ])).toEqual([
+      'api.example.com',
+      'xn--bcher-kva.example',
+      'uploads.example.com',
+    ]);
+  });
+
+  it.each([
+    '',
+    ' api.example.com',
+    'api.example.com ',
+    'https://api.example.com',
+    'user@api.example.com',
+    'api.example.com:443',
+    'api.example.com/path',
+    'api.example.com?debug=true',
+    'api.example.com#fragment',
+    'api.example.com\\path',
+    '%61pi.example.com',
+    'api..example.com',
+    'api.example.com..',
+    'api_example.com',
+    'api\u200B.example.com',
+    'api\u202E.example.com',
+  ])('rejects malformed or visually unsafe host %j', input => {
+    expect(() => canonicalizeIntegrationApiHost(input)).toThrow(IntegrationApiHostValidationError);
+  });
+
+  it.each([
+    'localhost',
+    'api.localhost',
+    'service.local',
+    'service.internal',
+    '127.0.0.1',
+    '[::1]',
+    'singlelabel',
+  ])('rejects non-public host %s', input => {
+    expect(() => canonicalizeIntegrationApiHost(input)).toThrow(/public DNS hostname|must be a hostname/);
+  });
+
+  it('requires a bounded non-empty source list even when entries would deduplicate', () => {
+    expect(() => canonicalizeIntegrationApiHosts([])).toThrow('must contain 1-25 hosts');
+    expect(() => canonicalizeIntegrationApiHosts(Array.from({ length: 26 }, () => 'api.example.com')))
+      .toThrow('must contain 1-25 hosts');
+  });
+
+  it('matches equivalent URL hostname spellings against canonical allowlists', () => {
+    expect(isIntegrationApiHostAllowed('API.Example.COM.', ['api.example.com'])).toBe(true);
+    expect(isIntegrationApiHostAllowed('bücher.example.', ['xn--bcher-kva.example'])).toBe(true);
+    expect(isIntegrationApiHostAllowed('other.example.com', ['api.example.com'])).toBe(false);
+    expect(isIntegrationApiHostAllowed('localhost', ['api.example.com'])).toBe(false);
+  });
+});

--- a/tests/unit/web-console/security/IntegrationApiHosts.test.ts
+++ b/tests/unit/web-console/security/IntegrationApiHosts.test.ts
@@ -91,4 +91,14 @@ describe('IntegrationApiHosts', () => {
     expect(isIntegrationApiHostAllowed('other.example.com', ['api.example.com'])).toBe(false);
     expect(isIntegrationApiHostAllowed('localhost', ['api.example.com'])).toBe(false);
   });
+
+  it('keeps legacy private-suffix compatibility read-only and blocks runtime egress', () => {
+    expect(canonicalizeIntegrationApiHost(
+      'api.company.corp',
+      'legacy api host',
+      { allowLegacyPrivateSuffixes: true },
+    )).toBe('api.company.corp');
+    expect(() => canonicalizeIntegrationApiHost('api.company.corp')).toThrow('public DNS hostname');
+    expect(isIntegrationApiHostAllowed('api.company.corp', ['api.company.corp'])).toBe(false);
+  });
 });

--- a/tests/unit/web-console/stores/ConsoleSecurityStores.test.ts
+++ b/tests/unit/web-console/stores/ConsoleSecurityStores.test.ts
@@ -718,6 +718,9 @@ describe('InMemoryIntegrationDescriptorStore', () => {
       apiHosts: ['localhost'],
     }))).rejects.toThrow(ConsoleStoreValidationError);
     await expect(store.upsert(oauthDescriptorInput({
+      apiHosts: ['api.company.corp'],
+    }))).rejects.toThrow(ConsoleStoreValidationError);
+    await expect(store.upsert(oauthDescriptorInput({
       apiHosts: ['API.Example.com'],
     }))).rejects.toThrow('apiHosts must contain unique canonical hostnames');
     await expect(store.upsert(oauthDescriptorInput({
@@ -750,6 +753,28 @@ describe('InMemoryIntegrationDescriptorStore', () => {
       createdAt: NOW,
       updatedAt: NOW,
     })).resolves.toMatchObject({ provider: 'airtable' });
+  });
+
+  it('keeps legacy private-suffix descriptors readable without permitting new writes', async () => {
+    const base = oauthDescriptorInput();
+    if (!base.oauth) throw new Error('fixture oauth missing');
+    const legacyRecord = {
+      id: DESCRIPTOR_ID,
+      ...base,
+      apiHosts: ['api.company.corp'],
+      oauth: {
+        ...base.oauth,
+        authorizationUrl: 'https://auth.company.corp/authorize',
+        tokenUrl: 'https://auth.company.corp/token',
+      },
+    };
+    const store = new InMemoryIntegrationDescriptorStore([legacyRecord]);
+
+    await expect(store.listVisible(USER_ID)).resolves.toEqual([
+      expect.objectContaining({ id: DESCRIPTOR_ID, apiHosts: ['api.company.corp'] }),
+    ]);
+    await expect(store.upsert({ ...base, apiHosts: ['api.company.corp'] }))
+      .rejects.toThrow(ConsoleStoreValidationError);
   });
 
   it('validates basic static-key injection: fixed Authorization header, no prefix', async () => {

--- a/tests/unit/web-console/stores/ConsoleSecurityStores.test.ts
+++ b/tests/unit/web-console/stores/ConsoleSecurityStores.test.ts
@@ -717,6 +717,12 @@ describe('InMemoryIntegrationDescriptorStore', () => {
     await expect(store.upsert(oauthDescriptorInput({
       apiHosts: ['localhost'],
     }))).rejects.toThrow(ConsoleStoreValidationError);
+    await expect(store.upsert(oauthDescriptorInput({
+      apiHosts: ['API.Example.com'],
+    }))).rejects.toThrow('apiHosts must contain unique canonical hostnames');
+    await expect(store.upsert(oauthDescriptorInput({
+      apiHosts: ['api.example.com', 'api.example.com'],
+    }))).rejects.toThrow('apiHosts must contain unique canonical hostnames');
     const baseOauth = oauthDescriptorInput().oauth;
     if (!baseOauth) throw new Error('fixture oauth missing');
     await expect(store.upsert(oauthDescriptorInput({

--- a/tests/unit/web-console/stores/PostgresConsoleStores.test.ts
+++ b/tests/unit/web-console/stores/PostgresConsoleStores.test.ts
@@ -841,6 +841,23 @@ describe('PostgresIntegrationDescriptorStore', () => {
     expect(row.clientSecretCiphertext).toEqual(Buffer.from('encrypted-client-secret'));
   });
 
+  it('keeps descriptors with legacy private suffixes readable after host hardening', async () => {
+    const row = integrationDescriptorRow({
+      apiHosts: ['api.company.corp'],
+      oauth: {
+        ...integrationDescriptorRow().oauth as Record<string, unknown>,
+        authorizationUrl: 'https://auth.company.corp/authorize',
+        tokenUrl: 'https://auth.company.corp/token',
+      },
+    });
+    transaction.select = jest.fn(() => selectingChain([row]));
+    const store = new PostgresIntegrationDescriptorStore({} as DatabaseInstance);
+
+    await expect(store.listVisible(USER_ID)).resolves.toEqual([
+      expect.objectContaining({ id: DESCRIPTOR_ID, apiHosts: ['api.company.corp'] }),
+    ]);
+  });
+
   it('paginates visible descriptors and encodes the next (provider, id) cursor', async () => {
     const rows = [
       integrationDescriptorRow({ provider: 'svc-a', id: '00000000-0000-4000-8000-0000000000a1' }),


### PR DESCRIPTION
## Summary

- canonicalize descriptor API hosts to lowercase ASCII/punycode with one documented trailing-root-dot policy
- reject schemes, credentials, ports, paths, queries, fragments, percent encoding, unsafe control/format characters, malformed DNS labels, IP literals, and private/local DNS names
- de-duplicate canonically equivalent hosts before persistence while requiring the storage boundary itself to contain only unique canonical values
- compare canonical URL hostnames in OpenAPI ingestion, the authorized request gateway, and the remote-MCP bridge
- fail curated seed loading when host or scope arrays contain mixed non-string entries instead of silently truncating them
- keep descriptors written before this hardening readable while quarantining newly restricted private suffixes from new writes and runtime egress
- explain the canonical display form in the custom-integration authoring UI

## Canonical form

Persisted `apiHosts` values are lowercase ASCII hostnames. WHATWG URL/IDNA processing converts internationalized names to punycode. A single trailing DNS root dot is accepted at authoring and comparison boundaries but removed before persistence, so equivalent spellings cannot miss or bypass the allowlist.

## Security behavior

- authoring and curated seed ingestion share one parser
- the store rejects non-canonical or duplicate records even if a caller bypasses authoring
- outbound checks fail closed when a URL hostname cannot be canonicalized as a public DNS hostname
- legacy rows using newly restricted private suffixes remain inspectable for migration, but cannot authorize outbound requests
- OAuth code exchange, token refresh, and revocation apply strict host policy before DNS resolution or credential-bearing egress
- Unicode lookalikes remain visibly distinct in persisted/API/UI output because they are rendered as punycode
- existing valid lowercase ASCII descriptors remain unchanged

## Validation

- production TypeScript build and runtime asset assembly
- repository-wide lint
- 279 focused integration/security/store tests
- canonical parser coverage for case, trailing dots, IDNs, Unicode dot variants, confusables, malformed syntax, private names, limits, and canonical collisions
- OpenAPI and remote-MCP routing regressions for equivalent host spellings
- Postgres and in-memory regressions for readable legacy descriptors, strict new writes, and blocked legacy-host egress
- OAuth regressions prove restricted legacy endpoints are rejected before DNS or pinned transport creation, even if DNS would return a public address
- critical security suite: 108 passed, 46 skipped by the configured name filter
- custom security audit: 0 critical/high/medium findings (8 pre-existing low integration-logging notices)
- package runtime asset verification
- cross-platform suite: 29 passed
- artifact-dependent and timing-sensitive baseline tests rerun individually after build and passed

Closes #2494.

Merge-commit only; do not squash or rebase the hosted integration history.
