### PR TITLE
ci: remove dead compiled-test fallback

### DIFF
--- a/.github/workflows/core-build-test.yml
+++ b/.github/workflows/core-build-test.yml
@@ -177,19 +177,6 @@ jobs:
             exit 1
           fi
 
-      - name: Run compiled tests approach
-        if: false  # Temporarily disabled - see PR #845
-        # Original condition: if: steps.original_tests.outcome == 'failure'
-        working-directory: ${{ github.workspace }}
-        run: |
-          echo "=== Running compiled test approach ==="
-          echo "Explicitly setting working directory to: ${{ github.workspace }}"
-          pwd
-          # Build the tests first
-          npm run build:test
-          # Run the compiled tests using cross-env
-          ./node_modules/.bin/cross-env NODE_OPTIONS='--experimental-vm-modules' ./node_modules/.bin/jest --config tests/jest.config.compiled.cjs --ci --watchAll=false
-
       - name: Validation complete
         run: |
           echo "✅ Core Build & Test Complete!"

--- a/tests/unit/github-workflow-validation.test.ts
+++ b/tests/unit/github-workflow-validation.test.ts
@@ -186,6 +186,9 @@ describe('GitHub Workflow Validation', () => {
       expect(performanceTests?.if).toContain(hostedBranch);
       expect(operatingSystems).toEqual(expect.stringContaining(hostedBranch));
       expect(operatingSystems).toEqual(expect.stringContaining('["ubuntu-latest"]'));
+      expect(steps).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ if: false })])
+      );
     });
 
     it('should give core and extended compatibility checks distinct names', () => {


### PR DESCRIPTION
## Summary

- remove the permanently disabled `Run compiled tests approach` step from the core workflow
- add a workflow regression assertion rejecting unreachable `if: false` steps in the core gate
- retain the supported compiled-test commands in `package.json` for explicit developer use

## Why

The fallback was guarded by `if: false` and could never run. It referred to the separate GitHubAuthManager test debt in #845, but retaining unreachable CI configuration obscured the active debug-and-enforce test path.

This cleanup is intentionally separate from #2513 so the completed cross-platform promotion-gate change remains independently reviewable.

## Validation

- `npm test -- --runInBand tests/unit/github-workflow-validation.test.ts` — 149 passed
- `npx eslint --max-warnings=0 tests/unit/github-workflow-validation.test.ts`
- `git diff --check`

## Scope

CI cleanup only. No runtime, dependency, lockfile, release-channel, or hosted transport behavior changes.

Closes #2514