### PR TITLE
fix(config): make setting reads prototype-safe

### DIFF
--- a/src/config/ConfigManager.ts
+++ b/src/config/ConfigManager.ts
@@ -46,7 +46,11 @@ import {
 } from '../utils/securityUtils.js';
 import { env } from './env.js';
 import { isKnownConfigPath, validateConfigPath } from './configSchema.js';
-import { deleteOwnConfigLeaf, parseSafeConfigPath } from './safeConfigDeletion.js';
+import {
+  deleteOwnConfigLeaf,
+  parseSafeConfigPath,
+  readOwnConfigValue,
+} from './safeConfigDeletion.js';
 import { IFileOperationsService } from '../services/FileOperationsService.js';
 import type { IOperatorConfigStore, OperatorConfig } from '../storage/operatorConfig/IOperatorConfigStore.js';
 import type { IUserConfigStore, UserConfig as UserConfigPayload } from '../storage/userConfig/IUserConfigStore.js';
@@ -930,19 +934,15 @@ export class ConfigManager {
     if (!this.config) {
       return defaultValue;
     }
-    
-    const keys = path.split('.');
-    let value: any = this.config;
-    
-    for (const key of keys) {
-      if (value && typeof value === 'object' && key in value) {
-        value = value[key];
-      } else {
-        return defaultValue;
-      }
+
+    try {
+      const result = readOwnConfigValue(this.config, parseSafeConfigPath(path));
+      return result.kind === 'found' ? result.value as T : defaultValue;
+    } catch {
+      // Reads preserve the historical default-value contract for malformed or
+      // unsafe paths; write/delete operations continue to reject them explicitly.
+      return defaultValue;
     }
-    
-    return value as T;
   }
 
   /**

--- a/src/config/safeConfigDeletion.ts
+++ b/src/config/safeConfigDeletion.ts
@@ -189,7 +189,11 @@ function asAllowedConfigRecord(value: unknown): MutableConfigRecord | null {
 }
 
 function asAllowedConfigReadContainer(value: unknown): MutableConfigRecord | null {
-  if (Array.isArray(value)) return value as unknown as MutableConfigRecord;
+  // Arrays are valid config containers for indexed reads, but Array.prototype
+  // is itself an array and must never be exposed as configuration data.
+  if (Array.isArray(value)) {
+    return isPrototypeObject(value) ? null : value as unknown as MutableConfigRecord;
+  }
   return asAllowedConfigRecord(value);
 }
 

--- a/src/config/safeConfigDeletion.ts
+++ b/src/config/safeConfigDeletion.ts
@@ -10,6 +10,11 @@ export type ConfigDeletionResult =
   | { kind: 'section' }
   | { kind: 'unsafe'; reason: string };
 
+export type ConfigReadResult =
+  | { kind: 'found'; value: unknown }
+  | { kind: 'missing' }
+  | { kind: 'unsafe'; reason: string };
+
 /**
  * Parse a dot-notation config path while rejecting prototype-related
  * segments before any object traversal occurs.
@@ -27,6 +32,53 @@ export function parseSafeConfigPath(path: string): readonly string[] {
     assertSafeSegment(segment);
   }
   return segments;
+}
+
+/**
+ * Read a config path without following inherited properties or invoking accessors.
+ */
+export function readOwnConfigValue(
+  root: unknown,
+  segments: readonly string[],
+): ConfigReadResult {
+  if (segments.length === 0) {
+    return { kind: 'unsafe', reason: 'Configuration path has no leaf segment.' };
+  }
+  for (const segment of segments) {
+    assertSafeSegment(segment);
+  }
+
+  let current = asAllowedConfigRecord(root);
+  if (!current) {
+    return { kind: 'unsafe', reason: 'Configuration root is not a plain object.' };
+  }
+
+  for (let index = 0; index < segments.length; index++) {
+    const descriptor = Object.getOwnPropertyDescriptor(current, segments[index]);
+    if (!descriptor) return { kind: 'missing' };
+    if (!isDataDescriptor(descriptor)) {
+      return {
+        kind: 'unsafe',
+        reason: index === segments.length - 1
+          ? 'Configuration leaf is an accessor property.'
+          : 'Configuration path crosses an accessor property.',
+      };
+    }
+
+    if (index === segments.length - 1) {
+      return { kind: 'found', value: descriptor.value };
+    }
+
+    current = asAllowedConfigReadContainer(descriptor.value);
+    if (!current) {
+      return {
+        kind: 'unsafe',
+        reason: 'Configuration path crosses a non-plain object.',
+      };
+    }
+  }
+
+  return { kind: 'missing' };
 }
 
 /**
@@ -134,6 +186,11 @@ function asAllowedConfigRecord(value: unknown): MutableConfigRecord | null {
   if (prototype !== Object.prototype && prototype !== null) return null;
   if (isPrototypeObject(value)) return null;
   return value as MutableConfigRecord;
+}
+
+function asAllowedConfigReadContainer(value: unknown): MutableConfigRecord | null {
+  if (Array.isArray(value)) return value as unknown as MutableConfigRecord;
+  return asAllowedConfigRecord(value);
 }
 
 function isPrototypeObject(value: object): boolean {

--- a/tests/unit/config/ConfigManager.test.ts
+++ b/tests/unit/config/ConfigManager.test.ts
@@ -150,6 +150,12 @@ describe('ConfigManager', () => {
       expect(configManager.getSetting('nested.leaf', 'fallback')).toBe('fallback');
     });
 
+    it('does not expose properties from Array.prototype stored as config data', () => {
+      setCachedConfig({ values: Array.prototype });
+
+      expect(configManager.getSetting('values.map', 'fallback')).toBe('fallback');
+    });
+
     it('does not invoke intermediate or leaf accessors', () => {
       const intermediateGetter = jest.fn(() => ({ leaf: 'value' }));
       const leafGetter = jest.fn(() => 'value');

--- a/tests/unit/config/ConfigManager.test.ts
+++ b/tests/unit/config/ConfigManager.test.ts
@@ -129,6 +129,86 @@ describe('ConfigManager', () => {
     });
   });
 
+  describe('Safe Setting Reads', () => {
+    const setCachedConfig = (value: unknown): void => {
+      expect(Reflect.set(configManager, 'config', value)).toBe(true);
+    };
+
+    it('reads normal and null-prototype configuration values', () => {
+      const nested = Object.assign(Object.create(null) as Record<string, unknown>, {
+        leaf: 'value',
+      });
+      setCachedConfig({ nested });
+
+      expect(configManager.getSetting('nested.leaf')).toBe('value');
+    });
+
+    it('returns the default for inherited properties and unsafe intermediate objects', () => {
+      const nested = Object.create({ leaf: 'inherited' }) as Record<string, unknown>;
+      setCachedConfig({ nested });
+
+      expect(configManager.getSetting('nested.leaf', 'fallback')).toBe('fallback');
+    });
+
+    it('does not invoke intermediate or leaf accessors', () => {
+      const intermediateGetter = jest.fn(() => ({ leaf: 'value' }));
+      const leafGetter = jest.fn(() => 'value');
+      const root: Record<string, unknown> = {};
+      const nested: Record<string, unknown> = {};
+      Object.defineProperty(root, 'accessor', { get: intermediateGetter });
+      Object.defineProperty(nested, 'leaf', { get: leafGetter });
+      Object.defineProperty(root, 'nested', { value: nested, enumerable: true });
+      setCachedConfig(root);
+
+      expect(configManager.getSetting('accessor.leaf', 'fallback')).toBe('fallback');
+      expect(configManager.getSetting('nested.leaf', 'fallback')).toBe('fallback');
+      expect(intermediateGetter).not.toHaveBeenCalled();
+      expect(leafGetter).not.toHaveBeenCalled();
+    });
+
+    it('returns the default when a hostile object rejects reflection', () => {
+      const { proxy, revoke } = Proxy.revocable({}, {});
+      setCachedConfig({ nested: proxy });
+      revoke();
+
+      expect(configManager.getSetting('nested.leaf', 'fallback')).toBe('fallback');
+    });
+
+    it.each([
+      '__proto__.polluted',
+      'user.CONSTRUCTOR.polluted',
+      'sync. prototype .polluted',
+      'user.%63onstructor.polluted',
+      'user.%2563onstructor.polluted',
+      'user.ｐｒｏｔｏｔｙｐｅ.polluted',
+      '',
+      '.user',
+      'user.',
+      'user..name',
+    ])('returns the default for malformed or dangerous path %s', path => {
+      const forbiddenGetter = jest.fn(() => ({ polluted: true }));
+      const root: Record<string, unknown> = {};
+      Object.defineProperty(root, 'constructor', { get: forbiddenGetter });
+      setCachedConfig(root);
+
+      expect(configManager.getSetting(path, 'fallback')).toBe('fallback');
+      expect(forbiddenGetter).not.toHaveBeenCalled();
+    });
+
+    it('preserves leaf arrays, objects, and explicitly stored undefined values', () => {
+      const values = ['one', 'two'];
+      const section = { enabled: true };
+      setCachedConfig({ values, section, explicitUndefined: undefined });
+
+      expect(configManager.getSetting('values')).toBe(values);
+      expect(configManager.getSetting('values.0')).toBe('one');
+      expect(configManager.getSetting('values.map', 'fallback')).toBe('fallback');
+      expect(configManager.getSetting('section')).toBe(section);
+      expect(configManager.getSetting('explicitUndefined', 'fallback')).toBeUndefined();
+      expect(configManager.getSetting('missing', 'fallback')).toBe('fallback');
+    });
+  });
+
   describe('OAuth Client ID Management', () => {
     it('should save and retrieve GitHub client ID', async () => {
       // Phase 4.5: persistence verified by reading back through the

--- a/tests/unit/config/safeConfigDeletion.test.ts
+++ b/tests/unit/config/safeConfigDeletion.test.ts
@@ -238,6 +238,13 @@ describe('safeConfigDeletion', () => {
       expect(readOwnConfigValue({ values }, ['values', 'map'])).toEqual({ kind: 'missing' });
     });
 
+    it('rejects Array.prototype as an intermediate read container', () => {
+      expect(readOwnConfigValue({ values: Array.prototype }, ['values', 'map'])).toEqual({
+        kind: 'unsafe',
+        reason: 'Configuration path crosses a non-plain object.',
+      });
+    });
+
     it('rejects dangerous segments even when called without the path parser', () => {
       expect(() => readOwnConfigValue({}, ['%2563onstructor'])).toThrow(/Forbidden property/);
     });

--- a/tests/unit/config/safeConfigDeletion.test.ts
+++ b/tests/unit/config/safeConfigDeletion.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, jest } from '@jest/globals';
 import {
   deleteOwnConfigLeaf,
   parseSafeConfigPath,
+  readOwnConfigValue,
 } from '../../../src/config/safeConfigDeletion.js';
 
 describe('safeConfigDeletion', () => {
@@ -166,6 +167,79 @@ describe('safeConfigDeletion', () => {
 
     it('returns missing idempotently for absent own properties', () => {
       expect(deleteOwnConfigLeaf({ custom: {} }, ['custom', 'leaf'])).toEqual({ kind: 'missing' });
+    });
+  });
+
+  describe('readOwnConfigValue', () => {
+    it('reads own data properties from plain and null-prototype objects', () => {
+      const nested = Object.assign(Object.create(null) as Record<string, unknown>, {
+        leaf: 42,
+      });
+
+      expect(readOwnConfigValue({ nested }, ['nested', 'leaf'])).toEqual({
+        kind: 'found',
+        value: 42,
+      });
+    });
+
+    it('distinguishes a stored undefined value from a missing property', () => {
+      expect(readOwnConfigValue({ nested: { leaf: undefined } }, ['nested', 'leaf'])).toEqual({
+        kind: 'found',
+        value: undefined,
+      });
+      expect(readOwnConfigValue({ nested: {} }, ['nested', 'leaf'])).toEqual({ kind: 'missing' });
+    });
+
+    it('does not follow inherited properties', () => {
+      const nested = Object.create({ leaf: 'inherited' }) as Record<string, unknown>;
+
+      expect(readOwnConfigValue({ nested }, ['nested', 'leaf'])).toEqual({
+        kind: 'unsafe',
+        reason: 'Configuration path crosses a non-plain object.',
+      });
+    });
+
+    it('does not invoke intermediate or leaf accessors', () => {
+      const intermediateGetter = jest.fn(() => ({ leaf: 'value' }));
+      const leafGetter = jest.fn(() => 'value');
+      const intermediateRoot: Record<string, unknown> = {};
+      const leafParent: Record<string, unknown> = {};
+      Object.defineProperty(intermediateRoot, 'nested', { get: intermediateGetter });
+      Object.defineProperty(leafParent, 'leaf', { get: leafGetter });
+
+      expect(readOwnConfigValue(intermediateRoot, ['nested', 'leaf'])).toEqual({
+        kind: 'unsafe',
+        reason: 'Configuration path crosses an accessor property.',
+      });
+      expect(readOwnConfigValue({ nested: leafParent }, ['nested', 'leaf'])).toEqual({
+        kind: 'unsafe',
+        reason: 'Configuration leaf is an accessor property.',
+      });
+      expect(intermediateGetter).not.toHaveBeenCalled();
+      expect(leafGetter).not.toHaveBeenCalled();
+    });
+
+    it('returns leaf objects and arrays and safely reads array entries', () => {
+      const section = { enabled: true };
+      const values = ['one', 'two'];
+
+      expect(readOwnConfigValue({ section }, ['section'])).toEqual({
+        kind: 'found',
+        value: section,
+      });
+      expect(readOwnConfigValue({ values }, ['values'])).toEqual({
+        kind: 'found',
+        value: values,
+      });
+      expect(readOwnConfigValue({ values }, ['values', '0'])).toEqual({
+        kind: 'found',
+        value: 'one',
+      });
+      expect(readOwnConfigValue({ values }, ['values', 'map'])).toEqual({ kind: 'missing' });
+    });
+
+    it('rejects dangerous segments even when called without the path parser', () => {
+      expect(() => readOwnConfigValue({}, ['%2563onstructor'])).toThrow(/Forbidden property/);
     });
   });
 });


### PR DESCRIPTION
## Summary

- validate dot-notation read paths with the canonical forbidden-segment parser
- traverse only own data descriptors without invoking accessors
- reject custom-prototype and other unsafe intermediate objects
- preserve plain/null-prototype objects, array own-index reads, leaf objects/arrays, stored `undefined`, and existing default-value behavior
- return the caller default for malformed or unsafe read paths

## Security contract

`ConfigManager.getSetting()` no longer follows the prototype chain through `in` or performs direct property reads. Inherited properties, accessor descriptors, encoded/Unicode prototype-related segments, and unsafe intermediate shapes cannot supply configuration values.

This is a focused beta-native follow-up to PR #2567. It does not import any part of frozen cleanup commit `bd98af2f` or modify the hosted ancestry.

## Validation

- `npm test -- --runInBand tests/unit/config` — 524/524 passed
- `npx tsc --noEmit --pretty false` — passed
- focused ESLint — passed
- `npm run build` — passed
- `npm run security:audit` — 0 findings across 438 files
- local Production Code Reviewer adversarial pass — no P0/P1/P2 findings
- `git diff --check` — passed

## Recovery process

Closes #2568. Child of recovery epic #2555.

Target: `beta`. Merge commit only after Mick explicitly approves. Do not squash or rebase.
