### PR TITLE
security: use cryptographic randomness for generated identities

### DIFF
--- a/src/utils/filesystem.ts
+++ b/src/utils/filesystem.ts
@@ -2,6 +2,7 @@
  * Filesystem and string manipulation utilities
  */
 
+import { randomInt } from 'node:crypto';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { ADJECTIVES, ANIMALS } from '../config/constants.js';
@@ -11,6 +12,14 @@ import { FileLockManager } from '../security/fileLockManager.js';
 
 // Singleton file operations service for utility functions
 let fileOperationsService: IFileOperationsService | null = null;
+
+const ID_SUFFIX_LENGTH = 4;
+const BASE36_RADIX = 36;
+const ID_SUFFIX_SPACE = BASE36_RADIX ** ID_SUFFIX_LENGTH;
+
+function generateIdSuffix(): string {
+  return randomInt(ID_SUFFIX_SPACE).toString(BASE36_RADIX).padStart(ID_SUFFIX_LENGTH, '0');
+}
 
 function getFileOperationsService(): IFileOperationsService {
   if (!fileOperationsService) {
@@ -23,9 +32,9 @@ function getFileOperationsService(): IFileOperationsService {
  * Generate an anonymous ID for users without identity
  */
 export function generateAnonymousId(): string {
-  const adjective = ADJECTIVES[Math.floor(Math.random() * ADJECTIVES.length)];
-  const animal = ANIMALS[Math.floor(Math.random() * ANIMALS.length)];
-  const random = Math.random().toString(36).substring(2, 6);
+  const adjective = ADJECTIVES[randomInt(ADJECTIVES.length)];
+  const animal = ANIMALS[randomInt(ANIMALS.length)];
+  const random = generateIdSuffix();
   return `anon-${adjective}-${animal}-${random}`;
 }
 
@@ -42,7 +51,7 @@ export function generateUniqueId(personaName: string, author?: string): string {
   // Issue #848: Add milliseconds + random suffix for sub-second uniqueness.
   // Critical for copy-on-write, swarm operations, and rapid programmatic creation.
   const msStr = now.getMilliseconds().toString().padStart(3, '0');
-  const rand = Math.random().toString(36).substring(2, 6);
+  const rand = generateIdSuffix();
   // SECURITY FIX: Prevent ReDoS by using a single-pass approach
   // Previously: Multiple replace() operations with unbounded quantifiers could cause exponential backtracking
   // Now: Single-pass transformation with built-in length limit

--- a/tests/unit/utils/filesystem.identity.test.ts
+++ b/tests/unit/utils/filesystem.identity.test.ts
@@ -1,0 +1,41 @@
+import { jest } from '@jest/globals';
+import { ADJECTIVES, ANIMALS } from '../../../src/config/constants.js';
+import { generateAnonymousId, generateUniqueId } from '../../../src/utils/filesystem.js';
+
+describe('filesystem identity generation', () => {
+  it('preserves the anonymous identity format and configured word lists', () => {
+    const identity = generateAnonymousId();
+    const match = /^anon-([a-z]+)-([a-z]+)-([a-z0-9]{4})$/.exec(identity);
+
+    expect(match).not.toBeNull();
+    expect(ADJECTIVES).toContain(match?.[1]);
+    expect(ANIMALS).toContain(match?.[2]);
+  });
+
+  it('preserves the unique element identity format', () => {
+    expect(generateUniqueId('My Persona', 'test-author')).toMatch(
+      /^my-persona_\d{8}-\d{9}-[a-z0-9]{4}_test-author$/,
+    );
+  });
+
+  it('does not rely on Math.random for production identity material', () => {
+    const randomSpy = jest.spyOn(Math, 'random').mockImplementation(() => {
+      throw new Error('Math.random must not be used for identity material');
+    });
+
+    try {
+      expect(generateAnonymousId()).toMatch(/^anon-[a-z]+-[a-z]+-[a-z0-9]{4}$/);
+      expect(generateUniqueId('Secure Identity', 'test-author')).toMatch(
+        /^secure-identity_\d{8}-\d{9}-[a-z0-9]{4}_test-author$/,
+      );
+    } finally {
+      randomSpy.mockRestore();
+    }
+  });
+
+  it('retains useful entropy across repeated generation', () => {
+    const suffixes = Array.from({ length: 100 }, () => generateAnonymousId().split('-').at(-1));
+
+    expect(new Set(suffixes).size).toBeGreaterThanOrEqual(90);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves the shared insecure-randomness path reported by CodeQL during PR #2516 recovery.

- replaces `Math.random()` identity generation with Node `crypto.randomInt()`
- uses unbiased cryptographic selection for anonymous adjective/animal components
- retains the established four-character lowercase base-36 suffix
- preserves anonymous and element unique-ID formats
- adds focused compatibility, entropy, and weak-RNG regression tests

## Root cause and landing decision

CodeQL attached its finding to `PersonaManager`, but the interprocedural path reaches `MetadataService` and then the identity helpers in `src/utils/filesystem.ts`. These helpers are identical on repaired beta `c9747510` and trusted hosted boundary `943b3dc7`, making this a shared beta-native defect.

This PR intentionally does not change unrelated randomness used for retry jitter, telemetry sampling, display names, tests, or benchmarks.

Closes #2563. Child of #2556 and recovery epic #2555.

## Validation

- `npm run build` — passed
- focused identity, MetadataService, Persona identity, and security tests — 93/93 passed
- filesystem ReDoS performance regression tests — 18/18 passed
- `npx eslint src/utils/filesystem.ts tests/unit/utils/filesystem.identity.test.ts` — passed
- `npm run security:audit` — passed, 0 findings
- `git diff --check` — passed
- local Production Code Review Team pass — no blocking findings; suffix-entropy test tightened before commit

## Dependency note

No dependencies or lockfiles changed. The existing beta lockfile reports its already tracked advisory cohort; dependency policy remains governed by #2451, #2452, and #2512.

## Merge policy

Target: `beta`.

Merge commit only. Do not squash or rebase. No merge without Mick's explicit approval.
