### PR TITLE
ci: restore cross-platform promotion gates

### DIFF
--- a/.github/workflows/core-build-test.yml
+++ b/.github/workflows/core-build-test.yml
@@ -166,17 +166,14 @@ jobs:
             echo "✗ package.json NOT FOUND"
           fi
 
-      - name: Enforce hosted integration unit tests
-        if: >-
-          always() &&
-          (github.base_ref == 'codex/hosted-http-integration' ||
-          github.ref == 'refs/heads/codex/hosted-http-integration')
+      - name: Enforce unit test result
+        if: always()
         shell: bash
         env:
           TEST_OUTCOME: ${{ steps.original_tests.outcome }}
         run: |
           if [ "$TEST_OUTCOME" != "success" ]; then
-            echo "Unit tests failed for the hosted integration gate."
+            echo "Unit tests failed for the core build gate."
             exit 1
           fi
 

--- a/.github/workflows/extended-node-compatibility.yml
+++ b/.github/workflows/extended-node-compatibility.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   extended-compatibility:
-    name: Test (${{ matrix.os }}, Node ${{ matrix.node-version }})
+    name: Extended (${{ matrix.os }}, Node ${{ matrix.node-version }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
 

--- a/tests/unit/database/allowlist-normalization-migration.test.ts
+++ b/tests/unit/database/allowlist-normalization-migration.test.ts
@@ -8,7 +8,7 @@ const migrationPath = path.resolve(
   testDir,
   '../../../src/database/migrations/0045_normalize_allowlist_identities.sql',
 );
-const migrationSql = fs.readFileSync(migrationPath, 'utf8');
+const migrationSql = fs.readFileSync(migrationPath, 'utf8').replaceAll('\r\n', '\n');
 
 describe('allowlist identity normalization migration', () => {
   it('normalizes canonical encodings without compatibility folding', () => {

--- a/tests/unit/github-workflow-validation.test.ts
+++ b/tests/unit/github-workflow-validation.test.ts
@@ -163,7 +163,7 @@ describe('GitHub Workflow Validation', () => {
       }
     );
 
-    it('should enforce unit tests and defer performance tests at the hosted stage', () => {
+    it('should enforce unit tests on every core platform and defer performance at the hosted stage', () => {
       const content = fs.readFileSync(
         path.join(workflowDir, 'core-build-test.yml'),
         'utf8'
@@ -172,14 +172,13 @@ describe('GitHub Workflow Validation', () => {
       const steps = workflow.jobs['hosted-test'].steps;
       const operatingSystems = workflow.jobs['hosted-test'].strategy?.matrix?.os;
       const unitTestGate = steps.find(
-        (step) => step.name === 'Enforce hosted integration unit tests'
+        (step) => step.name === 'Enforce unit test result'
       );
       const performanceTests = steps.find(
         (step) => step.id === 'performance_tests'
       );
 
-      expect(unitTestGate?.if).toContain('always()');
-      expect(unitTestGate?.if).toContain(hostedBranch);
+      expect(unitTestGate?.if).toBe('always()');
       expect(unitTestGate?.env?.TEST_OUTCOME).toBe(
         '${{ steps.original_tests.outcome }}'
       );
@@ -187,6 +186,21 @@ describe('GitHub Workflow Validation', () => {
       expect(performanceTests?.if).toContain(hostedBranch);
       expect(operatingSystems).toEqual(expect.stringContaining(hostedBranch));
       expect(operatingSystems).toEqual(expect.stringContaining('["ubuntu-latest"]'));
+    });
+
+    it('should give core and extended compatibility checks distinct names', () => {
+      const core = yaml.load(
+        fs.readFileSync(path.join(workflowDir, 'core-build-test.yml'), 'utf8')
+      ) as Workflow;
+      const extended = yaml.load(
+        fs.readFileSync(path.join(workflowDir, 'extended-node-compatibility.yml'), 'utf8')
+      ) as Workflow;
+
+      expect(core.jobs['hosted-test'].name).toContain('Test (');
+      expect(extended.jobs['extended-compatibility'].name).toContain('Extended (');
+      expect(core.jobs['hosted-test'].name).not.toBe(
+        extended.jobs['extended-compatibility'].name
+      );
     });
 
     it('should require successful MCP payloads from every Docker gate', () => {

--- a/tests/unit/scripts/publish-beta-release-state.test.ts
+++ b/tests/unit/scripts/publish-beta-release-state.test.ts
@@ -282,12 +282,13 @@ function runScenario(scenario: Scenario): {
   writeExecutable(path.join(binDirectory, 'npm'), fakeNpmScript);
 
   const release = scenario.release;
-  const result = spawnSync('/bin/bash', ['-c', validationScript ?? 'exit 99'], {
+  const bashExecutable = process.platform === 'win32' ? 'bash' : '/bin/bash';
+  const result = spawnSync(bashExecutable, ['-c', validationScript ?? 'exit 99'], {
     cwd: projectRoot,
     encoding: 'utf8',
     env: {
       ...process.env,
-      PATH: `${binDirectory}:${process.env.PATH ?? ''}`,
+      PATH: `${binDirectory}${path.delimiter}${process.env.PATH ?? ''}`,
       GITHUB_REF_NAME: 'beta',
       GITHUB_SHA: expectedSha,
       GITHUB_OUTPUT: outputPath,
@@ -303,6 +304,7 @@ function runScenario(scenario: Scenario): {
       FAKE_NPM_LATEST_VERSION: scenario.npmLatestVersion ?? '',
     },
   });
+  if (result.error) throw result.error;
 
   return {
     status: result.status,

--- a/tests/unit/scripts/publish-beta-release-state.test.ts
+++ b/tests/unit/scripts/publish-beta-release-state.test.ts
@@ -283,12 +283,18 @@ function runScenario(scenario: Scenario): {
 
   const release = scenario.release;
   const bashExecutable = process.platform === 'win32' ? 'bash' : '/bin/bash';
-  const result = spawnSync(bashExecutable, ['-c', validationScript ?? 'exit 99'], {
+  const shellBinDirectory = process.platform === 'win32'
+    ? binDirectory
+      .replaceAll('\\', '/')
+      .replace(/^([A-Za-z]):/, (_match, drive: string) => `/${drive.toLowerCase()}`)
+    : binDirectory;
+  const shellScript = `export PATH="$FAKE_BIN_DIRECTORY:$PATH"\n${validationScript ?? 'exit 99'}`;
+  const result = spawnSync(bashExecutable, ['-c', shellScript], {
     cwd: projectRoot,
     encoding: 'utf8',
     env: {
       ...process.env,
-      PATH: `${binDirectory}${path.delimiter}${process.env.PATH ?? ''}`,
+      FAKE_BIN_DIRECTORY: shellBinDirectory,
       GITHUB_REF_NAME: 'beta',
       GITHUB_SHA: expectedSha,
       GITHUB_OUTPUT: outputPath,

--- a/tests/unit/security/audit/SecurityAuditor.test.ts
+++ b/tests/unit/security/audit/SecurityAuditor.test.ts
@@ -141,8 +141,9 @@ describe('SecurityAuditor', () => {
       const scanner = new CodeScanner(defaultConfig.scanners.code);
       const findings = await scanner.scan({ projectRoot: tempDir });
 
-      expect(findings.some(finding => finding.file?.endsWith('/ui/app.js'))).toBe(true);
-      expect(findings.some(finding => finding.file?.endsWith('/vendor/purify.min.js'))).toBe(false);
+      const normalizedFindingPaths = findings.map(finding => finding.file?.replaceAll('\\', '/'));
+      expect(normalizedFindingPaths.some(file => file?.endsWith('/ui/app.js'))).toBe(true);
+      expect(normalizedFindingPaths.some(file => file?.endsWith('/vendor/purify.min.js'))).toBe(false);
     });
 
     test('custom audit policy does not suppress first-party source directories', async () => {


### PR DESCRIPTION
## Summary

- propagate captured `npm test` failures through the Core gate on every configured platform
- keep hosted integration lightweight at Ubuntu/Node 20 while making beta/develop/main matrix failures blocking
- give Extended Node compatibility checks distinct names so branch protection can identify them unambiguously
- retain the platform-aware path fixes already reconciled from beta in commit `55871e16` without changing runtime path or symlink-containment behavior

## Historical failure inventory

The previously hidden Windows failures were confined to seven suites and were repaired by beta commit `55871e16`: memory relative-path separators, native/resolved path expectations, Windows mode-bit handling, and canonical temp paths. The macOS `/var` to `/private/var` assertion was repaired by the same commit. That commit is already present in hosted integration with its original attribution.

## Validation

- `npm run build`
- `npm run lint -- --quiet`
- `npm test -- --runInBand --silent`
- focused workflow contract test: 149 passing
- focused historical platform suites: 351 passing on macOS

Cross-platform Node 20 and Extended Node 20/22 matrices will be manually dispatched against this exact branch after PR creation.

Closes #2468