### PR TITLE
refactor(auth): group refresh audit context

### DIFF
--- a/src/web-console/modules/integrations/IntegrationRequestGateway.ts
+++ b/src/web-console/modules/integrations/IntegrationRequestGateway.ts
@@ -186,12 +186,8 @@ export class IntegrationRequestGateway {
 
     const refresh = await this.refreshAudited(
       this.options.tokenRefresh,
-      session.userId,
-      session.sessionId,
-      provider,
+      requestContext,
       descriptor.id,
-      method,
-      url,
       record.accessTokenCiphertext,
     );
     if (refresh.kind !== 'refreshed' && refresh.kind !== 'reused') {
@@ -267,23 +263,27 @@ export class IntegrationRequestGateway {
 
   private async refreshAudited(
     tokenRefresh: IntegrationTokenRefreshService,
-    userId: string,
-    sessionId: string | null,
-    provider: UserIntegrationProvider,
+    ctx: GatewayRequestContext,
     integrationDescriptorId: string,
-    method: string,
-    url: URL,
     staleAccessTokenCiphertext: Buffer,
   ) {
     try {
       return await tokenRefresh.refreshOnDemand({
-        userId,
-        provider,
+        userId: ctx.userId,
+        provider: ctx.provider,
         integrationDescriptorId,
         staleAccessTokenCiphertext,
       });
     } catch (error) {
-      await this.auditCredentialError(provider, userId, sessionId, method, url, error instanceof IntegrationRequestError ? error.code : 'refresh_failed', true);
+      await this.auditCredentialError(
+        ctx.provider,
+        ctx.userId,
+        ctx.sessionId,
+        ctx.method,
+        ctx.url,
+        error instanceof IntegrationRequestError ? error.code : 'refresh_failed',
+        true,
+      );
       throw error;
     }
   }
@@ -558,7 +558,7 @@ interface IntegrationHttpResponse {
 }
 
 interface GatewayRequestContext {
-  readonly provider: string;
+  readonly provider: UserIntegrationProvider;
   readonly userId: string;
   readonly sessionId: string | null;
   readonly method: string;


### PR DESCRIPTION
## Summary

Resolve the sole SonarCloud issue currently reported on the clean reconciliation candidate without changing token-refresh behavior.

The private `refreshAudited()` helper previously accepted eight positional parameters. It now receives the existing immutable `GatewayRequestContext` for provider, user, session, method, and URL, while keeping the refresh service, descriptor ID, and stale ciphertext explicit.

The request context provider field is tightened to the existing branded `UserIntegrationProvider` type, matching the normalized runtime value and the refresh service contract.

## Behavior preserved

- one refresh attempt after a 401
- same user/provider/descriptor binding
- same stale-ciphertext compare-and-swap input
- same credential-error audit fields and reason mapping
- same retry and failure behavior

## Validation

- Focused gateway suite: **89/89 passed**
- TypeScript: passed
- Focused ESLint: passed
- Repository security audit: passed with 0 findings
- `git diff --check`: passed

Issue: #2582
Parent aggregation PR: #2576
Recovery epic: #2555

This is a one-file component PR targeting the reconciliation staging branch. It must not be squash/rebase merged, and it requires explicit maintainer approval before merge.