### PR TITLE
fix(auth): bind PostgreSQL signing-key rotation timestamps

### DIFF
--- a/src/storage/signingKeys/PostgresSigningKeyStore.ts
+++ b/src/storage/signingKeys/PostgresSigningKeyStore.ts
@@ -114,7 +114,10 @@ export class PostgresSigningKeyStore implements ISigningKeyStore {
         .update(authSigningKeys)
         .set({
           active: false,
-          rotatedAt: sql`COALESCE(${authSigningKeys.rotatedAt}, ${now})`,
+          rotatedAt: sql`COALESCE(
+            ${authSigningKeys.rotatedAt},
+            ${sql.param(now, authSigningKeys.rotatedAt)}
+          )`,
           retiredAt: now,
         })
         .where(eq(authSigningKeys.kind, write.kind));


### PR DESCRIPTION
## Summary

Fix the real-PostgreSQL signing-key rotation failure found while validating the clean hosted reconciliation candidate in #2576.

Drizzle only applies the timestamp column encoder when the fallback `Date` is explicitly bound to that encoder. The prior raw interpolation passed a JavaScript `Date` directly to postgres.js and failed before the replacement key could be inserted.

## Behavior preserved

- Existing `COALESCE(rotated_at, now)` semantics
- Retirement of all prior keys of the selected kind
- Isolation of other signing-key kinds
- Atomic rollback when the replacement `kid` is a duplicate
- The clean two-parent reconciliation commit and all hosted attribution remain unchanged

## Validation

- Focused signing-key parity against disposable PostgreSQL 17: **62/62 passed**
- Full database, HTTP database, RLS, auth, and storage-parity group against disposable PostgreSQL 17: **20/20 suites, 612/612 tests passed**
- `npm run build`: passed
- `npx tsc --noEmit`: passed
- `npm run lint`: passed
- `npm run security:audit`: passed with 0 findings
- `git diff --check`: passed

Issue: #2577
Parent aggregation PR: #2576
Recovery epic: #2555

This child PR targets the reconciliation branch intentionally. It must be merged with a normal merge commit, never squash/rebase, and only after explicit maintainer approval.