### PR TITLE
fix(security): clear hosted CodeQL blockers

### DIFF
--- a/scripts/lib/web-console-preview-credentials.ts
+++ b/scripts/lib/web-console-preview-credentials.ts
@@ -1,0 +1,41 @@
+import { randomUUID } from 'node:crypto';
+import { unlinkSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+interface PreviewCredentials {
+  readonly username: string;
+  readonly password: string;
+}
+
+interface NodeError extends Error {
+  readonly code?: string;
+}
+
+export function createPreviewCredentialFile(
+  directory: string,
+  credentials: PreviewCredentials,
+): string {
+  const credentialPath = path.join(
+    directory,
+    `.preview-credentials-${process.pid}-${randomUUID()}.json`,
+  );
+  const content = `${JSON.stringify(credentials, null, 2)}\n`;
+
+  writeFileSync(credentialPath, content, {
+    encoding: 'utf8',
+    flag: 'wx',
+    mode: 0o600,
+  });
+
+  return credentialPath;
+}
+
+export function removePreviewCredentialFile(credentialPath: string): void {
+  try {
+    unlinkSync(credentialPath);
+  } catch (error) {
+    if ((error as NodeError).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}

--- a/scripts/web-console-preview.ts
+++ b/scripts/web-console-preview.ts
@@ -2,6 +2,10 @@
 
 import { mkdirSync } from 'node:fs';
 import path from 'node:path';
+import {
+  createPreviewCredentialFile,
+  removePreviewCredentialFile,
+} from './lib/web-console-preview-credentials.js';
 
 const previewRoot = path.join(process.cwd(), '.console-preview');
 mkdirSync(previewRoot, { recursive: true });
@@ -20,6 +24,7 @@ const [{ BASE_URL, DB_NAME, bootApp, provisionDatabase, superuserUrlFor, waitFor
   ]);
 
 let childPid: number | undefined;
+let credentialPath: string | undefined;
 let stopping = false;
 let forceKillTimer: NodeJS.Timeout | undefined;
 
@@ -51,9 +56,13 @@ try {
   await seed.seedWorld();
   await closeDb();
 
+  credentialPath = createPreviewCredentialFile(previewRoot, {
+    username: 'e2e_admin',
+    password: seed.SEED_PASSWORD,
+  });
+
   console.log(`Web console preview: ${BASE_URL}/ui`);
-  console.log('Username: e2e_admin');
-  console.log(`Password: ${seed.SEED_PASSWORD}`);
+  console.log(`Credentials: ${credentialPath}`);
   console.log(`Runtime: ${process.env.E2E_APP_ENTRY ?? 'src/index.ts'}`);
   console.log(`Logs: ${logPath}`);
   console.log('Press Ctrl-C to stop.');
@@ -66,6 +75,13 @@ try {
   });
 } finally {
   if (forceKillTimer) clearTimeout(forceKillTimer);
+  if (credentialPath) {
+    try {
+      removePreviewCredentialFile(credentialPath);
+    } catch {
+      console.error(`Unable to remove preview credentials: ${credentialPath}`);
+    }
+  }
   await closeDb().catch(() => {});
   if (childPid !== undefined) {
     try { process.kill(-childPid, 'SIGKILL'); } catch { /* process already exited */ }

--- a/tests/unit/auth/embedded-as/allowlistGate.test.ts
+++ b/tests/unit/auth/embedded-as/allowlistGate.test.ts
@@ -316,10 +316,14 @@ describe('renderAllowlistDeniedPage', () => {
     expect(html).not.toMatch(/github_/);
   });
 
-  it('escapes operator-supplied contact note', () => {
-    const html = renderAllowlistDeniedPage('<script>alert("xss")</script>');
-    expect(html).not.toMatch(/<script>/);
-    expect(html).toMatch(/&lt;script&gt;/);
+  it.each([
+    '<script>alert("xss")</script>',
+    '<SCRIPT>alert("xss")</SCRIPT>',
+    '<ScRiPt data-test="xss">alert("xss")</sCrIpT>',
+  ])('escapes operator-supplied contact note: %s', contactNote => {
+    const html = renderAllowlistDeniedPage(contactNote);
+    expect(html).not.toMatch(/<script(?:\s|>)/i);
+    expect(html).toMatch(/&lt;script(?:\s|&gt;)/i);
     expect(html).toMatch(/&quot;|alert\(/);
   });
 

--- a/tests/unit/scripts/web-console-preview-credentials.test.ts
+++ b/tests/unit/scripts/web-console-preview-credentials.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from '@jest/globals';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  createPreviewCredentialFile,
+  removePreviewCredentialFile,
+} from '../../../scripts/lib/web-console-preview-credentials.js';
+
+const tempDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('web console preview credentials', () => {
+  it('writes credentials to an unpredictable owner-readable file', () => {
+    const directory = createTempDirectory();
+    const firstPath = createPreviewCredentialFile(directory, {
+      username: 'e2e_admin',
+      password: 'first-secret',
+    });
+    const secondPath = createPreviewCredentialFile(directory, {
+      username: 'e2e_admin',
+      password: 'second-secret',
+    });
+
+    expect(firstPath).not.toBe(secondPath);
+    expect(JSON.parse(fs.readFileSync(firstPath, 'utf8'))).toEqual({
+      username: 'e2e_admin',
+      password: 'first-secret',
+    });
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(firstPath).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it('removes the credential file and tolerates repeated cleanup', () => {
+    const directory = createTempDirectory();
+    const credentialPath = createPreviewCredentialFile(directory, {
+      username: 'e2e_admin',
+      password: 'temporary-secret',
+    });
+
+    removePreviewCredentialFile(credentialPath);
+    expect(fs.existsSync(credentialPath)).toBe(false);
+    expect(() => removePreviewCredentialFile(credentialPath)).not.toThrow();
+  });
+
+  it('keeps the preview launcher from writing the password to stdout', () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'scripts', 'web-console-preview.ts'),
+      'utf8',
+    );
+
+    expect(source).not.toMatch(/console\.log\([^\n]*SEED_PASSWORD/);
+    expect(source).toContain('createPreviewCredentialFile');
+    expect(source).toContain('removePreviewCredentialFile');
+  });
+});
+
+function createTempDirectory(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'dollhouse-preview-credentials-'));
+  tempDirectories.push(directory);
+  return directory;
+}


### PR DESCRIPTION
## Summary

- replace clear-text preview password logging with an unpredictable credential file created with owner-only permissions
- remove the temporary credential file during preview shutdown and failure cleanup
- strengthen the allowlist denial-page XSS regression for lowercase, uppercase, and mixed-case script tags

## Security contract

The preview remains loopback-only. Its generated password is no longer written to stdout or stderr; the launcher prints only the path to a mode-0600 JSON credential file under `.console-preview`. Cleanup tolerates an already-removed file but surfaces other deletion failures without exposing credential contents.

## Validation

- `npm ci --ignore-scripts`
- focused Jest suites: 30/30 passed
- `BuildInfoService.parallel.test.ts`: 21/21 passed on isolated rerun after one full-suite timing fluctuation
- ESLint on all changed files: passed
- `npm run build`: passed
- `npm run security:audit`: passed with 0 critical/high/medium findings (8 pre-existing low audit-logging heuristics)
- `git diff --check`: passed
- full serial Jest run progressed through the broad suite but was not clean locally: an unchanged GitHub collection token test exceeded its 10-second timeout, then Node exhausted its 4 GB heap after roughly six minutes

Closes #2523
Closes #2524

## Merge policy

Do not merge without Mick's explicit approval. Use a merge commit, never squash or rebase, to preserve history and attribution.