### PR TITLE
fix(deps): update nodemailer to 9.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "js-yaml": "^4.1.1",
         "jsdom": "^24.1.3",
         "node-fetch": "^3.3.2",
-        "nodemailer": "^8.0.7",
+        "nodemailer": "9.0.3",
         "oidc-provider": "^9.8.3",
         "otpauth": "^9.5.0",
         "postgres": "^3.4.9",
@@ -10422,9 +10422,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
-      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
     "js-yaml": "^4.1.1",
     "jsdom": "^24.1.3",
     "node-fetch": "^3.3.2",
-    "nodemailer": "^8.0.7",
+    "nodemailer": "9.0.3",
     "oidc-provider": "^9.8.3",
     "otpauth": "^9.5.0",
     "postgres": "^3.4.9",

--- a/src/auth/embedded-as/methods/nodemailerEmailSender.ts
+++ b/src/auth/embedded-as/methods/nodemailerEmailSender.ts
@@ -123,5 +123,9 @@ export class NodemailerEmailSender implements EmailSender {
 }
 
 function escapeHtmlAttr(value: string): string {
-  return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('<', '&lt;');
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
 }

--- a/tests/unit/auth/embedded-as/methods/nodemailerEmailSender.test.ts
+++ b/tests/unit/auth/embedded-as/methods/nodemailerEmailSender.test.ts
@@ -128,15 +128,15 @@ describe('NodemailerEmailSender — magic-link delivery', () => {
 
     await sender.sendMagicLink({
       to: 'user@example.com',
-      url: 'https://mcp.example/auth/email/verify?token=a&next=<done>',
+      url: 'https://mcp.example/auth/email/verify?token=a&next="<done>"',
     });
 
     expect(sendMail).toHaveBeenCalledWith(expect.objectContaining({
       from: 'from@example.com',
       to: 'user@example.com',
       subject: 'Sign in to DollhouseMCP',
-      text: expect.stringContaining('token=a&next=<done>'),
-      html: expect.stringContaining('token=a&amp;next=&lt;done>'),
+      text: expect.stringContaining('token=a&next="<done>"'),
+      html: expect.stringContaining('token=a&amp;next=&quot;&lt;done>&quot;'),
     }));
   });
 });

--- a/tests/unit/auth/embedded-as/methods/nodemailerEmailSender.test.ts
+++ b/tests/unit/auth/embedded-as/methods/nodemailerEmailSender.test.ts
@@ -109,12 +109,16 @@ describe('NodemailerEmailSender — verify() must-fix #10 startup gate', () => {
       connectionTimeoutMs: 500,
     });
 
-    await expect(sender.verify()).rejects.toThrow(/STARTTLS|implicit TLS|authenticate/);
+    const verification = sender.verify();
+    await expect(verification).rejects.toThrow('SMTP verify failed for 127.0.0.1:465');
+    await expect(verification).rejects.toThrow(
+      'Confirm the server supports STARTTLS (port 587) or implicit TLS (port 465)',
+    );
   }, 5_000);
 });
 
 describe('NodemailerEmailSender — magic-link delivery', () => {
-  it('passes the expected envelope and escaped HTML to Nodemailer', async () => {
+  function createSenderWithMockTransport() {
     const sender = new NodemailerEmailSender({
       host: 'smtp.example.com',
       port: 587,
@@ -125,6 +129,11 @@ describe('NodemailerEmailSender — magic-link delivery', () => {
     }).transporter;
     const sendMail = jest.fn(async (_message: unknown) => ({ messageId: 'test' }));
     transport.sendMail = sendMail;
+    return { sender, sendMail };
+  }
+
+  it('passes the expected envelope and escaped HTML to Nodemailer', async () => {
+    const { sender, sendMail } = createSenderWithMockTransport();
 
     await sender.sendMagicLink({
       to: 'user@example.com',
@@ -138,5 +147,26 @@ describe('NodemailerEmailSender — magic-link delivery', () => {
       text: expect.stringContaining('token=a&next="<done>"'),
       html: expect.stringContaining('token=a&amp;next=&quot;&lt;done>&quot;'),
     }));
+  });
+
+  it('accepts a magic-link URL at the 2048-character limit', async () => {
+    const { sender, sendMail } = createSenderWithMockTransport();
+
+    await sender.sendMagicLink({
+      to: 'user@example.com',
+      url: 'x'.repeat(2_048),
+    });
+
+    expect(sendMail).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a magic-link URL over 2048 characters before delivery', async () => {
+    const { sender, sendMail } = createSenderWithMockTransport();
+
+    await expect(sender.sendMagicLink({
+      to: 'user@example.com',
+      url: 'x'.repeat(2_049),
+    })).rejects.toThrow('magic-link URL exceeds 2048 chars (got 2049)');
+    expect(sendMail).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/auth/embedded-as/methods/nodemailerEmailSender.test.ts
+++ b/tests/unit/auth/embedded-as/methods/nodemailerEmailSender.test.ts
@@ -9,7 +9,7 @@
  * link configuration that silently never delivers email.
  */
 
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 import { NodemailerEmailSender } from '../../../../../src/auth/embedded-as/methods/nodemailerEmailSender.js';
 
 describe('NodemailerEmailSender — port enforcement', () => {
@@ -44,6 +44,46 @@ describe('NodemailerEmailSender — port enforcement', () => {
       user: 'u', password: 'p', from: 'from@example.com',
     })).not.toThrow();
   });
+
+  it('configures STARTTLS and all timeout phases on port 587', () => {
+    const sender = new NodemailerEmailSender({
+      host: 'smtp.example.com',
+      port: 587,
+      user: 'u', password: 'p', from: 'from@example.com',
+      connectionTimeoutMs: 1_234,
+    });
+    const { options } = (sender as unknown as {
+      transporter: { options: Record<string, unknown> };
+    }).transporter;
+
+    expect(options).toMatchObject({
+      host: 'smtp.example.com',
+      port: 587,
+      secure: false,
+      requireTLS: true,
+      auth: { user: 'u', pass: 'p' },
+      connectionTimeout: 1_234,
+      greetingTimeout: 1_234,
+      socketTimeout: 1_234,
+    });
+  });
+
+  it('configures implicit TLS without requiring STARTTLS on port 465', () => {
+    const sender = new NodemailerEmailSender({
+      host: 'smtp.example.com',
+      port: 465,
+      user: 'u', password: 'p', from: 'from@example.com',
+    });
+    const { options } = (sender as unknown as {
+      transporter: { options: Record<string, unknown> };
+    }).transporter;
+
+    expect(options).toMatchObject({
+      port: 465,
+      secure: true,
+      requireTLS: false,
+    });
+  });
 });
 
 describe('NodemailerEmailSender — verify() must-fix #10 startup gate', () => {
@@ -71,4 +111,32 @@ describe('NodemailerEmailSender — verify() must-fix #10 startup gate', () => {
 
     await expect(sender.verify()).rejects.toThrow(/STARTTLS|implicit TLS|authenticate/);
   }, 5_000);
+});
+
+describe('NodemailerEmailSender — magic-link delivery', () => {
+  it('passes the expected envelope and escaped HTML to Nodemailer', async () => {
+    const sender = new NodemailerEmailSender({
+      host: 'smtp.example.com',
+      port: 587,
+      user: 'u', password: 'p', from: 'from@example.com',
+    });
+    const transport = (sender as unknown as {
+      transporter: { sendMail: (message: unknown) => Promise<unknown> };
+    }).transporter;
+    const sendMail = jest.fn(async (_message: unknown) => ({ messageId: 'test' }));
+    transport.sendMail = sendMail;
+
+    await sender.sendMagicLink({
+      to: 'user@example.com',
+      url: 'https://mcp.example/auth/email/verify?token=a&next=<done>',
+    });
+
+    expect(sendMail).toHaveBeenCalledWith(expect.objectContaining({
+      from: 'from@example.com',
+      to: 'user@example.com',
+      subject: 'Sign in to DollhouseMCP',
+      text: expect.stringContaining('token=a&next=<done>'),
+      html: expect.stringContaining('token=a&amp;next=&lt;done>'),
+    }));
+  });
 });

--- a/tests/unit/auth/embedded-as/methods/nodemailerEmailSender.test.ts
+++ b/tests/unit/auth/embedded-as/methods/nodemailerEmailSender.test.ts
@@ -109,9 +109,13 @@ describe('NodemailerEmailSender — verify() must-fix #10 startup gate', () => {
       connectionTimeoutMs: 500,
     });
 
-    const verification = sender.verify();
-    await expect(verification).rejects.toThrow('SMTP verify failed for 127.0.0.1:465');
-    await expect(verification).rejects.toThrow(
+    const verificationError = await sender.verify().catch((error: unknown) => error);
+    expect(verificationError).toBeInstanceOf(Error);
+    if (!(verificationError instanceof Error)) {
+      throw new Error('Expected SMTP verification to reject with an Error');
+    }
+    expect(verificationError.message).toContain('SMTP verify failed for 127.0.0.1:465');
+    expect(verificationError.message).toContain(
       'Confirm the server supports STARTTLS (port 587) or implicit TLS (port 465)',
     );
   }, 5_000);
@@ -145,7 +149,7 @@ describe('NodemailerEmailSender — magic-link delivery', () => {
       to: 'user@example.com',
       subject: 'Sign in to DollhouseMCP',
       text: expect.stringContaining('token=a&next="<done>"'),
-      html: expect.stringContaining('token=a&amp;next=&quot;&lt;done>&quot;'),
+      html: expect.stringContaining('token=a&amp;next=&quot;&lt;done&gt;&quot;'),
     }));
   });
 


### PR DESCRIPTION
## Summary

Updates the direct runtime dependency `nodemailer` from 8.0.7 to an exact 9.0.3 pin. Adds focused regression coverage for STARTTLS/implicit TLS configuration, timeout propagation, delivery envelope fields, canonical HTML attribute escaping (`&`, `"`, `<`, and `>`), and the 2,048-character magic-link URL boundary.

Part of #2488. Closes #2511. Declaration-version monitoring is tracked in #2510.

## Supply-chain review

- Candidate published 2026-06-30 and allowed to cool before adoption.
- Package has no runtime dependencies or consumer lifecycle hooks.
- npm artifact includes registry signatures and SLSA provenance.
- Release tag resolves to the npm artifact git commit.
- Changes through 9.0.3 include STARTTLS, socket, parser/lifecycle, and proxy-injection hardening.
- Exact pin prevents an unreviewed future 9.x release from entering installs.
- No unrelated lockfile packages moved.

## Type compatibility

Nodemailer does not ship built-in declarations and there is currently no `@types/nodemailer@9`; 8.0.1 is the newest DefinitelyTyped release. Nodemailer 9 changes TLS validation behavior rather than the mailer API used here. TypeScript passes, and the focused tests inspect the constructed runtime transport to verify every SMTP option DollhouseMCP relies upon. Future declaration updates are tracked in #2510.

## Security effect

- Full-tree audit: 25 vulnerable packages -> 24.
- Runtime audit: 14 vulnerable packages -> 13.
- Removes one high-severity runtime finding.

## Verification

- `npm ci --ignore-scripts`
- `npm run build:safety`
- `tsc --noEmit`
- `npm run typecheck:scripts`
- Nodemailer focused unit tests: 11 tests passed
- Existing mail/auth unit tests: 3 suites / 59 tests passed before the added cases
- OAuth mail integration tests: 2 suites / 11 tests passed
- Custom security audit: 0 critical, high, or medium findings; 8 pre-existing low-confidence logging notices in untouched integration modules
- `npm ls nodemailer --all` resolves only `nodemailer@9.0.3`

## Rollback

Revert these commits to restore the prior 8.0.7 declaration and lockfile resolution.