### PR TITLE
ci: bind Claude reviews to the current PR head

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,6 +11,10 @@ on:
     #   - "src/**/*.jsx"
   workflow_dispatch:  # Allow manual runs on fork PRs by maintainers
 
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Skip Dependabot PRs and fork PRs since they don't have access to secrets (CLAUDE_CODE_OAUTH_TOKEN)
@@ -29,9 +33,31 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify checked out PR head
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          actual_head_sha="$(git rev-parse HEAD)"
+          if [[ "${actual_head_sha}" != "${EXPECTED_HEAD_SHA}" ]]; then
+            echo "::error::Checked out ${actual_head_sha}, expected PR head ${EXPECTED_HEAD_SHA}"
+            exit 1
+          fi
+          current_head_sha="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+          if [[ "${current_head_sha}" != "${EXPECTED_HEAD_SHA}" ]]; then
+            echo "::error::Queued review expected ${EXPECTED_HEAD_SHA}, current PR head is ${current_head_sha}"
+            exit 1
+          fi
+          echo "Review checkout verified at ${EXPECTED_HEAD_SHA}"
 
       - name: Run Claude Code Review
         id: claude-review
@@ -45,6 +71,12 @@ jobs:
           
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
+            The exact pull-request head for this review is ${{ github.event.pull_request.head.sha }}.
+            Before reviewing, verify that git rev-parse HEAD equals that exact SHA. If it does
+            not match, stop and report the mismatch instead of reviewing stale code. Review
+            the complete pull-request diff ending at that SHA, and begin the report with:
+            **Reviewed commit:** `${{ github.event.pull_request.head.sha }}`
+
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
@@ -56,27 +88,17 @@ jobs:
             
             Be constructive and helpful in your feedback.
 
-          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
-          
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
-          
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
-          # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
+      - name: Verify PR head remained current
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          current_head_sha="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+          if [[ "${current_head_sha}" != "${EXPECTED_HEAD_SHA}" ]]; then
+            echo "::error::PR head moved from ${EXPECTED_HEAD_SHA} to ${current_head_sha} during review"
+            exit 1
+          fi
+          echo "Review completed for current PR head ${EXPECTED_HEAD_SHA}"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,13 +29,13 @@ jobs:
       contents: read
       pull-requests: write
       issues: read
-      id-token: write
     
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # The reviewer needs both PR parents locally to inspect the complete diff.
           fetch-depth: 0
           persist-credentials: false
 

--- a/tests/unit/github-workflow-validation.test.ts
+++ b/tests/unit/github-workflow-validation.test.ts
@@ -34,6 +34,10 @@ interface Workflow {
   jobs: Record<string, WorkflowJob>;
   env?: Record<string, any>;
   permissions?: Record<string, string> | string;
+  concurrency?: {
+    group?: string;
+    'cancel-in-progress'?: boolean;
+  };
 }
 
 describe('GitHub Workflow Validation', () => {
@@ -222,6 +226,46 @@ describe('GitHub Workflow Validation', () => {
 
       expect(betaPublishWorkflow).toContain('-beta(\\.[0-9A-Za-z.-]+)?$');
       expect(betaDeployWorkflow).toContain('-beta(\\.[0-9A-Za-z.-]+)?$');
+    });
+  });
+
+  describe('Claude review head integrity', () => {
+    let workflow: Workflow;
+
+    beforeAll(() => {
+      const workflowPath = path.join(workflowDir, 'claude-code-review.yml');
+      workflow = yaml.load(fs.readFileSync(workflowPath, 'utf8')) as Workflow;
+    });
+
+    it('cancels superseded reviews for the same pull request', () => {
+      expect(workflow.concurrency?.group).toContain('github.event.pull_request.number');
+      expect(workflow.concurrency?.['cancel-in-progress']).toBe(true);
+    });
+
+    it('checks out and verifies the exact pull-request head', () => {
+      const steps = workflow.jobs['claude-review'].steps;
+      const checkout = steps.find(step => step.name === 'Checkout repository');
+      const verifyCheckout = steps.find(step => step.name === 'Verify checked out PR head');
+
+      expect(checkout?.uses).toMatch(/^actions\/checkout@[a-f0-9]{40}$/);
+      expect(checkout?.with?.ref).toBe('${{ github.event.pull_request.head.sha }}');
+      expect(checkout?.with?.['fetch-depth']).toBe(0);
+      expect(checkout?.with?.['persist-credentials']).toBe(false);
+      expect(verifyCheckout?.run).toContain('git rev-parse HEAD');
+      expect(verifyCheckout?.run).toContain("--jq '.head.sha'");
+      expect(verifyCheckout?.run).toContain('EXPECTED_HEAD_SHA');
+    });
+
+    it('binds the review prompt and completion check to the same head', () => {
+      const steps = workflow.jobs['claude-review'].steps;
+      const review = steps.find(step => step.name === 'Run Claude Code Review');
+      const verifyCurrent = steps.find(step => step.name === 'Verify PR head remained current');
+      const prompt = String(review?.with?.direct_prompt ?? '');
+
+      expect(prompt).toContain('github.event.pull_request.head.sha');
+      expect(prompt).toContain('**Reviewed commit:**');
+      expect(verifyCurrent?.run).toContain("--jq '.head.sha'");
+      expect(verifyCurrent?.run).toContain('PR head moved');
     });
   });
 });

--- a/tests/unit/github-workflow-validation.test.ts
+++ b/tests/unit/github-workflow-validation.test.ts
@@ -251,6 +251,7 @@ describe('GitHub Workflow Validation', () => {
       expect(checkout?.with?.ref).toBe('${{ github.event.pull_request.head.sha }}');
       expect(checkout?.with?.['fetch-depth']).toBe(0);
       expect(checkout?.with?.['persist-credentials']).toBe(false);
+      expect(workflow.jobs['claude-review'].permissions?.['id-token']).toBeUndefined();
       expect(verifyCheckout?.run).toContain('git rev-parse HEAD');
       expect(verifyCheckout?.run).toContain("--jq '.head.sha'");
       expect(verifyCheckout?.run).toContain('EXPECTED_HEAD_SHA');


### PR DESCRIPTION
## Summary

Prevents a green Claude review check from representing an older PR head.

- checks out the exact `pull_request.head.sha`
- verifies the event SHA against both Git and the live GitHub PR before review
- cancels superseded review runs for the same PR
- binds the prompt's visible `Reviewed commit` marker to that SHA
- verifies the PR head again after review
- pins checkout and disables persisted credentials
- removes obsolete commented workflow examples
- adds focused workflow-validation coverage

## Context

PR #2516 produced a green Claude review run after cleanup commit `bd98af2f`, but the posted review explicitly covered prior commit `943b3dc7`. This PR is the beta-native first child of recovery epic #2555.

Closes #2557.

## Validation

- `npm test -- --runInBand tests/unit/github-workflow-validation.test.ts` — 135/135 passed
- `npx eslint tests/unit/github-workflow-validation.test.ts` — passed
- `npm run build` — passed
- `git diff --check` — passed

## Baseline note

`npm run build:test` is not a clean beta gate: it reports the existing repository-wide compiled-test TypeScript backlog across unrelated files. This PR does not change those failures.

## Merge policy

Target: `beta`.

Merge commit only. Do not squash or rebase. No merge without Mick's explicit approval.