### PR TITLE
test(cache): expect canonical paths on Windows

### DIFF
--- a/tests/unit/cache/CollectionCache.test.ts
+++ b/tests/unit/cache/CollectionCache.test.ts
@@ -61,7 +61,7 @@ describe('CollectionCache', () => {
       const customCache = new CollectionCache(fileOperations, '/custom/path');
       expect(customCache).toBeInstanceOf(CollectionCache);
       expect(customCache.getCacheFilePath()).toBe(
-        path.join('/custom/path', '.dollhousemcp', 'cache', 'collection-cache.json')
+        path.resolve('/custom/path', '.dollhousemcp', 'cache', 'collection-cache.json')
       );
     });
 
@@ -72,7 +72,7 @@ describe('CollectionCache', () => {
       });
 
       expect(canonicalCache.getCacheFilePath()).toBe(
-        path.join('/canonical/cache', 'collection-cache.json')
+        path.resolve('/canonical/cache', 'collection-cache.json')
       );
     });
   });


### PR DESCRIPTION
## Summary

Fix the two deterministic Windows failures on the clean hosted reconciliation candidate.

`CollectionCache` intentionally canonicalizes its configured directory and cache file with `path.resolve()`. These tests incorrectly constructed their expectations with `path.join()`, which omits the drive prefix for POSIX-looking fixture paths on Windows.

This PR aligns the assertions with the documented canonical-path contract. It does not change production behavior or cache placement.

## Validation

- Focused `CollectionCache` unit suite: **12/12 passed**
- Focused ESLint: passed
- `git diff --check`: passed
- Windows Node 20/22 GitHub checks provide the platform-specific verification

Issue: #2580
Parent aggregation PR: #2576
Recovery epic: #2555

This child PR targets the reconciliation branch intentionally. It must be merged with a normal merge commit, never squash/rebase, and only after explicit maintainer approval.