### PR TITLE
fix(security): close hosted promotion blockers

### DIFF
--- a/src/web-console/modules/integrations/AuthorizedIntegrationGateway.ts
+++ b/src/web-console/modules/integrations/AuthorizedIntegrationGateway.ts
@@ -44,10 +44,10 @@ import {
  * verification binds to always matches what is actually executed. The
  * management-write facades (ingestOpenApiSpec / regenerateSkill / remote-MCP
  * callTool) authorize on a synthetic `_internal:/...` sentinel target
- * carrying the material content (the spec body, the tool arguments); their
- * provenance-only inputs (`sourceUrl`, `regenerateSkill`) are deliberately
- * outside the bound scope, and the sentinel path is gateway-rejectable so a
- * management approval can never be replayed as a real integration_request.
+ * carrying the behavior-changing content (the spec and regenerate flag, or
+ * the tool arguments). Provenance-only `sourceUrl` remains outside the bound
+ * scope, and the sentinel path is gateway-rejectable so a management approval
+ * can never be replayed as a real integration_request.
  */
 
 type PolicyErrorShape = NonNullable<IntegrationRequestPolicyDecision['error']>;
@@ -114,7 +114,10 @@ export class AuthorizedIntegrationOperationCatalog {
       provider: input.provider,
       method: 'PUT',
       path: INTEGRATION_OPENAPI_SPEC_POLICY_PATH,
-      body: input.spec,
+      body: {
+        spec: input.spec,
+        regenerateSkill: input.regenerateSkill === true,
+      },
     });
     if (!decision.authorized) return decision.denial;
     const result = await this.options.catalog.ingestOpenApiSpec(input);

--- a/src/web-console/modules/integrations/IntegrationOperationCatalog.ts
+++ b/src/web-console/modules/integrations/IntegrationOperationCatalog.ts
@@ -714,8 +714,12 @@ function buildNormalizedPaths(rawPaths: Readonly<Record<string, unknown>>): Reco
   const normalizedPaths: Record<string, unknown> = {};
   const operationIds = new Set<string>();
   for (const [path, pathItemValue] of Object.entries(rawPaths).sort(([left], [right]) => left.localeCompare(right))) {
-    if (!path.startsWith('/')) {
-      throw new IntegrationOperationCatalogError('invalid_openapi_spec', 'OpenAPI paths must start with /.', 400);
+    if (!path.startsWith('/') || path.startsWith('//') || path.includes('\\')) {
+      throw new IntegrationOperationCatalogError(
+        'invalid_openapi_spec',
+        'OpenAPI paths must be absolute paths without protocol-relative or backslash forms.',
+        400,
+      );
     }
     const normalizedPathItem = normalizePathItem(asRecord(pathItemValue), path, operationIds);
     if (Object.keys(normalizedPathItem).some(key => HTTP_METHODS.has(key))) {

--- a/src/web-console/modules/integrations/IntegrationRemoteMcpBridge.ts
+++ b/src/web-console/modules/integrations/IntegrationRemoteMcpBridge.ts
@@ -183,18 +183,15 @@ export class IntegrationRemoteMcpBridge {
             502,
           );
         }
-        const safeTool = this.redactRemotePayload({
-          description: tool.description,
-          inputSchema: tool.inputSchema,
-        }, bearerToken) as { description?: unknown; inputSchema?: unknown };
-        return [{
+        const remoteTool: RemoteMcpTool = {
           provider: descriptor.provider,
           remoteName: tool.name,
           localName: remoteMcpLocalToolName(descriptor.provider, tool.name),
-          description: typeof safeTool.description === 'string' ? safeTool.description : undefined,
-          inputSchema: safeTool.inputSchema as Tool['inputSchema'],
+          description: tool.description,
+          inputSchema: tool.inputSchema,
           serverUrl: config.serverUrl.toString(),
-        }];
+        };
+        return [this.redactRemoteTool(remoteTool, bearerToken)];
       });
     });
   }
@@ -223,10 +220,10 @@ export class IntegrationRemoteMcpBridge {
         'remote_mcp_call_failed',
         'Remote MCP tool call failed.',
       );
-      return {
+      return this.redactRemoteCallResult({
         provider: descriptor.provider,
         remoteName: input.remoteName,
-        result: this.redactRemotePayload(result, bearerToken),
+        result,
         provenance: {
           source: 'third_party_integration',
           trust: 'untrusted',
@@ -234,7 +231,7 @@ export class IntegrationRemoteMcpBridge {
           remoteTool: input.remoteName,
           handling: 'data_only_not_instructions',
         },
-      };
+      }, bearerToken);
     });
   }
 
@@ -343,6 +340,47 @@ export class IntegrationRemoteMcpBridge {
         502,
       );
     }
+  }
+
+  private redactRemoteTool(tool: RemoteMcpTool, bearerToken: string): RemoteMcpTool {
+    const safe = this.redactRemotePayload(tool, bearerToken) as RemoteMcpTool;
+    this.assertRemoteWrapperFieldsUnchanged([
+      [safe.provider, tool.provider],
+      [safe.remoteName, tool.remoteName],
+      [safe.localName, tool.localName],
+    ]);
+    return safe;
+  }
+
+  private redactRemoteCallResult(
+    result: RemoteMcpCallResult,
+    bearerToken: string,
+  ): RemoteMcpCallResult {
+    const safe = this.redactRemotePayload(result, bearerToken) as RemoteMcpCallResult;
+    this.assertRemoteWrapperFieldsUnchanged([
+      [safe.provider, result.provider],
+      [safe.remoteName, result.remoteName],
+      [safe.provenance.source, result.provenance.source],
+      [safe.provenance.trust, result.provenance.trust],
+      [safe.provenance.provider, result.provenance.provider],
+      [safe.provenance.remoteTool, result.provenance.remoteTool],
+      [safe.provenance.handling, result.provenance.handling],
+    ]);
+    return safe;
+  }
+
+  private assertRemoteWrapperFieldsUnchanged(fields: readonly (readonly [unknown, unknown])[]): void {
+    if (fields.some(([safe, original]) => safe !== original)) {
+      throw this.unsafeRemoteWrapperError();
+    }
+  }
+
+  private unsafeRemoteWrapperError(): IntegrationRemoteMcpBridgeError {
+    return new IntegrationRemoteMcpBridgeError(
+      'remote_mcp_response_invalid',
+      'Remote MCP response could not be handled safely.',
+      502,
+    );
   }
 }
 

--- a/src/web-console/modules/integrations/IntegrationRemoteMcpBridge.ts
+++ b/src/web-console/modules/integrations/IntegrationRemoteMcpBridge.ts
@@ -18,6 +18,12 @@ import {
   type DnsLookupAddress,
 } from './IntegrationPublicHostGuard.js';
 import { createPinnedOutboundFactory, type PinnedFetch, type PinnedOutboundFactory } from './PinnedOutboundFactory.js';
+import {
+  createBoundedRemoteMcpFetch,
+  DEFAULT_REMOTE_MCP_RESPONSE_BYTES,
+  redactRemoteMcpCredentialEchoes,
+  RemoteMcpPayloadSafetyError,
+} from './IntegrationRemoteMcpSecurity.js';
 
 const DEFAULT_REMOTE_MCP_TIMEOUT_MS = 5_000;
 
@@ -38,6 +44,7 @@ export interface IntegrationRemoteMcpBridgeOptions {
   readonly pinnedOutbound?: PinnedOutboundFactory;
   readonly dnsLookup?: DnsLookup;
   readonly timeoutMs?: number;
+  readonly maxResponseBytes?: number;
 }
 
 export interface RemoteMcpTool {
@@ -101,12 +108,14 @@ export class IntegrationRemoteMcpBridge {
   private readonly pinnedOutboundFactory: PinnedOutboundFactory;
   private readonly dnsLookupImpl: DnsLookup;
   private readonly timeoutMs: number;
+  private readonly maxResponseBytes: number;
 
   constructor(private readonly options: IntegrationRemoteMcpBridgeOptions) {
     this.clientFactory = options.clientFactory ?? createSdkRemoteMcpClient;
     this.pinnedOutboundFactory = options.pinnedOutbound ?? createPinnedOutboundFactory();
     this.dnsLookupImpl = options.dnsLookup ?? dnsLookup;
     this.timeoutMs = options.timeoutMs ?? DEFAULT_REMOTE_MCP_TIMEOUT_MS;
+    this.maxResponseBytes = options.maxResponseBytes ?? DEFAULT_REMOTE_MCP_RESPONSE_BYTES;
   }
 
   async listAllowedTools(): Promise<readonly RemoteMcpTool[]> {
@@ -156,20 +165,32 @@ export class IntegrationRemoteMcpBridge {
     const vetted = await this.assertRemoteMcpPublicHost(config.serverUrl.hostname);
     const bearerToken = this.decryptAccessToken(integration, userId);
     return await this.withPinnedClient(config.serverUrl, bearerToken, vetted, async client => {
-      const listed = await withTimeout(
+      const listed = await this.awaitRemoteOperation(
         client.listTools(),
-        this.timeoutMs,
         'remote_mcp_list_timeout',
         'Remote MCP tools/list timed out.',
+        'remote_mcp_list_failed',
+        'Remote MCP tools/list failed.',
       );
       return listed.tools.flatMap(tool => {
         if (!config.allowedTools.has(tool.name)) return [];
+        if (this.redactRemotePayload(tool.name, bearerToken) !== tool.name) {
+          throw new IntegrationRemoteMcpBridgeError(
+            'remote_mcp_response_invalid',
+            'Remote MCP tool metadata could not be handled safely.',
+            502,
+          );
+        }
+        const safeTool = this.redactRemotePayload({
+          description: tool.description,
+          inputSchema: tool.inputSchema,
+        }, bearerToken) as { description?: unknown; inputSchema?: unknown };
         return [{
           provider: descriptor.provider,
           remoteName: tool.name,
           localName: remoteMcpLocalToolName(descriptor.provider, tool.name),
-          description: tool.description,
-          inputSchema: tool.inputSchema,
+          description: typeof safeTool.description === 'string' ? safeTool.description : undefined,
+          inputSchema: safeTool.inputSchema as Tool['inputSchema'],
           serverUrl: config.serverUrl.toString(),
         }];
       });
@@ -193,16 +214,17 @@ export class IntegrationRemoteMcpBridge {
     const vetted = await this.assertRemoteMcpPublicHost(config.serverUrl.hostname);
     const bearerToken = this.decryptAccessToken(integration, session.userId);
     return await this.withPinnedClient(config.serverUrl, bearerToken, vetted, async client => {
-      const result = await withTimeout(
+      const result = await this.awaitRemoteOperation(
         client.callTool({ name: input.remoteName, arguments: readArguments(input.arguments) }),
-        this.timeoutMs,
         'remote_mcp_call_timeout',
         'Remote MCP tool call timed out.',
+        'remote_mcp_call_failed',
+        'Remote MCP tool call failed.',
       );
       return {
         provider: descriptor.provider,
         remoteName: input.remoteName,
-        result,
+        result: this.redactRemotePayload(result, bearerToken),
         provenance: {
           source: 'third_party_integration',
           trust: 'untrusted',
@@ -271,7 +293,8 @@ export class IntegrationRemoteMcpBridge {
   }
 
   private async connectClient(serverUrl: URL, bearerToken: string, pinnedFetch: PinnedFetch): Promise<RemoteMcpClient> {
-    const clientPromise = this.clientFactory({ serverUrl, bearerToken, pinnedFetch });
+    const boundedFetch = createBoundedRemoteMcpFetch(pinnedFetch, this.maxResponseBytes);
+    const clientPromise = this.clientFactory({ serverUrl, bearerToken, pinnedFetch: boundedFetch });
     try {
       return await withTimeout(
         clientPromise,
@@ -283,7 +306,40 @@ export class IntegrationRemoteMcpBridge {
       // If the connection resolves after the timeout fired, close it so we don't leak
       // a dangling transport (the try/finally below only covers the post-connect phase).
       void clientPromise.then(client => client.close()).catch(() => { /* best-effort cleanup */ });
-      throw error;
+      if (error instanceof IntegrationRemoteMcpBridgeError) throw error;
+      throw new IntegrationRemoteMcpBridgeError(
+        'remote_mcp_connect_failed',
+        'Remote MCP server connection failed.',
+        502,
+      );
+    }
+  }
+
+  private async awaitRemoteOperation<T>(
+    promise: Promise<T>,
+    timeoutCode: string,
+    timeoutMessage: string,
+    failureCode: string,
+    failureMessage: string,
+  ): Promise<T> {
+    try {
+      return await withTimeout(promise, this.timeoutMs, timeoutCode, timeoutMessage);
+    } catch (error) {
+      if (error instanceof IntegrationRemoteMcpBridgeError) throw error;
+      throw new IntegrationRemoteMcpBridgeError(failureCode, failureMessage, 502);
+    }
+  }
+
+  private redactRemotePayload(value: unknown, bearerToken: string): unknown {
+    try {
+      return redactRemoteMcpCredentialEchoes(value, bearerToken);
+    } catch (error) {
+      if (!(error instanceof RemoteMcpPayloadSafetyError)) throw error;
+      throw new IntegrationRemoteMcpBridgeError(
+        'remote_mcp_response_invalid',
+        'Remote MCP response could not be handled safely.',
+        502,
+      );
     }
   }
 }
@@ -329,6 +385,13 @@ function parseAllowedServerUrl(value: string, descriptor: IntegrationDescriptorR
     url = new URL(value);
   } catch {
     throw new IntegrationRemoteMcpBridgeError('remote_mcp_invalid_server_url', 'Remote MCP server URL is invalid.', 400);
+  }
+  if (url.username !== '' || url.password !== '') {
+    throw new IntegrationRemoteMcpBridgeError(
+      'remote_mcp_invalid_server_url',
+      'Remote MCP server URL must not contain user information.',
+      400,
+    );
   }
   if (url.protocol !== 'https:' || !isIntegrationApiHostAllowed(url.hostname, descriptor.apiHosts)) {
     throw new IntegrationRemoteMcpBridgeError(

--- a/src/web-console/modules/integrations/IntegrationRemoteMcpBridge.ts
+++ b/src/web-console/modules/integrations/IntegrationRemoteMcpBridge.ts
@@ -174,6 +174,8 @@ export class IntegrationRemoteMcpBridge {
       );
       return listed.tools.flatMap(tool => {
         if (!config.allowedTools.has(tool.name)) return [];
+        // A name is both the allowlist key and invocation target; redacting it
+        // would authorize one name and invoke another, so credential echoes fail closed.
         if (this.redactRemotePayload(tool.name, bearerToken) !== tool.name) {
           throw new IntegrationRemoteMcpBridgeError(
             'remote_mcp_response_invalid',

--- a/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
+++ b/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
@@ -6,6 +6,7 @@ const MAX_PAYLOAD_NODES = 100_000;
 const MAX_CREDENTIAL_DECODE_DEPTH = 4;
 const JSON_ESCAPE_PATTERN = /\\(?:["\\/bfnrt]|u[0-9a-fA-F]{4})/g;
 const PERCENT_ESCAPE_RUN_PATTERN = /(?:%[0-9A-Fa-f]{2})+/g;
+const UTF8_DECODER = new TextDecoder();
 
 export const DEFAULT_REMOTE_MCP_RESPONSE_BYTES = 1024 * 1024;
 
@@ -278,14 +279,17 @@ function decodedVariants(value: string): readonly string[] {
 }
 
 function decodeValidPercentEscapeRuns(value: string): string {
-  return value.replace(PERCENT_ESCAPE_RUN_PATTERN, (run) => {
-    try {
-      return decodeURIComponent(run);
-    } catch {
-      // Preserve runs that are byte-shaped but not valid UTF-8.
-      return run;
-    }
-  });
+  return value.replace(PERCENT_ESCAPE_RUN_PATTERN, decodePercentEscapeRun);
+}
+
+function decodePercentEscapeRun(run: string): string {
+  const bytes = new Uint8Array(run.length / 3);
+  for (let offset = 0; offset < run.length; offset += 3) {
+    bytes[offset / 3] = Number.parseInt(run.slice(offset + 1, offset + 3), 16);
+  }
+  // Decoding is inspection-only. Replacement characters isolate invalid UTF-8
+  // bytes while allowing adjacent valid spans to continue through the bounded scan.
+  return UTF8_DECODER.decode(bytes);
 }
 
 function decodeJsonEscapes(value: string): string {

--- a/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
+++ b/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
@@ -5,6 +5,7 @@ const MAX_PAYLOAD_DEPTH = 128;
 const MAX_PAYLOAD_NODES = 100_000;
 const MAX_CREDENTIAL_DECODE_DEPTH = 4;
 const JSON_ESCAPE_PATTERN = /\\(?:["\\/bfnrt]|u[0-9a-fA-F]{4})/g;
+const PERCENT_ESCAPE_RUN_PATTERN = /(?:%[0-9A-Fa-f]{2})+/g;
 
 export const DEFAULT_REMOTE_MCP_RESPONSE_BYTES = 1024 * 1024;
 
@@ -273,13 +274,18 @@ function appendUnseenDecodedVariant(
 }
 
 function decodedVariants(value: string): readonly string[] {
-  const variants = [decodeJsonEscapes(value)];
-  try {
-    variants.push(decodeURIComponent(value));
-  } catch {
-    // Malformed percent escapes have no URI-decoded variant.
-  }
-  return variants;
+  return [decodeJsonEscapes(value), decodeValidPercentEscapeRuns(value)];
+}
+
+function decodeValidPercentEscapeRuns(value: string): string {
+  return value.replace(PERCENT_ESCAPE_RUN_PATTERN, (run) => {
+    try {
+      return decodeURIComponent(run);
+    } catch {
+      // Preserve runs that are byte-shaped but not valid UTF-8.
+      return run;
+    }
+  });
 }
 
 function decodeJsonEscapes(value: string): string {

--- a/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
+++ b/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
@@ -74,8 +74,8 @@ export function createBoundedRemoteMcpFetch(
  * custom-client output fail closed instead of overflowing the process stack.
  */
 export function redactRemoteMcpCredentialEchoes(value: unknown, credential: string): unknown {
-  if (credential === '') {
-    throw new RemoteMcpPayloadSafetyError('Remote MCP credential is empty.');
+  if (credential === '' || REDACTED.includes(credential)) {
+    throw new RemoteMcpPayloadSafetyError('Remote MCP credential cannot be safely redacted.');
   }
   const patterns = credentialPatterns(credential);
   if (!isContainer(value)) return redactPrimitive(value, patterns);
@@ -143,7 +143,9 @@ function createContainer(value: object): unknown[] | Record<string, unknown> {
 function redactPrimitive(value: unknown, patterns: CredentialPatterns): unknown {
   if (typeof value === 'string') return redactCredentialString(value, patterns);
   if (value === null || typeof value === 'number' || typeof value === 'boolean') {
-    return patterns.exact.includes(String(value)) ? REDACTED : value;
+    const serialized = String(value);
+    const redacted = redactCredentialString(serialized, patterns);
+    return redacted === serialized ? value : redacted;
   }
   return value;
 }
@@ -153,7 +155,7 @@ function credentialPatterns(credential: string): CredentialPatterns {
     // Reject lone surrogates before constructing UTF-8 alternatives.
     encodeURIComponent(credential);
   } catch {
-    return { exact: [credential], encoded: null };
+    throw new RemoteMcpPayloadSafetyError('Remote MCP credential cannot be safely redacted.');
   }
   return {
     exact: [credential],
@@ -186,23 +188,25 @@ function encodedCredentialPattern(credential: string): RegExp {
 
 function unicodeEscapedCharacterPattern(character: string): string {
   let pattern = '';
-  for (let index = 0; index < character.length; index += 1) {
-    const hexadecimal = character.charCodeAt(index).toString(16).padStart(4, '0');
-    pattern += `\\\\u${Array.from(hexadecimal, caseInsensitiveHexDigit).join('')}`;
+  for (const codeUnit of character.split('')) {
+    const value = codeUnit.codePointAt(0);
+    if (value === undefined) continue;
+    const hexadecimal = value.toString(16).padStart(4, '0');
+    pattern += String.raw`\\u${Array.from(hexadecimal, caseInsensitiveHexDigit).join('')}`;
   }
   return pattern;
 }
 
 function jsonShortEscape(character: string): string | null {
   switch (character) {
-    case '"': return '\\"';
-    case '\\': return '\\\\';
-    case '/': return '\\/';
-    case '\b': return '\\b';
-    case '\f': return '\\f';
-    case '\n': return '\\n';
-    case '\r': return '\\r';
-    case '\t': return '\\t';
+    case '"': return String.raw`\"`;
+    case '\\': return String.raw`\\`;
+    case '/': return String.raw`\/`;
+    case '\b': return String.raw`\b`;
+    case '\f': return String.raw`\f`;
+    case '\n': return String.raw`\n`;
+    case '\r': return String.raw`\r`;
+    case '\t': return String.raw`\t`;
     default: return null;
   }
 }
@@ -220,7 +224,7 @@ function caseInsensitiveHexDigit(value: string): string {
 }
 
 function escapeRegexCharacter(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\\$&`);
 }
 
 function defineSafeProperty(

--- a/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
+++ b/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
@@ -8,7 +8,7 @@ export const DEFAULT_REMOTE_MCP_RESPONSE_BYTES = 1024 * 1024;
 
 interface CredentialPatterns {
   readonly exact: readonly string[];
-  readonly percentEncoded: RegExp | null;
+  readonly encoded: RegExp | null;
 }
 
 interface PayloadTraversalFrame {
@@ -153,28 +153,58 @@ function credentialPatterns(credential: string): CredentialPatterns {
     // Reject lone surrogates before constructing UTF-8 alternatives.
     encodeURIComponent(credential);
   } catch {
-    return { exact: [credential], percentEncoded: null };
+    return { exact: [credential], encoded: null };
   }
   return {
     exact: [credential],
-    percentEncoded: percentEncodedCredentialPattern(credential),
+    encoded: encodedCredentialPattern(credential),
   };
 }
 
 function redactCredentialString(value: string, patterns: CredentialPatterns): string {
   let redacted = value;
   for (const pattern of patterns.exact) redacted = redacted.replaceAll(pattern, REDACTED);
-  if (patterns.percentEncoded) redacted = redacted.replace(patterns.percentEncoded, REDACTED);
+  if (patterns.encoded) redacted = redacted.replace(patterns.encoded, REDACTED);
   return redacted;
 }
 
-function percentEncodedCredentialPattern(credential: string): RegExp {
+function encodedCredentialPattern(credential: string): RegExp {
   let pattern = '';
   for (const character of credential) {
     const encodedBytes = Array.from(new TextEncoder().encode(character), percentEncodedBytePattern).join('');
-    pattern += `(?:${escapeRegexCharacter(character)}|${encodedBytes})`;
+    const alternatives = [
+      escapeRegexCharacter(character),
+      encodedBytes,
+      unicodeEscapedCharacterPattern(character),
+    ];
+    const shortEscape = jsonShortEscape(character);
+    if (shortEscape) alternatives.push(escapeRegexCharacter(shortEscape));
+    pattern += `(?:${alternatives.join('|')})`;
   }
   return new RegExp(pattern, 'g');
+}
+
+function unicodeEscapedCharacterPattern(character: string): string {
+  let pattern = '';
+  for (let index = 0; index < character.length; index += 1) {
+    const hexadecimal = character.charCodeAt(index).toString(16).padStart(4, '0');
+    pattern += `\\\\u${Array.from(hexadecimal, caseInsensitiveHexDigit).join('')}`;
+  }
+  return pattern;
+}
+
+function jsonShortEscape(character: string): string | null {
+  switch (character) {
+    case '"': return '\\"';
+    case '\\': return '\\\\';
+    case '/': return '\\/';
+    case '\b': return '\\b';
+    case '\f': return '\\f';
+    case '\n': return '\\n';
+    case '\r': return '\\r';
+    case '\t': return '\\t';
+    default: return null;
+  }
 }
 
 function percentEncodedBytePattern(byte: number): string {

--- a/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
+++ b/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
@@ -149,15 +149,15 @@ function redactPrimitive(value: unknown, patterns: CredentialPatterns): unknown 
 }
 
 function credentialPatterns(credential: string): CredentialPatterns {
-  let encoded: string;
   try {
-    encoded = encodeURIComponent(credential);
+    // Reject lone surrogates before constructing UTF-8 alternatives.
+    encodeURIComponent(credential);
   } catch {
     return { exact: [credential], percentEncoded: null };
   }
   return {
     exact: [credential],
-    percentEncoded: encoded === credential ? null : percentEncodedCredentialPattern(encoded),
+    percentEncoded: percentEncodedCredentialPattern(credential),
   };
 }
 
@@ -168,25 +168,20 @@ function redactCredentialString(value: string, patterns: CredentialPatterns): st
   return redacted;
 }
 
-function percentEncodedCredentialPattern(encoded: string): RegExp {
+function percentEncodedCredentialPattern(credential: string): RegExp {
   let pattern = '';
-  for (let cursor = 0; cursor < encoded.length;) {
-    const first = encoded[cursor] ?? '';
-    const second = encoded[cursor + 1] ?? '';
-    const third = encoded[cursor + 2] ?? '';
-    if (first === '%' && isHexDigit(second) && isHexDigit(third)) {
-      pattern += `%${caseInsensitiveHexDigit(second)}${caseInsensitiveHexDigit(third)}`;
-      cursor += 3;
-      continue;
-    }
-    pattern += escapeRegexCharacter(first);
-    cursor += 1;
+  for (const character of credential) {
+    const encodedBytes = Array.from(new TextEncoder().encode(character), percentEncodedBytePattern).join('');
+    pattern += `(?:${escapeRegexCharacter(character)}|${encodedBytes})`;
   }
   return new RegExp(pattern, 'g');
 }
 
-function isHexDigit(value: string): boolean {
-  return /^[0-9A-Fa-f]$/.test(value);
+function percentEncodedBytePattern(byte: number): string {
+  const hexadecimal = byte.toString(16).padStart(2, '0');
+  const first = caseInsensitiveHexDigit(hexadecimal[0] ?? '');
+  const second = caseInsensitiveHexDigit(hexadecimal[1] ?? '');
+  return `%${first}${second}`;
 }
 
 function caseInsensitiveHexDigit(value: string): string {

--- a/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
+++ b/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
@@ -6,6 +6,24 @@ const MAX_PAYLOAD_NODES = 100_000;
 
 export const DEFAULT_REMOTE_MCP_RESPONSE_BYTES = 1024 * 1024;
 
+interface CredentialPatterns {
+  readonly exact: readonly string[];
+  readonly percentEncoded: RegExp | null;
+}
+
+interface PayloadTraversalFrame {
+  readonly source: object;
+  readonly target: unknown[] | Record<string, unknown>;
+  readonly depth: number;
+}
+
+interface PayloadTraversalState {
+  readonly patterns: CredentialPatterns;
+  readonly seen: WeakSet<object>;
+  readonly pending: PayloadTraversalFrame[];
+  visitedNodes: number;
+}
+
 export class RemoteMcpPayloadSafetyError extends Error {
   constructor(message: string) {
     super(message);
@@ -13,7 +31,10 @@ export class RemoteMcpPayloadSafetyError extends Error {
   }
 }
 
-/** Limit each MCP POST response while preserving JSON and SSE streaming semantics. */
+/**
+ * Limit each MCP POST response while preserving JSON and SSE streaming semantics.
+ * Long-lived GET notification streams are intentionally not capped cumulatively.
+ */
 export function createBoundedRemoteMcpFetch(
   pinnedFetch: PinnedFetch,
   maxBytes: number,
@@ -60,38 +81,54 @@ export function redactRemoteMcpCredentialEchoes(value: unknown, credential: stri
   if (!isContainer(value)) return redactPrimitive(value, patterns);
 
   const root = createContainer(value);
-  const seen = new WeakSet<object>([value]);
-  const pending: Array<{ source: object; target: unknown[] | Record<string, unknown>; depth: number }> = [
-    { source: value, target: root, depth: 0 },
-  ];
-  let visitedNodes = 0;
-
-  while (pending.length > 0) {
-    const current = pending.pop();
-    if (!current) break;
-    if (current.depth >= MAX_PAYLOAD_DEPTH) {
-      throw new RemoteMcpPayloadSafetyError('Remote MCP response exceeds the supported nesting depth.');
-    }
-    for (const [key, field] of Object.entries(current.source)) {
-      visitedNodes += 1;
-      if (visitedNodes > MAX_PAYLOAD_NODES) {
-        throw new RemoteMcpPayloadSafetyError('Remote MCP response exceeds the supported node count.');
-      }
-      const safeKey = redactCredentialString(key, patterns);
-      if (!isContainer(field)) {
-        defineSafeProperty(current.target, safeKey, redactPrimitive(field, patterns));
-        continue;
-      }
-      if (seen.has(field)) {
-        throw new RemoteMcpPayloadSafetyError('Remote MCP response contains a circular reference.');
-      }
-      seen.add(field);
-      const child = createContainer(field);
-      defineSafeProperty(current.target, safeKey, child);
-      pending.push({ source: field, target: child, depth: current.depth + 1 });
-    }
+  const state: PayloadTraversalState = {
+    patterns,
+    seen: new WeakSet<object>([value]),
+    pending: [{ source: value, target: root, depth: 0 }],
+    visitedNodes: 0,
+  };
+  while (state.pending.length > 0) {
+    const current = state.pending.pop();
+    if (current) copyContainerFields(current, state);
   }
   return root;
+}
+
+function copyContainerFields(current: PayloadTraversalFrame, state: PayloadTraversalState): void {
+  if (current.depth >= MAX_PAYLOAD_DEPTH) {
+    throw new RemoteMcpPayloadSafetyError('Remote MCP response exceeds the supported nesting depth.');
+  }
+  for (const [key, field] of Object.entries(current.source)) {
+    copyContainerField(current, key, field, state);
+  }
+}
+
+function copyContainerField(
+  current: PayloadTraversalFrame,
+  key: string,
+  field: unknown,
+  state: PayloadTraversalState,
+): void {
+  recordVisitedNode(state);
+  const safeKey = redactCredentialString(key, state.patterns);
+  if (!isContainer(field)) {
+    defineSafeProperty(current.target, safeKey, redactPrimitive(field, state.patterns));
+    return;
+  }
+  if (state.seen.has(field)) {
+    throw new RemoteMcpPayloadSafetyError('Remote MCP response contains a circular reference.');
+  }
+  state.seen.add(field);
+  const child = createContainer(field);
+  defineSafeProperty(current.target, safeKey, child);
+  state.pending.push({ source: field, target: child, depth: current.depth + 1 });
+}
+
+function recordVisitedNode(state: PayloadTraversalState): void {
+  state.visitedNodes += 1;
+  if (state.visitedNodes > MAX_PAYLOAD_NODES) {
+    throw new RemoteMcpPayloadSafetyError('Remote MCP response exceeds the supported node count.');
+  }
 }
 
 function isContainer(value: unknown): value is object {
@@ -99,33 +136,66 @@ function isContainer(value: unknown): value is object {
 }
 
 function createContainer(value: object): unknown[] | Record<string, unknown> {
+  // Preserve sparse-array length while safe property definitions copy present indexes.
   return Array.isArray(value) ? new Array<unknown>(value.length) : {};
 }
 
-function redactPrimitive(value: unknown, patterns: readonly string[]): unknown {
+function redactPrimitive(value: unknown, patterns: CredentialPatterns): unknown {
   if (typeof value === 'string') return redactCredentialString(value, patterns);
   if (value === null || typeof value === 'number' || typeof value === 'boolean') {
-    return patterns.includes(String(value)) ? REDACTED : value;
+    return patterns.exact.includes(String(value)) ? REDACTED : value;
   }
   return value;
 }
 
-function credentialPatterns(credential: string): readonly string[] {
-  const patterns = [credential];
+function credentialPatterns(credential: string): CredentialPatterns {
   let encoded: string;
   try {
     encoded = encodeURIComponent(credential);
   } catch {
-    return patterns;
+    return { exact: [credential], percentEncoded: null };
   }
-  if (encoded !== credential) patterns.push(encoded);
-  return patterns;
+  return {
+    exact: [credential],
+    percentEncoded: encoded === credential ? null : percentEncodedCredentialPattern(encoded),
+  };
 }
 
-function redactCredentialString(value: string, patterns: readonly string[]): string {
+function redactCredentialString(value: string, patterns: CredentialPatterns): string {
   let redacted = value;
-  for (const pattern of patterns) redacted = redacted.replaceAll(pattern, REDACTED);
+  for (const pattern of patterns.exact) redacted = redacted.replaceAll(pattern, REDACTED);
+  if (patterns.percentEncoded) redacted = redacted.replace(patterns.percentEncoded, REDACTED);
   return redacted;
+}
+
+function percentEncodedCredentialPattern(encoded: string): RegExp {
+  let pattern = '';
+  for (let cursor = 0; cursor < encoded.length;) {
+    const first = encoded[cursor] ?? '';
+    const second = encoded[cursor + 1] ?? '';
+    const third = encoded[cursor + 2] ?? '';
+    if (first === '%' && isHexDigit(second) && isHexDigit(third)) {
+      pattern += `%${caseInsensitiveHexDigit(second)}${caseInsensitiveHexDigit(third)}`;
+      cursor += 3;
+      continue;
+    }
+    pattern += escapeRegexCharacter(first);
+    cursor += 1;
+  }
+  return new RegExp(pattern, 'g');
+}
+
+function isHexDigit(value: string): boolean {
+  return /^[0-9A-Fa-f]$/.test(value);
+}
+
+function caseInsensitiveHexDigit(value: string): string {
+  const lower = value.toLowerCase();
+  return lower >= 'a' && lower <= 'f' ? `[${lower}${lower.toUpperCase()}]` : value;
+}
+
+function escapeRegexCharacter(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function defineSafeProperty(

--- a/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
+++ b/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
@@ -20,6 +20,11 @@ interface ResponseByteLimitState {
   byteBeforePrevious: number;
 }
 
+interface DecodedFrontierResult {
+  readonly containsCredential: boolean;
+  readonly next: string[];
+}
+
 interface PayloadTraversalFrame {
   readonly source: object;
   readonly target: unknown[] | Record<string, unknown>;
@@ -230,20 +235,41 @@ function decodedVariantContainsCredential(value: string, credential: string): bo
   const seen = new Set<string>([value]);
   let frontier = [value];
   for (let depth = 0; depth < MAX_CREDENTIAL_DECODE_DEPTH; depth += 1) {
-    const next: string[] = [];
-    for (const variant of frontier) {
-      for (const decoded of decodedVariants(variant)) {
-        if (depth > 0 && decoded.includes(credential)) return true;
-        if (decoded !== variant && !seen.has(decoded)) {
-          seen.add(decoded);
-          next.push(decoded);
-        }
-      }
-    }
-    frontier = next;
+    const expanded = expandDecodedFrontier(frontier, credential, depth > 0, seen);
+    if (expanded.containsCredential) return true;
+    frontier = expanded.next;
     if (frontier.length === 0) return false;
   }
   return false;
+}
+
+function expandDecodedFrontier(
+  frontier: readonly string[],
+  credential: string,
+  inspectForCredential: boolean,
+  seen: Set<string>,
+): DecodedFrontierResult {
+  const next: string[] = [];
+  for (const variant of frontier) {
+    for (const decoded of decodedVariants(variant)) {
+      if (inspectForCredential && decoded.includes(credential)) {
+        return { containsCredential: true, next };
+      }
+      appendUnseenDecodedVariant(decoded, variant, seen, next);
+    }
+  }
+  return { containsCredential: false, next };
+}
+
+function appendUnseenDecodedVariant(
+  decoded: string,
+  source: string,
+  seen: Set<string>,
+  next: string[],
+): void {
+  if (decoded === source || seen.has(decoded)) return;
+  seen.add(decoded);
+  next.push(decoded);
 }
 
 function decodedVariants(value: string): readonly string[] {
@@ -259,7 +285,7 @@ function decodedVariants(value: string): readonly string[] {
 function decodeJsonEscapes(value: string): string {
   return value.replace(JSON_ESCAPE_PATTERN, (escape) => {
     if (escape.startsWith(String.raw`\u`)) {
-      return String.fromCharCode(Number.parseInt(escape.slice(2), 16));
+      return String.fromCodePoint(Number.parseInt(escape.slice(2), 16));
     }
     switch (escape[1]) {
       case '"': return '"';

--- a/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
+++ b/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
@@ -230,14 +230,19 @@ function redactCredentialString(value: string, patterns: CredentialPatterns): st
   let redacted = value;
   for (const pattern of patterns.exact) redacted = redacted.replaceAll(pattern, REDACTED);
   if (patterns.encoded) redacted = redacted.replace(patterns.encoded, REDACTED);
-  return redacted;
+  if (redacted.includes(patterns.credential)) return REDACTED;
+  return decodedVariantContainsCredential(redacted, patterns.credential, true) ? REDACTED : redacted;
 }
 
-function decodedVariantContainsCredential(value: string, credential: string): boolean {
+function decodedVariantContainsCredential(
+  value: string,
+  credential: string,
+  inspectFirstLayer = false,
+): boolean {
   const seen = new Set<string>([value]);
   let frontier = [value];
   for (let depth = 0; depth < MAX_CREDENTIAL_DECODE_DEPTH; depth += 1) {
-    const expanded = expandDecodedFrontier(frontier, credential, depth > 0, seen);
+    const expanded = expandDecodedFrontier(frontier, credential, inspectFirstLayer || depth > 0, seen);
     if (expanded.containsCredential) return true;
     frontier = expanded.next;
     if (frontier.length === 0) return false;

--- a/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
+++ b/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
@@ -1,0 +1,142 @@
+import type { PinnedFetch } from './PinnedOutboundFactory.js';
+
+const REDACTED = '[redacted]';
+const MAX_PAYLOAD_DEPTH = 128;
+const MAX_PAYLOAD_NODES = 100_000;
+
+export const DEFAULT_REMOTE_MCP_RESPONSE_BYTES = 1024 * 1024;
+
+export class RemoteMcpPayloadSafetyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RemoteMcpPayloadSafetyError';
+  }
+}
+
+/** Limit each MCP POST response while preserving JSON and SSE streaming semantics. */
+export function createBoundedRemoteMcpFetch(
+  pinnedFetch: PinnedFetch,
+  maxBytes: number,
+): PinnedFetch {
+  return async (input, init) => {
+    const response = await pinnedFetch(input, init);
+    if ((init?.method ?? 'GET').toUpperCase() !== 'POST') return response;
+
+    const contentLength = response.headers.get('content-length');
+    if (contentLength !== null && Number.parseInt(contentLength, 10) > maxBytes) {
+      await response.body?.cancel().catch(() => {});
+      throw new RemoteMcpPayloadSafetyError('Remote MCP response exceeds the configured byte limit.');
+    }
+    if (!response.body) return response;
+
+    let totalBytes = 0;
+    const boundedBody = response.body.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        totalBytes += chunk.byteLength;
+        if (totalBytes > maxBytes) {
+          throw new RemoteMcpPayloadSafetyError('Remote MCP response exceeds the configured byte limit.');
+        }
+        controller.enqueue(chunk);
+      },
+    }));
+    return new Response(boundedBody, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  };
+}
+
+/**
+ * Clone JSON-like MCP output while removing the exact bearer credential from
+ * every exposed string and property name. Traversal limits make malformed
+ * custom-client output fail closed instead of overflowing the process stack.
+ */
+export function redactRemoteMcpCredentialEchoes(value: unknown, credential: string): unknown {
+  if (credential === '') {
+    throw new RemoteMcpPayloadSafetyError('Remote MCP credential is empty.');
+  }
+  const patterns = credentialPatterns(credential);
+  if (!isContainer(value)) return redactPrimitive(value, patterns);
+
+  const root = createContainer(value);
+  const seen = new WeakSet<object>([value]);
+  const pending: Array<{ source: object; target: unknown[] | Record<string, unknown>; depth: number }> = [
+    { source: value, target: root, depth: 0 },
+  ];
+  let visitedNodes = 0;
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current) break;
+    if (current.depth >= MAX_PAYLOAD_DEPTH) {
+      throw new RemoteMcpPayloadSafetyError('Remote MCP response exceeds the supported nesting depth.');
+    }
+    for (const [key, field] of Object.entries(current.source)) {
+      visitedNodes += 1;
+      if (visitedNodes > MAX_PAYLOAD_NODES) {
+        throw new RemoteMcpPayloadSafetyError('Remote MCP response exceeds the supported node count.');
+      }
+      const safeKey = redactCredentialString(key, patterns);
+      if (!isContainer(field)) {
+        defineSafeProperty(current.target, safeKey, redactPrimitive(field, patterns));
+        continue;
+      }
+      if (seen.has(field)) {
+        throw new RemoteMcpPayloadSafetyError('Remote MCP response contains a circular reference.');
+      }
+      seen.add(field);
+      const child = createContainer(field);
+      defineSafeProperty(current.target, safeKey, child);
+      pending.push({ source: field, target: child, depth: current.depth + 1 });
+    }
+  }
+  return root;
+}
+
+function isContainer(value: unknown): value is object {
+  return value !== null && typeof value === 'object';
+}
+
+function createContainer(value: object): unknown[] | Record<string, unknown> {
+  return Array.isArray(value) ? new Array<unknown>(value.length) : {};
+}
+
+function redactPrimitive(value: unknown, patterns: readonly string[]): unknown {
+  if (typeof value === 'string') return redactCredentialString(value, patterns);
+  if (value === null || typeof value === 'number' || typeof value === 'boolean') {
+    return patterns.includes(String(value)) ? REDACTED : value;
+  }
+  return value;
+}
+
+function credentialPatterns(credential: string): readonly string[] {
+  const patterns = [credential];
+  let encoded: string;
+  try {
+    encoded = encodeURIComponent(credential);
+  } catch {
+    return patterns;
+  }
+  if (encoded !== credential) patterns.push(encoded);
+  return patterns;
+}
+
+function redactCredentialString(value: string, patterns: readonly string[]): string {
+  let redacted = value;
+  for (const pattern of patterns) redacted = redacted.replaceAll(pattern, REDACTED);
+  return redacted;
+}
+
+function defineSafeProperty(
+  target: unknown[] | Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+}

--- a/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
+++ b/src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.ts
@@ -3,12 +3,21 @@ import type { PinnedFetch } from './PinnedOutboundFactory.js';
 const REDACTED = '[redacted]';
 const MAX_PAYLOAD_DEPTH = 128;
 const MAX_PAYLOAD_NODES = 100_000;
+const MAX_CREDENTIAL_DECODE_DEPTH = 4;
+const JSON_ESCAPE_PATTERN = /\\(?:["\\/bfnrt]|u[0-9a-fA-F]{4})/g;
 
 export const DEFAULT_REMOTE_MCP_RESPONSE_BYTES = 1024 * 1024;
 
 interface CredentialPatterns {
+  readonly credential: string;
   readonly exact: readonly string[];
   readonly encoded: RegExp | null;
+}
+
+interface ResponseByteLimitState {
+  totalBytes: number;
+  previousByte: number;
+  byteBeforePrevious: number;
 }
 
 interface PayloadTraversalFrame {
@@ -32,8 +41,7 @@ export class RemoteMcpPayloadSafetyError extends Error {
 }
 
 /**
- * Limit each MCP POST response while preserving JSON and SSE streaming semantics.
- * Long-lived GET notification streams are intentionally not capped cumulatively.
+ * Limit each MCP POST response and each event on long-lived GET SSE streams.
  */
 export function createBoundedRemoteMcpFetch(
   pinnedFetch: PinnedFetch,
@@ -41,31 +49,77 @@ export function createBoundedRemoteMcpFetch(
 ): PinnedFetch {
   return async (input, init) => {
     const response = await pinnedFetch(input, init);
-    if ((init?.method ?? 'GET').toUpperCase() !== 'POST') return response;
+    const method = (init?.method ?? 'GET').toUpperCase();
+    if (method === 'POST') return boundRemoteMcpResponse(response, maxBytes, false);
+    if (method === 'GET') return boundRemoteMcpResponse(response, maxBytes, true);
+    return response;
+  };
+}
 
+function boundRemoteMcpResponse(response: Response, maxBytes: number, perSseEvent: boolean): Response {
+  if (!perSseEvent) {
     const contentLength = response.headers.get('content-length');
     if (contentLength !== null && Number.parseInt(contentLength, 10) > maxBytes) {
-      await response.body?.cancel().catch(() => {});
+      void response.body?.cancel().catch(() => {});
       throw new RemoteMcpPayloadSafetyError('Remote MCP response exceeds the configured byte limit.');
     }
-    if (!response.body) return response;
+  }
+  if (!response.body) return response;
 
-    let totalBytes = 0;
-    const boundedBody = response.body.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
-      transform(chunk, controller) {
-        totalBytes += chunk.byteLength;
-        if (totalBytes > maxBytes) {
-          throw new RemoteMcpPayloadSafetyError('Remote MCP response exceeds the configured byte limit.');
-        }
-        controller.enqueue(chunk);
-      },
-    }));
-    return new Response(boundedBody, {
-      status: response.status,
-      statusText: response.statusText,
-      headers: response.headers,
-    });
+  const state: ResponseByteLimitState = {
+    totalBytes: 0,
+    previousByte: -1,
+    byteBeforePrevious: -1,
   };
+  const boundedBody = response.body.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      enforceResponseByteLimit(chunk, maxBytes, perSseEvent, state);
+      controller.enqueue(chunk);
+    },
+  }));
+  return new Response(boundedBody, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
+function enforceResponseByteLimit(
+  chunk: Uint8Array,
+  maxBytes: number,
+  perSseEvent: boolean,
+  state: ResponseByteLimitState,
+): void {
+  if (!perSseEvent) {
+    state.totalBytes += chunk.byteLength;
+    assertWithinResponseByteLimit(state.totalBytes, maxBytes);
+    return;
+  }
+  for (const byte of chunk) {
+    if (isSseEventBoundary(byte, state.previousByte, state.byteBeforePrevious)) {
+      state.totalBytes = 0;
+    } else {
+      state.totalBytes += 1;
+      assertWithinResponseByteLimit(state.totalBytes, maxBytes);
+    }
+    state.byteBeforePrevious = state.previousByte;
+    state.previousByte = byte;
+  }
+}
+
+function assertWithinResponseByteLimit(totalBytes: number, maxBytes: number): void {
+  if (totalBytes > maxBytes) {
+    throw new RemoteMcpPayloadSafetyError('Remote MCP response exceeds the configured byte limit.');
+  }
+}
+
+function isSseEventBoundary(byte: number, previousByte: number, byteBeforePrevious: number): boolean {
+  const LF = 0x0a;
+  const CR = 0x0d;
+  if (byte === CR) return previousByte === CR || previousByte === LF;
+  if (byte !== LF) return false;
+  if (previousByte === LF) return true;
+  return previousByte === CR && (byteBeforePrevious === CR || byteBeforePrevious === LF);
 }
 
 /**
@@ -158,16 +212,67 @@ function credentialPatterns(credential: string): CredentialPatterns {
     throw new RemoteMcpPayloadSafetyError('Remote MCP credential cannot be safely redacted.');
   }
   return {
+    credential,
     exact: [credential],
     encoded: encodedCredentialPattern(credential),
   };
 }
 
 function redactCredentialString(value: string, patterns: CredentialPatterns): string {
+  if (decodedVariantContainsCredential(value, patterns.credential)) return REDACTED;
   let redacted = value;
   for (const pattern of patterns.exact) redacted = redacted.replaceAll(pattern, REDACTED);
   if (patterns.encoded) redacted = redacted.replace(patterns.encoded, REDACTED);
   return redacted;
+}
+
+function decodedVariantContainsCredential(value: string, credential: string): boolean {
+  const seen = new Set<string>([value]);
+  let frontier = [value];
+  for (let depth = 0; depth < MAX_CREDENTIAL_DECODE_DEPTH; depth += 1) {
+    const next: string[] = [];
+    for (const variant of frontier) {
+      for (const decoded of decodedVariants(variant)) {
+        if (depth > 0 && decoded.includes(credential)) return true;
+        if (decoded !== variant && !seen.has(decoded)) {
+          seen.add(decoded);
+          next.push(decoded);
+        }
+      }
+    }
+    frontier = next;
+    if (frontier.length === 0) return false;
+  }
+  return false;
+}
+
+function decodedVariants(value: string): readonly string[] {
+  const variants = [decodeJsonEscapes(value)];
+  try {
+    variants.push(decodeURIComponent(value));
+  } catch {
+    // Malformed percent escapes have no URI-decoded variant.
+  }
+  return variants;
+}
+
+function decodeJsonEscapes(value: string): string {
+  return value.replace(JSON_ESCAPE_PATTERN, (escape) => {
+    if (escape.startsWith(String.raw`\u`)) {
+      return String.fromCharCode(Number.parseInt(escape.slice(2), 16));
+    }
+    switch (escape[1]) {
+      case '"': return '"';
+      case '\\': return '\\';
+      case '/': return '/';
+      case 'b': return '\b';
+      case 'f': return '\f';
+      case 'n': return '\n';
+      case 'r': return '\r';
+      case 't': return '\t';
+      default: return escape;
+    }
+  });
 }
 
 function encodedCredentialPattern(credential: string): RegExp {

--- a/tests/unit/server/tools/IntegrationTools.test.ts
+++ b/tests/unit/server/tools/IntegrationTools.test.ts
@@ -463,7 +463,10 @@ describe('IntegrationTools', () => {
       provider: 'gmail',
       method: 'PUT',
       path: '_internal:/integration/openapi_spec',
-      body: { openapi: '3.1.0', paths: { '/profile': { get: { responses: { 200: { description: 'ok' } } } } } },
+      body: {
+        spec: { openapi: '3.1.0', paths: { '/profile': { get: { responses: { 200: { description: 'ok' } } } } } },
+        regenerateSkill: false,
+      },
     });
     expect(catalog.ingestOpenApiSpec).not.toHaveBeenCalled();
     expect(JSON.parse(result.content[0].text)).toMatchObject({

--- a/tests/unit/web-console/modules/AuthorizedIntegrationGateway.test.ts
+++ b/tests/unit/web-console/modules/AuthorizedIntegrationGateway.test.ts
@@ -187,9 +187,33 @@ describe('AuthorizedIntegrationOperationCatalog', () => {
       provider: 'gmail',
       method: 'PUT',
       path: '_internal:/integration/openapi_spec',
-      body: spec,
+      body: { spec, regenerateSkill: false },
     });
     expect(outcome).toMatchObject({ ok: true, result: { operationCount: 1 } });
+  });
+
+  it('binds the regenerate-skill side effect into spec-ingestion approval input', async () => {
+    const catalog = {
+      ingestOpenApiSpec: jest.fn<IntegrationOperationCatalog['ingestOpenApiSpec']>().mockResolvedValue({
+        provider: 'gmail',
+        descriptorId: '00000000-0000-4000-8000-000000000001',
+        specHash: 'a'.repeat(64),
+        operationCount: 1,
+      }),
+    } as unknown as IntegrationOperationCatalog;
+    const policyEnforcer = enforcerAllowing();
+    const authorized = new AuthorizedIntegrationOperationCatalog({ catalog, policyEnforcer });
+    const spec = { openapi: '3.1.0', paths: {} };
+
+    await authorized.ingestOpenApiSpec({ provider: 'gmail', spec, sourceUrl: null, regenerateSkill: false });
+    await authorized.ingestOpenApiSpec({ provider: 'gmail', spec, sourceUrl: null, regenerateSkill: true });
+
+    expect(policyEnforcer.authorize).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      body: { spec, regenerateSkill: false },
+    }));
+    expect(policyEnforcer.authorize).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      body: { spec, regenerateSkill: true },
+    }));
   });
 
   it('never mutates through the catalog when policy denies a management write', async () => {

--- a/tests/unit/web-console/modules/IntegrationOperationCatalog.test.ts
+++ b/tests/unit/web-console/modules/IntegrationOperationCatalog.test.ts
@@ -307,6 +307,31 @@ describe('IntegrationOperationCatalog', () => {
     }))).rejects.toMatchObject({ code: 'invalid_openapi_spec' });
   });
 
+  it.each([
+    ['protocol-relative', '//evil.example.com/messages'],
+    ['backslash-bearing', '/gmail\\v1/messages'],
+  ])('rejects %s OpenAPI operation paths during ingestion', async (_label, unsafePath) => {
+    const { catalog, contextTracker } = createCatalog({
+      descriptor: descriptor({ ownership: 'byo', ownerUserId: USER_ID }),
+      scopes: [GMAIL_READONLY],
+    });
+
+    await expect(runAsUser(contextTracker, () => catalog.ingestOpenApiSpec({
+      provider: 'gmail',
+      spec: {
+        ...openApiSpec(),
+        paths: {
+          [unsafePath]: {
+            get: { operationId: 'unsafe', responses: { 200: { description: 'ok' } } },
+          },
+        },
+      },
+    }))).rejects.toMatchObject({
+      code: 'invalid_openapi_spec',
+      message: expect.stringContaining('absolute paths'),
+    });
+  });
+
   it('accepts an equivalent canonical spelling of an allowlisted OpenAPI server host', async () => {
     const { catalog, contextTracker } = createCatalog({
       descriptor: descriptor({

--- a/tests/unit/web-console/modules/IntegrationRemoteMcpBridge.test.ts
+++ b/tests/unit/web-console/modules/IntegrationRemoteMcpBridge.test.ts
@@ -203,6 +203,29 @@ describe('IntegrationRemoteMcpBridge', () => {
     });
   });
 
+  it('fails closed when a credential collides with behavior-defining wrapper metadata', async () => {
+    const secretEncryption = encryption();
+    const clientFactory = jest.fn<RemoteMcpClientFactory>().mockResolvedValue({
+      listTools: jest.fn(),
+      callTool: jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'result' }] }),
+      close: jest.fn(() => Promise.resolve()),
+    });
+    const { bridge, contextTracker } = fixture({
+      clientFactory,
+      integrations: [integration(secretEncryption, REMOTE_DOCS, REMOTE_DOCS)],
+      secretEncryption,
+    });
+
+    await expect(runAsUser(contextTracker, () => bridge.callTool({
+      provider: REMOTE_DOCS,
+      remoteName: 'search',
+      arguments: {},
+    }))).rejects.toMatchObject({
+      code: 'remote_mcp_response_invalid',
+      status: 502,
+    } satisfies Partial<IntegrationRemoteMcpBridgeError>);
+  });
+
   it('rejects remote MCP server URLs outside descriptor apiHosts', async () => {
     const { bridge, contextTracker } = fixture({
       descriptor: descriptor({
@@ -385,6 +408,7 @@ function fixture(options: {
   readonly integration?: UserIntegrationRecord;
   readonly integrations?: readonly UserIntegrationRecord[];
   readonly integrationStore?: IUserIntegrationStore;
+  readonly secretEncryption?: AeadSecretEncryptionService;
   readonly clientFactory?: RemoteMcpClientFactory;
   readonly dnsLookup?: DnsLookup;
   readonly timeoutMs?: number;
@@ -393,7 +417,7 @@ function fixture(options: {
   readonly discoveryGate?: (provider: string) => Promise<boolean>;
 } = {}) {
   const contextTracker = new ContextTracker();
-  const secretEncryption = encryption();
+  const secretEncryption = options.secretEncryption ?? encryption();
   const descriptorRecords = options.descriptors ?? [options.descriptor ?? descriptor()];
   const integrationRecords = options.integrations ?? [options.integration ?? integration(secretEncryption)];
   return {
@@ -452,7 +476,11 @@ function descriptor(overrides: Partial<IntegrationDescriptorRecord> = {}): Integ
   };
 }
 
-function integration(secretEncryption: AeadSecretEncryptionService, provider = REMOTE_DOCS): UserIntegrationRecord {
+function integration(
+  secretEncryption: AeadSecretEncryptionService,
+  provider = REMOTE_DOCS,
+  accessToken = 'remote-access-token',
+): UserIntegrationRecord {
   return {
     id: INTEGRATION_ID,
     userId: USER_ID,
@@ -461,7 +489,7 @@ function integration(secretEncryption: AeadSecretEncryptionService, provider = R
     externalInstallationId: null,
     authorizedPermissions: { scopes: ['docs.read'] },
     accessTokenCiphertext: secretEncryption.encrypt(
-      Buffer.from('remote-access-token', 'utf8'),
+      Buffer.from(accessToken, 'utf8'),
       integrationSecretContext('access_token', USER_ID, provider),
     ),
     refreshTokenCiphertext: null,

--- a/tests/unit/web-console/modules/IntegrationRemoteMcpBridge.test.ts
+++ b/tests/unit/web-console/modules/IntegrationRemoteMcpBridge.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../../src/web-console/modules/integrations/IntegrationRemoteMcpBridge.js';
 import { integrationSecretContext } from '../../../../src/web-console/modules/integrations/IntegrationSecretContext.js';
 import type { DnsLookup } from '../../../../src/web-console/modules/integrations/IntegrationPublicHostGuard.js';
+import type { PinnedFetch, PinnedOutboundFactory } from '../../../../src/web-console/modules/integrations/PinnedOutboundFactory.js';
 
 const USER_ID = '00000000-0000-4000-8000-000000000001';
 const DESCRIPTOR_ID = '00000000-0000-4000-8000-000000000002';
@@ -131,6 +132,77 @@ describe('IntegrationRemoteMcpBridge', () => {
     });
   });
 
+  it('redacts bearer-token echoes throughout remote MCP call results', async () => {
+    const credential = 'remote-access-token';
+    const clientFactory = jest.fn<RemoteMcpClientFactory>().mockResolvedValue({
+      listTools: jest.fn(),
+      callTool: jest.fn().mockResolvedValue({
+        content: [{ type: 'text', text: `remote echoed ${credential}` }],
+        structuredContent: {
+          nested: [`Bearer ${credential}`, { [credential]: credential }],
+        },
+      }),
+      close: jest.fn(() => Promise.resolve()),
+    });
+    const { bridge, contextTracker } = fixture({ clientFactory });
+
+    const result = await runAsUser(contextTracker, () => bridge.callTool({
+      provider: REMOTE_DOCS,
+      remoteName: 'search',
+      arguments: {},
+    }));
+
+    expect(JSON.stringify(result)).not.toContain(credential);
+    expect(result.result).toMatchObject({
+      content: [{ text: 'remote echoed [redacted]' }],
+      structuredContent: {
+        nested: ['Bearer [redacted]', { '[redacted]': '[redacted]' }],
+      },
+    });
+  });
+
+  it('replaces credential-bearing remote MCP errors with a static failure', async () => {
+    const clientFactory = jest.fn<RemoteMcpClientFactory>().mockResolvedValue({
+      listTools: jest.fn(),
+      callTool: jest.fn().mockRejectedValue(new Error('Bearer remote-access-token was rejected')),
+      close: jest.fn(() => Promise.resolve()),
+    });
+    const { bridge, contextTracker } = fixture({ clientFactory });
+
+    await expect(runAsUser(contextTracker, () => bridge.callTool({
+      provider: REMOTE_DOCS,
+      remoteName: 'search',
+      arguments: {},
+    }))).rejects.toMatchObject({
+      code: 'remote_mcp_call_failed',
+      message: 'Remote MCP tool call failed.',
+      status: 502,
+    } satisfies Partial<IntegrationRemoteMcpBridgeError>);
+  });
+
+  it('redacts bearer-token echoes from discovered tool metadata', async () => {
+    const clientFactory = jest.fn<RemoteMcpClientFactory>().mockResolvedValue({
+      listTools: jest.fn().mockResolvedValue({
+        tools: [{
+          name: 'search',
+          description: 'Use remote-access-token to search',
+          inputSchema: { type: 'object', description: 'Bearer remote-access-token' },
+        }],
+      }),
+      callTool: jest.fn(),
+      close: jest.fn(() => Promise.resolve()),
+    });
+    const { bridge, contextTracker } = fixture({ clientFactory });
+
+    const tools = await runAsUser(contextTracker, () => bridge.listAllowedTools());
+
+    expect(JSON.stringify(tools)).not.toContain('remote-access-token');
+    expect(tools[0]).toMatchObject({
+      description: 'Use [redacted] to search',
+      inputSchema: { description: 'Bearer [redacted]' },
+    });
+  });
+
   it('rejects remote MCP server URLs outside descriptor apiHosts', async () => {
     const { bridge, contextTracker } = fixture({
       descriptor: descriptor({
@@ -150,6 +222,67 @@ describe('IntegrationRemoteMcpBridge', () => {
     }))).rejects.toMatchObject({
       code: 'remote_mcp_server_not_allowed',
       status: 400,
+    } satisfies Partial<IntegrationRemoteMcpBridgeError>);
+  });
+
+  it('rejects remote MCP server URLs containing user information', async () => {
+    const { bridge, contextTracker } = fixture({
+      descriptor: descriptor({
+        operationPromotion: {
+          remoteMcp: {
+            serverUrl: 'https://user:password@mcp.example.com/mcp',
+            tools: ['search'],
+          },
+        },
+      }),
+    });
+
+    await expect(runAsUser(contextTracker, () => bridge.callTool({
+      provider: REMOTE_DOCS,
+      remoteName: 'search',
+      arguments: {},
+    }))).rejects.toMatchObject({
+      code: 'remote_mcp_invalid_server_url',
+      status: 400,
+    } satisfies Partial<IntegrationRemoteMcpBridgeError>);
+  });
+
+  it('rejects chunked remote MCP POST responses that exceed the byte cap', async () => {
+    const encoder = new TextEncoder();
+    const rawFetch = jest.fn<PinnedFetch>().mockResolvedValue(new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('12345'));
+        controller.enqueue(encoder.encode('67890'));
+        controller.close();
+      },
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+    const pinnedOutbound: PinnedOutboundFactory = () => ({
+      fetch: rawFetch,
+      close: () => Promise.resolve(),
+    });
+    const clientFactory = jest.fn<RemoteMcpClientFactory>().mockImplementation(async ({ pinnedFetch, serverUrl }) => {
+      const response = await pinnedFetch(serverUrl, { method: 'POST' });
+      await response.text();
+      return {
+        listTools: () => Promise.resolve({ tools: [] }),
+        callTool: () => Promise.resolve({}),
+        close: () => Promise.resolve(),
+      };
+    });
+    const { bridge, contextTracker } = fixture({
+      clientFactory,
+      pinnedOutbound,
+      maxResponseBytes: 8,
+    });
+
+    await expect(runAsUser(contextTracker, () => bridge.callTool({
+      provider: REMOTE_DOCS,
+      remoteName: 'search',
+      arguments: {},
+    }))).rejects.toMatchObject({
+      code: 'remote_mcp_connect_failed',
+      message: 'Remote MCP server connection failed.',
+      status: 502,
     } satisfies Partial<IntegrationRemoteMcpBridgeError>);
   });
 
@@ -255,6 +388,8 @@ function fixture(options: {
   readonly clientFactory?: RemoteMcpClientFactory;
   readonly dnsLookup?: DnsLookup;
   readonly timeoutMs?: number;
+  readonly maxResponseBytes?: number;
+  readonly pinnedOutbound?: PinnedOutboundFactory;
   readonly discoveryGate?: (provider: string) => Promise<boolean>;
 } = {}) {
   const contextTracker = new ContextTracker();
@@ -271,6 +406,8 @@ function fixture(options: {
       discoveryGate: options.discoveryGate ?? (() => Promise.resolve(true)),
       dnsLookup: options.dnsLookup ?? publicDnsLookup,
       timeoutMs: options.timeoutMs,
+      maxResponseBytes: options.maxResponseBytes,
+      pinnedOutbound: options.pinnedOutbound,
       clientFactory: options.clientFactory ?? (() => Promise.resolve({
         listTools: () => Promise.resolve({ tools: [] }),
         callTool: () => Promise.resolve({}),

--- a/tests/unit/web-console/modules/IntegrationRemoteMcpSecurity.test.ts
+++ b/tests/unit/web-console/modules/IntegrationRemoteMcpSecurity.test.ts
@@ -59,6 +59,7 @@ describe('IntegrationRemoteMcpSecurity', () => {
       nestedJson: 'abc\\\\/def',
       mixedLayers: 'abc%255Cu002fdef',
       malformedNeighbor: '%ZZabc%252Fdef',
+      invalidUtf8Neighbor: '%FF%61%62%63%252F%64%65%66',
     }, 'abc/def');
 
     expect(result).toEqual({
@@ -66,6 +67,7 @@ describe('IntegrationRemoteMcpSecurity', () => {
       nestedJson: '[redacted]',
       mixedLayers: '[redacted]',
       malformedNeighbor: '[redacted]',
+      invalidUtf8Neighbor: '[redacted]',
     });
   });
 

--- a/tests/unit/web-console/modules/IntegrationRemoteMcpSecurity.test.ts
+++ b/tests/unit/web-console/modules/IntegrationRemoteMcpSecurity.test.ts
@@ -53,6 +53,15 @@ describe('IntegrationRemoteMcpSecurity', () => {
     });
   });
 
+  it('redacts credential substrings in serialized primitives', () => {
+    expect(redactRemoteMcpCredentialEchoes({ value: 91234 }, '123')).toEqual({
+      value: '9[redacted]4',
+    });
+    expect(redactRemoteMcpCredentialEchoes({ value: true }, 'rue')).toEqual({
+      value: 't[redacted]',
+    });
+  });
+
   it('rejects declared and chunked POST responses above the byte limit', async () => {
     const encoder = new TextEncoder();
     const declaredFetch = jest.fn<PinnedFetch>().mockResolvedValue(new Response('small', {
@@ -87,6 +96,9 @@ describe('IntegrationRemoteMcpSecurity', () => {
 
   it('fails closed for empty credentials and circular custom-client output', () => {
     expect(() => redactRemoteMcpCredentialEchoes({}, '')).toThrow(RemoteMcpPayloadSafetyError);
+    expect(() => redactRemoteMcpCredentialEchoes({}, '[redacted]')).toThrow(RemoteMcpPayloadSafetyError);
+    expect(() => redactRemoteMcpCredentialEchoes({}, 'red')).toThrow(RemoteMcpPayloadSafetyError);
+    expect(() => redactRemoteMcpCredentialEchoes({}, '\uD800')).toThrow(RemoteMcpPayloadSafetyError);
     const circular: Record<string, unknown> = {};
     circular.self = circular;
     expect(() => redactRemoteMcpCredentialEchoes(circular, 'credential')).toThrow(

--- a/tests/unit/web-console/modules/IntegrationRemoteMcpSecurity.test.ts
+++ b/tests/unit/web-console/modules/IntegrationRemoteMcpSecurity.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import {
+  createBoundedRemoteMcpFetch,
+  redactRemoteMcpCredentialEchoes,
+  RemoteMcpPayloadSafetyError,
+} from '../../../../src/web-console/modules/integrations/IntegrationRemoteMcpSecurity.js';
+import type { PinnedFetch } from '../../../../src/web-console/modules/integrations/PinnedOutboundFactory.js';
+
+describe('IntegrationRemoteMcpSecurity', () => {
+  it('redacts equivalent lowercase and mixed-case percent escapes', () => {
+    const result = redactRemoteMcpCredentialEchoes({
+      lower: 'abc%2fdef%3ahere',
+      mixed: 'abc%2Fdef%3ahere',
+      ordinaryCaseIsSignificant: 'ABC%2fdef%3ahere',
+    }, 'abc/def:here');
+
+    expect(result).toEqual({
+      lower: '[redacted]',
+      mixed: '[redacted]',
+      ordinaryCaseIsSignificant: 'ABC%2fdef%3ahere',
+    });
+  });
+
+  it('rejects declared and chunked POST responses above the byte limit', async () => {
+    const encoder = new TextEncoder();
+    const declaredFetch = jest.fn<PinnedFetch>().mockResolvedValue(new Response('small', {
+      headers: { 'content-length': '9' },
+    }));
+    const chunkedFetch = jest.fn<PinnedFetch>().mockResolvedValue(new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('12345'));
+        controller.enqueue(encoder.encode('67890'));
+        controller.close();
+      },
+    })));
+
+    await expect(createBoundedRemoteMcpFetch(declaredFetch, 8)(new URL('https://mcp.example.com'), {
+      method: 'POST',
+    })).rejects.toBeInstanceOf(RemoteMcpPayloadSafetyError);
+    const chunked = await createBoundedRemoteMcpFetch(chunkedFetch, 8)(new URL('https://mcp.example.com'), {
+      method: 'POST',
+    });
+    await expect(chunked.text()).rejects.toBeInstanceOf(RemoteMcpPayloadSafetyError);
+  });
+
+  it('leaves long-lived GET response streams uncapped', async () => {
+    const pinnedFetch = jest.fn<PinnedFetch>().mockResolvedValue(new Response('1234567890'));
+
+    const response = await createBoundedRemoteMcpFetch(pinnedFetch, 8)(new URL('https://mcp.example.com'), {
+      method: 'GET',
+    });
+
+    await expect(response.text()).resolves.toBe('1234567890');
+  });
+
+  it('fails closed for empty credentials and circular custom-client output', () => {
+    expect(() => redactRemoteMcpCredentialEchoes({}, '')).toThrow(RemoteMcpPayloadSafetyError);
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() => redactRemoteMcpCredentialEchoes(circular, 'credential')).toThrow(
+      RemoteMcpPayloadSafetyError,
+    );
+  });
+});

--- a/tests/unit/web-console/modules/IntegrationRemoteMcpSecurity.test.ts
+++ b/tests/unit/web-console/modules/IntegrationRemoteMcpSecurity.test.ts
@@ -37,6 +37,22 @@ describe('IntegrationRemoteMcpSecurity', () => {
     });
   });
 
+  it('redacts credentials in already-serialized JSON and log strings', () => {
+    const result = redactRemoteMcpCredentialEchoes({
+      shortEscape: 'abc\\/def',
+      unicodeEscape: '\\u0061bc\\u002fdef',
+      mixed: 'a%62c\\u002Fdef',
+      ordinaryCaseIsSignificant: '\\u0041bc\\/def',
+    }, 'abc/def');
+
+    expect(result).toEqual({
+      shortEscape: '[redacted]',
+      unicodeEscape: '[redacted]',
+      mixed: '[redacted]',
+      ordinaryCaseIsSignificant: '\\u0041bc\\/def',
+    });
+  });
+
   it('rejects declared and chunked POST responses above the byte limit', async () => {
     const encoder = new TextEncoder();
     const declaredFetch = jest.fn<PinnedFetch>().mockResolvedValue(new Response('small', {

--- a/tests/unit/web-console/modules/IntegrationRemoteMcpSecurity.test.ts
+++ b/tests/unit/web-console/modules/IntegrationRemoteMcpSecurity.test.ts
@@ -78,6 +78,9 @@ describe('IntegrationRemoteMcpSecurity', () => {
     expect(redactRemoteMcpCredentialEchoes({ value: true }, 'rue')).toEqual({
       value: 't[redacted]',
     });
+    expect(redactRemoteMcpCredentialEchoes({ value: 'd]xx' }, 'd]x')).toEqual({
+      value: '[redacted]',
+    });
   });
 
   it('rejects declared and chunked POST responses above the byte limit', async () => {

--- a/tests/unit/web-console/modules/IntegrationRemoteMcpSecurity.test.ts
+++ b/tests/unit/web-console/modules/IntegrationRemoteMcpSecurity.test.ts
@@ -22,6 +22,21 @@ describe('IntegrationRemoteMcpSecurity', () => {
     });
   });
 
+  it('redacts URI-unreserved credential characters when remotely percent encoded', () => {
+    const credential = 'header.payload-signature_v1~';
+    const result = redactRemoteMcpCredentialEchoes({
+      encoded: 'header%2epayload%2Dsignature%5fv1%7e',
+      mixed: 'header%2Epayload-signature%5Fv1~',
+      ordinaryCaseIsSignificant: 'Header%2epayload%2Dsignature%5fv1%7e',
+    }, credential);
+
+    expect(result).toEqual({
+      encoded: '[redacted]',
+      mixed: '[redacted]',
+      ordinaryCaseIsSignificant: 'Header%2epayload%2Dsignature%5fv1%7e',
+    });
+  });
+
   it('rejects declared and chunked POST responses above the byte limit', async () => {
     const encoder = new TextEncoder();
     const declaredFetch = jest.fn<PinnedFetch>().mockResolvedValue(new Response('small', {

--- a/tests/unit/web-console/modules/IntegrationRemoteMcpSecurity.test.ts
+++ b/tests/unit/web-console/modules/IntegrationRemoteMcpSecurity.test.ts
@@ -58,12 +58,14 @@ describe('IntegrationRemoteMcpSecurity', () => {
       doublePercent: 'abc%252Fdef',
       nestedJson: 'abc\\\\/def',
       mixedLayers: 'abc%255Cu002fdef',
+      malformedNeighbor: '%ZZabc%252Fdef',
     }, 'abc/def');
 
     expect(result).toEqual({
       doublePercent: '[redacted]',
       nestedJson: '[redacted]',
       mixedLayers: '[redacted]',
+      malformedNeighbor: '[redacted]',
     });
   });
 

--- a/tests/unit/web-console/modules/IntegrationRemoteMcpSecurity.test.ts
+++ b/tests/unit/web-console/modules/IntegrationRemoteMcpSecurity.test.ts
@@ -53,6 +53,20 @@ describe('IntegrationRemoteMcpSecurity', () => {
     });
   });
 
+  it('redacts credentials recovered through bounded recursive decoding', () => {
+    const result = redactRemoteMcpCredentialEchoes({
+      doublePercent: 'abc%252Fdef',
+      nestedJson: 'abc\\\\/def',
+      mixedLayers: 'abc%255Cu002fdef',
+    }, 'abc/def');
+
+    expect(result).toEqual({
+      doublePercent: '[redacted]',
+      nestedJson: '[redacted]',
+      mixedLayers: '[redacted]',
+    });
+  });
+
   it('redacts credential substrings in serialized primitives', () => {
     expect(redactRemoteMcpCredentialEchoes({ value: 91234 }, '123')).toEqual({
       value: '9[redacted]4',
@@ -84,14 +98,33 @@ describe('IntegrationRemoteMcpSecurity', () => {
     await expect(chunked.text()).rejects.toBeInstanceOf(RemoteMcpPayloadSafetyError);
   });
 
-  it('leaves long-lived GET response streams uncapped', async () => {
-    const pinnedFetch = jest.fn<PinnedFetch>().mockResolvedValue(new Response('1234567890'));
+  it('caps each GET SSE event without imposing a cumulative stream limit', async () => {
+    const encoder = new TextEncoder();
+    const allowedFetch = jest.fn<PinnedFetch>().mockResolvedValue(new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('1234\n'));
+        controller.enqueue(encoder.encode('\n5678\r\n'));
+        controller.enqueue(encoder.encode('\r\n'));
+        controller.close();
+      },
+    })));
+    const oversizedFetch = jest.fn<PinnedFetch>().mockResolvedValue(new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('1234'));
+        controller.enqueue(encoder.encode('56789'));
+        controller.close();
+      },
+    })));
 
-    const response = await createBoundedRemoteMcpFetch(pinnedFetch, 8)(new URL('https://mcp.example.com'), {
+    const response = await createBoundedRemoteMcpFetch(allowedFetch, 8)(new URL('https://mcp.example.com'), {
+      method: 'GET',
+    });
+    const oversized = await createBoundedRemoteMcpFetch(oversizedFetch, 8)(new URL('https://mcp.example.com'), {
       method: 'GET',
     });
 
-    await expect(response.text()).resolves.toBe('1234567890');
+    await expect(response.text()).resolves.toBe('1234\n\n5678\r\n\r\n');
+    await expect(oversized.text()).rejects.toBeInstanceOf(RemoteMcpPayloadSafetyError);
   });
 
   it('fails closed for empty credentials and circular custom-client output', () => {


### PR DESCRIPTION
## Summary

First child PR for the hosted-integration promotion tracked by #2516. This PR is limited to the current security blockers and directly related input-boundary hardening.

- bind the behavior-changing `regenerateSkill` flag into OpenAPI-ingestion approval material
- cap every remote MCP POST response and each GET SSE event at 1 MiB before SDK parsing
- recursively redact exact, percent-encoded, JSON-escaped, and bounded multiply encoded bearer-token echoes from remote MCP tool metadata and call results
- replace upstream connect/list/call exception text with static bridge errors so credentials cannot escape through logs or callers
- reject remote MCP URLs containing userinfo and reject protocol-relative/backslash OpenAPI paths at ingestion
- add regression coverage through both the authorized facades and the model-facing integration tools

## Security properties

- approval for `regenerateSkill: false` cannot authorize a replay with `regenerateSkill: true`
- a malicious remote MCP server cannot return its bearer credential to the model in nested result shapes, keys, descriptions, or schemas
- declared and chunked oversized POST responses and unterminated oversized GET SSE events are bounded before SDK parsing
- remote error bodies are not propagated as exception messages
- response traversal fails closed on excessive depth, node count, or circular custom-client output

## Validation

- `npm run build`
- `npx tsc --noEmit`
- ESLint on all changed source and test files with zero warnings
- 66 focused integration-policy/bridge/catalog/tool tests
- 494 built-package and protocol regression tests
- 108 critical security tests
- repository security audit: 0 critical, 0 high, 0 medium; 8 pre-existing low audit-logging heuristics

A monolithic local all-tests run was also attempted. It reached unrelated environmental failures (Podman unavailable), local timing thresholds, and eventually the process heap ceiling; the affected build-dependent suites passed after the required build in the 494-test regression run. GitHub CI remains the full-suite source of truth.

## Merge policy

Use a merge commit; do not squash or rebase. This PR must not be merged until explicitly approved.

Refs #2516