### PR TITLE
fix(config): make dynamic setting deletion prototype-safe

### DIFF
--- a/src/config/ConfigManager.ts
+++ b/src/config/ConfigManager.ts
@@ -46,6 +46,7 @@ import {
 } from '../utils/securityUtils.js';
 import { env } from './env.js';
 import { isKnownConfigPath, validateConfigPath } from './configSchema.js';
+import { deleteOwnConfigLeaf, parseSafeConfigPath } from './safeConfigDeletion.js';
 import { IFileOperationsService } from '../services/FileOperationsService.js';
 import type { IOperatorConfigStore, OperatorConfig } from '../storage/operatorConfig/IOperatorConfigStore.js';
 import type { IUserConfigStore, UserConfig as UserConfigPayload } from '../storage/userConfig/IUserConfigStore.js';
@@ -1077,7 +1078,7 @@ export class ConfigManager {
       await this.initialize();
     }
 
-    validatePropertyPath(path, 'path');
+    const keys = parseSafeConfigPath(path);
 
     // Same admin gate as updateSetting — per-host paths require 'admin'.
     if (ConfigManager.isPerHostPath(path) && this.contextTracker) {
@@ -1095,35 +1096,24 @@ export class ConfigManager {
       }
     }
 
-    const previousValue = this.getSetting(path);
-    if (previousValue === undefined) {
-      return {
-        success: false,
-        message: `Configuration path '${path}' has no stored value to delete.`,
-      };
+    const deletion = deleteOwnConfigLeaf(this.config, keys, {
+      rejectObjectLeaf: !isKnownConfigPath(path),
+    });
+    if (deletion.kind === 'missing') {
+      return { success: true, message: `Setting '${path}' was already unset` };
     }
-    if (!isKnownConfigPath(path) && isPlainObject(previousValue)) {
+    if (deletion.kind === 'section') {
       return {
         success: false,
         message: `Configuration path '${path}' is a section, not a leaf setting. Delete a specific setting path instead.`,
       };
     }
+    if (deletion.kind === 'unsafe') {
+      logger.warn('[ConfigManager] Rejected unsafe config deletion', { path, reason: deletion.reason });
+      return { success: false, message: `Configuration path '${path}' cannot be deleted safely: ${deletion.reason}` };
+    }
 
-    const keys = path.split('.');
-    let current: any = this.config;
-    // Navigate to the parent
-    for (let i = 0; i < keys.length - 1; i++) {
-      const key = keys[i];
-      if (!safeHasOwnProperty(current, key)) {
-        // Parent missing — nothing to delete; return idempotently
-        return { success: true, message: `Setting '${path}' was already unset`, previousValue };
-      }
-      current = current[key];
-    }
-    const lastKey = keys.at(-1)!;
-    if (safeHasOwnProperty(current, lastKey)) {
-      delete current[lastKey];
-    }
+    const previousValue = deletion.previousValue;
 
     await this.persistMerged(userId, this.config!);
 
@@ -1565,10 +1555,4 @@ export class ConfigManager {
       sortKeys: false
     });
   }
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  if (value === null || typeof value !== 'object') return false;
-  const proto = Object.getPrototypeOf(value);
-  return proto === Object.prototype || proto === null;
 }

--- a/src/config/safeConfigDeletion.ts
+++ b/src/config/safeConfigDeletion.ts
@@ -1,4 +1,5 @@
 const FORBIDDEN_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype']);
+// Bound decoding so nested encodings are caught without allowing unbounded work.
 const MAX_DECODE_PASSES = 3;
 
 type MutableConfigRecord = Record<string, unknown>;
@@ -44,26 +45,46 @@ export function deleteOwnConfigLeaf(
     assertSafeSegment(segment);
   }
 
+  const parentResult = resolveConfigParent(root, segments.slice(0, -1));
+  if ('result' in parentResult) return parentResult.result;
+  return deleteOwnLeaf(parentResult.parent, segments.at(-1)!, options.rejectObjectLeaf === true);
+}
+
+function resolveConfigParent(
+  root: unknown,
+  parentSegments: readonly string[],
+): { parent: MutableConfigRecord } | { result: ConfigDeletionResult } {
   let current = asAllowedConfigRecord(root);
   if (!current) {
-    return { kind: 'unsafe', reason: 'Configuration root is not a plain object.' };
+    return { result: { kind: 'unsafe', reason: 'Configuration root is not a plain object.' } };
   }
 
-  for (const segment of segments.slice(0, -1)) {
+  for (const segment of parentSegments) {
     const descriptor = Object.getOwnPropertyDescriptor(current, segment);
-    if (!descriptor) return { kind: 'missing' };
+    if (!descriptor) return { result: { kind: 'missing' } };
     if (!isDataDescriptor(descriptor)) {
-      return { kind: 'unsafe', reason: 'Configuration path crosses an accessor property.' };
+      return {
+        result: { kind: 'unsafe', reason: 'Configuration path crosses an accessor property.' },
+      };
     }
 
     current = asAllowedConfigRecord(descriptor.value);
     if (!current) {
-      return { kind: 'unsafe', reason: 'Configuration path crosses a non-plain object.' };
+      return {
+        result: { kind: 'unsafe', reason: 'Configuration path crosses a non-plain object.' },
+      };
     }
   }
 
-  const leaf = segments.at(-1)!;
-  const descriptor = Object.getOwnPropertyDescriptor(current, leaf);
+  return { parent: current };
+}
+
+function deleteOwnLeaf(
+  parent: MutableConfigRecord,
+  leaf: string,
+  rejectObjectLeaf: boolean,
+): ConfigDeletionResult {
+  const descriptor = Object.getOwnPropertyDescriptor(parent, leaf);
   if (!descriptor) return { kind: 'missing' };
   if (!isDataDescriptor(descriptor)) {
     return { kind: 'unsafe', reason: 'Configuration leaf is an accessor property.' };
@@ -71,11 +92,11 @@ export function deleteOwnConfigLeaf(
   if (!descriptor.configurable) {
     return { kind: 'unsafe', reason: 'Configuration leaf is not configurable.' };
   }
-  if (options.rejectObjectLeaf && asAllowedConfigRecord(descriptor.value)) {
+  if (rejectObjectLeaf && asAllowedConfigRecord(descriptor.value)) {
     return { kind: 'section' };
   }
 
-  if (!Reflect.deleteProperty(current, leaf)) {
+  if (!Reflect.deleteProperty(parent, leaf)) {
     return { kind: 'unsafe', reason: 'Configuration leaf could not be deleted.' };
   }
   return { kind: 'deleted', previousValue: descriptor.value };
@@ -124,5 +145,7 @@ function isPrototypeObject(value: object): boolean {
 function isDataDescriptor(
   descriptor: PropertyDescriptor,
 ): descriptor is PropertyDescriptor & { value: unknown } {
-  return Object.hasOwn(descriptor, 'value');
+  return Object.hasOwn(descriptor, 'value')
+    && !Object.hasOwn(descriptor, 'get')
+    && !Object.hasOwn(descriptor, 'set');
 }

--- a/src/config/safeConfigDeletion.ts
+++ b/src/config/safeConfigDeletion.ts
@@ -114,7 +114,9 @@ function assertSafeSegment(segment: string): void {
     try {
       decoded = decodeURIComponent(candidate);
     } catch {
-      throw new Error('Configuration path contains invalid percent encoding.');
+      // A literal percent sign is valid in a custom config key. Since the
+      // segment cannot be decoded, it cannot resolve to a hidden forbidden key.
+      return;
     }
     if (decoded === candidate) return;
     candidate = decoded;

--- a/src/config/safeConfigDeletion.ts
+++ b/src/config/safeConfigDeletion.ts
@@ -1,0 +1,128 @@
+const FORBIDDEN_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype']);
+const MAX_DECODE_PASSES = 3;
+
+type MutableConfigRecord = Record<string, unknown>;
+
+export type ConfigDeletionResult =
+  | { kind: 'deleted'; previousValue: unknown }
+  | { kind: 'missing' }
+  | { kind: 'section' }
+  | { kind: 'unsafe'; reason: string };
+
+/**
+ * Parse a dot-notation config path while rejecting prototype-related
+ * segments before any object traversal occurs.
+ */
+export function parseSafeConfigPath(path: string): readonly string[] {
+  if (typeof path !== 'string' || path.length === 0) {
+    throw new Error('Configuration path must be a non-empty string.');
+  }
+
+  const segments = path.split('.');
+  for (const segment of segments) {
+    if (segment.length === 0) {
+      throw new Error('Configuration path must not contain empty segments.');
+    }
+    assertSafeSegment(segment);
+  }
+  return segments;
+}
+
+/**
+ * Delete a leaf without following inherited properties or invoking accessors.
+ * Unknown object-valued leaves can be rejected to preserve section semantics.
+ */
+export function deleteOwnConfigLeaf(
+  root: unknown,
+  segments: readonly string[],
+  options: { readonly rejectObjectLeaf?: boolean } = {},
+): ConfigDeletionResult {
+  if (segments.length === 0) {
+    return { kind: 'unsafe', reason: 'Configuration path has no leaf segment.' };
+  }
+  for (const segment of segments) {
+    assertSafeSegment(segment);
+  }
+
+  let current = asAllowedConfigRecord(root);
+  if (!current) {
+    return { kind: 'unsafe', reason: 'Configuration root is not a plain object.' };
+  }
+
+  for (const segment of segments.slice(0, -1)) {
+    const descriptor = Object.getOwnPropertyDescriptor(current, segment);
+    if (!descriptor) return { kind: 'missing' };
+    if (!isDataDescriptor(descriptor)) {
+      return { kind: 'unsafe', reason: 'Configuration path crosses an accessor property.' };
+    }
+
+    current = asAllowedConfigRecord(descriptor.value);
+    if (!current) {
+      return { kind: 'unsafe', reason: 'Configuration path crosses a non-plain object.' };
+    }
+  }
+
+  const leaf = segments.at(-1)!;
+  const descriptor = Object.getOwnPropertyDescriptor(current, leaf);
+  if (!descriptor) return { kind: 'missing' };
+  if (!isDataDescriptor(descriptor)) {
+    return { kind: 'unsafe', reason: 'Configuration leaf is an accessor property.' };
+  }
+  if (!descriptor.configurable) {
+    return { kind: 'unsafe', reason: 'Configuration leaf is not configurable.' };
+  }
+  if (options.rejectObjectLeaf && asAllowedConfigRecord(descriptor.value)) {
+    return { kind: 'section' };
+  }
+
+  if (!Reflect.deleteProperty(current, leaf)) {
+    return { kind: 'unsafe', reason: 'Configuration leaf could not be deleted.' };
+  }
+  return { kind: 'deleted', previousValue: descriptor.value };
+}
+
+function assertSafeSegment(segment: string): void {
+  let candidate = segment;
+  for (let pass = 0; pass < MAX_DECODE_PASSES; pass++) {
+    const canonical = candidate.normalize('NFKC').trim().toLowerCase();
+    if (FORBIDDEN_SEGMENTS.has(canonical)) {
+      throw new Error(`Forbidden property in configuration path: ${segment}`);
+    }
+
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(candidate);
+    } catch {
+      throw new Error('Configuration path contains invalid percent encoding.');
+    }
+    if (decoded === candidate) return;
+    candidate = decoded;
+  }
+
+  const canonical = candidate.normalize('NFKC').trim().toLowerCase();
+  if (FORBIDDEN_SEGMENTS.has(canonical)) {
+    throw new Error(`Forbidden property in configuration path: ${segment}`);
+  }
+}
+
+function asAllowedConfigRecord(value: unknown): MutableConfigRecord | null {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return null;
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) return null;
+  if (isPrototypeObject(value)) return null;
+  return value as MutableConfigRecord;
+}
+
+function isPrototypeObject(value: object): boolean {
+  const descriptor = Object.getOwnPropertyDescriptor(value, 'constructor');
+  return descriptor !== undefined
+    && isDataDescriptor(descriptor)
+    && typeof descriptor.value === 'function'
+    && descriptor.value.prototype === value;
+}
+
+function isDataDescriptor(
+  descriptor: PropertyDescriptor,
+): descriptor is PropertyDescriptor & { value: unknown } {
+  return Object.hasOwn(descriptor, 'value');
+}

--- a/tests/unit/config/ConfigManager.test.ts
+++ b/tests/unit/config/ConfigManager.test.ts
@@ -315,6 +315,38 @@ describe('ConfigManager', () => {
       await expect(configManager.updateSetting('sync.prototype.polluted', 'evil')).rejects.toThrow();
     });
 
+    it.each([
+      '__proto__.polluted',
+      'user.CONSTRUCTOR.polluted',
+      'sync.%70rototype.polluted',
+    ])('should reject dangerous deleteSetting path %s', async path => {
+      await expect(configManager.deleteSetting(path)).rejects.toThrow();
+    });
+
+    it('deletes a valid custom leaf through the store boundary and remains idempotent', async () => {
+      const operatorStore = new InMemoryOperatorConfigStore();
+      const userStore = new InMemoryUserConfigStore();
+      await userStore.save('00000000-0000-0000-0000-000000000000', {
+        githubConfig: {}, syncConfig: {}, autoloadConfig: {}, retentionConfig: {},
+        wizardConfig: {}, displayConfig: { custom: { obsolete: 'value', keep: true } },
+        collectionConfig: {}, autoActivateConfig: {}, sourcePriorityConfig: {},
+        userIdentityConfig: {}, configVersion: 1,
+      });
+      const manager = new ConfigManager(mockFileOperations, mockOs, operatorStore, userStore, null);
+      await manager.initialize();
+
+      const deleted = await manager.deleteSetting('display.custom.obsolete');
+      expect(deleted).toMatchObject({ success: true, previousValue: 'value' });
+      const stored = await userStore.load('00000000-0000-0000-0000-000000000000');
+      expect(stored.displayConfig).toMatchObject({ custom: { keep: true } });
+      expect((stored.displayConfig.custom as Record<string, unknown>)).not.toHaveProperty('obsolete');
+
+      await expect(manager.deleteSetting('display.custom.obsolete')).resolves.toMatchObject({
+        success: true,
+        message: expect.stringContaining('already unset'),
+      });
+    });
+
     it('should reject __proto__ in resetConfig section', async () => {
         mockFileOperations.exists.mockResolvedValue(false);
         mockFileOperations.createDirectory.mockResolvedValue(undefined);

--- a/tests/unit/config/ConfigManager.test.ts
+++ b/tests/unit/config/ConfigManager.test.ts
@@ -347,6 +347,27 @@ describe('ConfigManager', () => {
       });
     });
 
+    it('deletes a custom leaf containing a literal percent sign', async () => {
+      const operatorStore = new InMemoryOperatorConfigStore();
+      const userStore = new InMemoryUserConfigStore();
+      await userStore.save('00000000-0000-0000-0000-000000000000', {
+        githubConfig: {}, syncConfig: {}, autoloadConfig: {}, retentionConfig: {},
+        wizardConfig: {}, displayConfig: { custom: { 'discount%': 'value', keep: true } },
+        collectionConfig: {}, autoActivateConfig: {}, sourcePriorityConfig: {},
+        userIdentityConfig: {}, configVersion: 1,
+      });
+      const manager = new ConfigManager(mockFileOperations, mockOs, operatorStore, userStore, null);
+      await manager.initialize();
+
+      await expect(manager.deleteSetting('display.custom.discount%')).resolves.toMatchObject({
+        success: true,
+        previousValue: 'value',
+      });
+      const stored = await userStore.load('00000000-0000-0000-0000-000000000000');
+      expect(stored.displayConfig).toMatchObject({ custom: { keep: true } });
+      expect((stored.displayConfig.custom as Record<string, unknown>)).not.toHaveProperty('discount%');
+    });
+
     it('should reject __proto__ in resetConfig section', async () => {
         mockFileOperations.exists.mockResolvedValue(false);
         mockFileOperations.createDirectory.mockResolvedValue(undefined);

--- a/tests/unit/config/safeConfigDeletion.test.ts
+++ b/tests/unit/config/safeConfigDeletion.test.ts
@@ -40,6 +40,15 @@ describe('safeConfigDeletion', () => {
       expect(root.constructor).toBe('leave-me-alone');
     });
 
+    it('rejects double-encoded dangerous segments without relying on the path parser', () => {
+      const root = Object.assign(Object.create(null) as Record<string, unknown>, {
+        '%2563onstructor': 'leave-me-alone',
+      });
+
+      expect(() => deleteOwnConfigLeaf(root, ['%2563onstructor'])).toThrow(/Forbidden property/);
+      expect(root['%2563onstructor']).toBe('leave-me-alone');
+    });
+
     it('deletes a configurable own data property', () => {
       const root = { custom: { leaf: 'value' } };
 

--- a/tests/unit/config/safeConfigDeletion.test.ts
+++ b/tests/unit/config/safeConfigDeletion.test.ts
@@ -17,16 +17,16 @@ describe('safeConfigDeletion', () => {
       expect(() => parseSafeConfigPath(path)).toThrow(/Forbidden property/);
     });
 
-    it.each(['', '.user', 'user.', 'user..name', 'user.%zz'])('rejects malformed path %s', path => {
+    it.each(['', '.user', 'user.', 'user..name'])('rejects malformed path %s', path => {
       expect(() => parseSafeConfigPath(path)).toThrow();
     });
 
-    it('preserves valid custom segments', () => {
-      expect(parseSafeConfigPath('display.custom-theme.value')).toEqual([
-        'display',
-        'custom-theme',
-        'value',
-      ]);
+    it.each([
+      'display.custom-theme.value',
+      'display.custom.discount%',
+      'display.custom.%zz',
+    ])('preserves valid custom path %s', path => {
+      expect(parseSafeConfigPath(path)).toEqual(path.split('.'));
     });
   });
 
@@ -57,6 +57,16 @@ describe('safeConfigDeletion', () => {
         previousValue: 'value',
       });
       expect(root.custom).not.toHaveProperty('leaf');
+    });
+
+    it('deletes a custom property containing a literal percent sign', () => {
+      const root = { custom: { 'discount%': 'value' } };
+
+      expect(deleteOwnConfigLeaf(root, ['custom', 'discount%'])).toEqual({
+        kind: 'deleted',
+        previousValue: 'value',
+      });
+      expect(root.custom).not.toHaveProperty('discount%');
     });
 
     it('supports null-prototype objects', () => {

--- a/tests/unit/config/safeConfigDeletion.test.ts
+++ b/tests/unit/config/safeConfigDeletion.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import {
+  deleteOwnConfigLeaf,
+  parseSafeConfigPath,
+} from '../../../src/config/safeConfigDeletion.js';
+
+describe('safeConfigDeletion', () => {
+  describe('parseSafeConfigPath', () => {
+    it.each([
+      '__proto__.polluted',
+      'user.CONSTRUCTOR.polluted',
+      'sync. prototype .polluted',
+      'user.%63onstructor.polluted',
+      'user.%2563onstructor.polluted',
+      'user.ｐｒｏｔｏｔｙｐｅ.polluted',
+    ])('rejects dangerous path variant %s', path => {
+      expect(() => parseSafeConfigPath(path)).toThrow(/Forbidden property/);
+    });
+
+    it.each(['', '.user', 'user.', 'user..name', 'user.%zz'])('rejects malformed path %s', path => {
+      expect(() => parseSafeConfigPath(path)).toThrow();
+    });
+
+    it('preserves valid custom segments', () => {
+      expect(parseSafeConfigPath('display.custom-theme.value')).toEqual([
+        'display',
+        'custom-theme',
+        'value',
+      ]);
+    });
+  });
+
+  describe('deleteOwnConfigLeaf', () => {
+    it('rejects dangerous segments even when called without the path parser', () => {
+      const root = Object.assign(Object.create(null) as Record<string, unknown>, {
+        constructor: 'leave-me-alone',
+      });
+
+      expect(() => deleteOwnConfigLeaf(root, ['constructor'])).toThrow(/Forbidden property/);
+      expect(root.constructor).toBe('leave-me-alone');
+    });
+
+    it('deletes a configurable own data property', () => {
+      const root = { custom: { leaf: 'value' } };
+
+      expect(deleteOwnConfigLeaf(root, ['custom', 'leaf'])).toEqual({
+        kind: 'deleted',
+        previousValue: 'value',
+      });
+      expect(root.custom).not.toHaveProperty('leaf');
+    });
+
+    it('supports null-prototype objects', () => {
+      const nested = Object.assign(Object.create(null) as Record<string, unknown>, { leaf: 42 });
+      const root = Object.assign(Object.create(null) as Record<string, unknown>, { nested });
+
+      expect(deleteOwnConfigLeaf(root, ['nested', 'leaf'])).toEqual({
+        kind: 'deleted',
+        previousValue: 42,
+      });
+      expect(Object.hasOwn(nested, 'leaf')).toBe(false);
+    });
+
+    it('treats inherited properties as missing without mutating the prototype', () => {
+      const prototype = { leaf: 'inherited' };
+      const nested = Object.create(prototype) as Record<string, unknown>;
+      const root = { nested };
+
+      expect(deleteOwnConfigLeaf(root, ['nested', 'leaf'])).toEqual({
+        kind: 'unsafe',
+        reason: 'Configuration path crosses a non-plain object.',
+      });
+      expect(prototype.leaf).toBe('inherited');
+    });
+
+    it('does not follow Object.prototype properties', () => {
+      const root = { nested: {} };
+
+      expect(deleteOwnConfigLeaf(root, ['nested', 'toString'])).toEqual({ kind: 'missing' });
+      expect(Object.hasOwn(root.nested, 'toString')).toBe(false);
+    });
+
+    it('does not invoke an intermediate accessor', () => {
+      const getter = jest.fn(() => ({ leaf: 'value' }));
+      const root: Record<string, unknown> = {};
+      Object.defineProperty(root, 'nested', { configurable: true, get: getter });
+
+      expect(deleteOwnConfigLeaf(root, ['nested', 'leaf'])).toEqual({
+        kind: 'unsafe',
+        reason: 'Configuration path crosses an accessor property.',
+      });
+      expect(getter).not.toHaveBeenCalled();
+    });
+
+    it('does not invoke or delete a leaf accessor', () => {
+      const getter = jest.fn(() => 'value');
+      const nested: Record<string, unknown> = {};
+      Object.defineProperty(nested, 'leaf', { configurable: true, get: getter });
+
+      expect(deleteOwnConfigLeaf({ nested }, ['nested', 'leaf'])).toEqual({
+        kind: 'unsafe',
+        reason: 'Configuration leaf is an accessor property.',
+      });
+      expect(getter).not.toHaveBeenCalled();
+      expect(Object.hasOwn(nested, 'leaf')).toBe(true);
+    });
+
+    it('rejects non-configurable leaves', () => {
+      const nested: Record<string, unknown> = {};
+      Object.defineProperty(nested, 'leaf', { configurable: false, value: 'value' });
+
+      expect(deleteOwnConfigLeaf({ nested }, ['nested', 'leaf'])).toEqual({
+        kind: 'unsafe',
+        reason: 'Configuration leaf is not configurable.',
+      });
+      expect(nested.leaf).toBe('value');
+    });
+
+    it.each([
+      ['array', []],
+      ['class instance', new (class ConfigValue {})()],
+      ['date', new Date()],
+    ])('rejects a %s intermediate', (_label, nested) => {
+      expect(deleteOwnConfigLeaf({ nested }, ['nested', 'leaf'])).toEqual({
+        kind: 'unsafe',
+        reason: 'Configuration path crosses a non-plain object.',
+      });
+    });
+
+    it('rejects prototype objects', () => {
+      class ConfigValue {}
+
+      expect(deleteOwnConfigLeaf({ nested: ConfigValue.prototype }, ['nested', 'leaf'])).toEqual({
+        kind: 'unsafe',
+        reason: 'Configuration path crosses a non-plain object.',
+      });
+    });
+
+    it('rejects deleting an unknown object-valued section', () => {
+      const root = { custom: { section: { leaf: true } } };
+
+      expect(deleteOwnConfigLeaf(root, ['custom', 'section'], { rejectObjectLeaf: true })).toEqual({
+        kind: 'section',
+      });
+      expect(root.custom.section).toEqual({ leaf: true });
+    });
+
+    it('returns missing idempotently for absent own properties', () => {
+      expect(deleteOwnConfigLeaf({ custom: {} }, ['custom', 'leaf'])).toEqual({ kind: 'missing' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- parse deletion paths before traversal and reject prototype-related case, Unicode-normalized, whitespace-shaped, and percent-encoded variants
- traverse only own data descriptors on plain or null-prototype objects
- refuse inherited/custom-prototype objects, accessors, arrays, class instances, prototype objects, and non-configurable leaves
- preserve valid custom leaf deletion, section protection, and idempotent missing-key behavior

Addresses #2565. Focused security child of #2556 and recovery epic #2555.

## Security contract

`Reflect.deleteProperty` is reached only after the parent has been proven to be an allowed plain object and the leaf has been proven to be an own, configurable data property. No getter or inherited property is followed during lookup.

## Validation

- production build passed
- TypeScript no-emit check passed
- focused ESLint passed with no findings
- 86 focused ConfigManager/security tests passed
- Dollhouse security audit passed with 0 findings across 439 files
- Production Code Review Team adversarial pass found no production blocker
- broad local unit run progressed through hundreds of passing suites before Node 24 exhausted its 4 GB heap; unrelated baseline timing/network tests and Docker-to-remote-Podman connectivity failed locally and remain for CI matrices

## Landing

Target: `beta`. Merge commit only after Mick explicitly approves. Do not squash or rebase.