### PR TITLE
fix(auth): bind PostgreSQL signing-key rotation timestamps

### DIFF
--- a/src/storage/signingKeys/PostgresSigningKeyStore.ts
+++ b/src/storage/signingKeys/PostgresSigningKeyStore.ts
@@ -114,7 +114,10 @@ export class PostgresSigningKeyStore implements ISigningKeyStore {
         .update(authSigningKeys)
         .set({
           active: false,
-          rotatedAt: sql`COALESCE(${authSigningKeys.rotatedAt}, ${now})`,
+          rotatedAt: sql`COALESCE(
+            ${authSigningKeys.rotatedAt},
+            ${sql.param(now, authSigningKeys.rotatedAt)}
+          )`,
           retiredAt: now,
         })
         .where(eq(authSigningKeys.kind, write.kind));


### PR DESCRIPTION
## Summary

- bind the signing-key rotation fallback timestamp through the Drizzle column encoder
- preserve an existing non-null `rotated_at` value while setting it only when absent
- retain the existing transaction boundary so a failed replacement insert rolls back key retirement

This is a fresh, focused implementation from `beta` at `254b9665e0862fbfcfe261a00ceb0577c583de00`. It does not import or reconstruct the stale reconciliation ancestry from PR #2578.

Fixes #2577.

## Why

Passing a JavaScript `Date` directly through a raw SQL template bypassed the PostgreSQL timestamp column encoder. Real PostgreSQL execution could therefore reject rotation with an unsupported object-type binding. `sql.param(now, authSigningKeys.rotatedAt)` uses the column's encoder for the fallback while keeping the SQL-side `COALESCE` behavior atomic.

## Validation

- `npm run build`
- `npx tsc --noEmit`
- focused ESLint for the store and parity contract
- `npm run security:audit`: 0 findings across 441 files
- real PostgreSQL 17 signing-key parity on Ubuntu Podman: 62/62 tests
- broad PostgreSQL/database/storage integration on Ubuntu Podman: 20/20 suites, 389/389 tests
- full native unit run: 553 suites and 12,591 tests passed; one unrelated wall-clock assertion exceeded its local threshold under the full serial load
- isolated CI-mode rerun of that timing suite: 21/21 tests passed
- isolated permission-error suite on macOS: 61/61 tests passed

The local Production Code Reviewer runtime could not persist terminal state because its existing agent state exceeds the 64 KiB limit. That runtime defect is tracked in #2597. A manual adversarial review found no additional P0/P1/P2 issue in this one-file change.

## Scope and history

- one source file
- one commit
- beta-native change
- no merge performed
