### PR TITLE
fix(deps): update nanoid to 5.1.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10300,9 +10300,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "5.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
-      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Updates the transitive `nanoid` used by `oidc-provider` from 5.1.11 to 5.1.16. This is an intentionally lockfile-only update because `oidc-provider@9.8.3` already declares a compatible `^5.1.7` range.

Part of #2488.

## Supply-chain review

- Candidate published 2026-06-24 and allowed to cool before adoption.
- Package has no runtime dependencies or lifecycle scripts.
- npm artifact includes registry signatures and SLSA provenance.
- Release tag resolves to the npm artifact git commit.
- No unrelated lockfile packages moved.

## Security effect

- Full-tree audit: 25 vulnerable packages -> 24.
- Runtime audit: 14 vulnerable packages -> 13.
- Removes one high-severity runtime finding.

## Verification

- `npm ci --ignore-scripts`
- `npm run build:safety`
- `tsc --noEmit`
- `npm run typecheck:scripts`
- Embedded authorization unit tests: 33 suites / 371 tests passed
- OAuth integration tests: 3 suites / 18 tests passed
- Custom security audit: 0 critical, high, or medium findings; 8 pre-existing low-confidence logging notices in untouched integration modules
- `npm ls nanoid --all` resolves only `nanoid@5.1.16` under `oidc-provider`

## Rollback

Revert this single lockfile-only commit to restore 5.1.11.