### PR TITLE
Release v2.0.41 - Important policy reliability hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.0.41] - 2026-08-26
+
+- **Important update — strongly recommended for all users**, especially installations that use the Permissions dashboard, active agents or ensembles, Gatekeeper policy enforcement, or persisted activation restore.
+- Stop overlapping Permissions dashboard polls from expanding complete element catalogs and amplifying into sustained CPU, memory, parsing, activation, validation, and logging work. Active-policy reporting now uses lightweight indexed lookups, coalesces same-generation dashboard snapshots, deduplicates ensemble references, and bounds member resolution concurrency. (#2618, #2621)
+- Keep enforcement decisions fresh while safely merging invalidations from overlapping storage scans, so external policy edits are not hidden by dashboard snapshot reuse or stale in-flight scans. (#2618, #2621)
+- Preserve stable policy and agent identity across external metadata renames, filename collisions, deactivation, session-policy aggregation, deadlock relief, and server restart restoration; legacy name-only activation records are upgraded when they can be resolved safely. (#2618, #2621)
+- Serialize policy exports through their newest queued work and install OAuth helper shutdown handlers before readiness, eliminating the remaining export race and macOS/Node 22 compatibility failure found during hotfix validation. (#2618, #2621)
+
 ## [2.0.40] - 2026-08-05
 
 - Recover stale agent execution policies through a narrow, durable-state-verified path while preserving active restarts, DangerZone requirements, read restrictions, and independent agent executions. This resolves the documented abort-path failure and mitigates the broader interrupted-execution incident while automatic cleanup remains tracked separately. (#2427, #2428, #2441)

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "dollhousemcp",
   "display_name": "DollhouseMCP",
-  "version": "2.0.40",
+  "version": "2.0.41",
   "description": "Open-source AI customization through modular Dollhouse elements — personas, skills, templates, agents, memories, and ensembles.",
   "long_description": "DollhouseMCP is an MCP server that lets you customize your AI with modular Dollhouse elements. Create personas that shape behavior and permissions, skills that add capabilities, templates for consistent outputs, agents for autonomous multi-step goals, memories for persistent context, and ensembles that bundle elements together. Includes MCP-AQL query language with 5 semantic CRUDE endpoints, Gatekeeper permission system, community collection, and a built-in portfolio browser.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.40",
+  "version": "2.0.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.40",
+      "version": "2.0.41",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.40",
+  "version": "2.0.41",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.40",
+  "version": "2.0.41",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.40",
+      "version": "2.0.41",
       "transport": {
         "type": "stdio"
       }

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -3,7 +3,7 @@
  * Generated at build time by scripts/generate-version.js
  */
 
-export const PACKAGE_VERSION = '2.0.40';
-export const BUILD_TIMESTAMP = '2026-08-05T18:45:06.812Z';
+export const PACKAGE_VERSION = '2.0.41';
+export const BUILD_TIMESTAMP = '2026-08-26T19:05:01.970Z';
 export const BUILD_TYPE: 'npm' | 'git' = 'git';
 export const PACKAGE_NAME = '@dollhousemcp/mcp-server';


### PR DESCRIPTION
## Release 2.0.41 — important reliability and policy-correctness update

This stable patch publishes the fully reviewed hotfix already merged to `main` in #2621. **We strongly recommend that all DollhouseMCP users update to 2.0.41**, especially installations that use the Permissions dashboard, active agents or ensembles, Gatekeeper enforcement, or persisted activation restore.

### What this fixes

- **Runaway dashboard polling and resource amplification** (#2618, #2621): active-policy reporting no longer expands complete element catalogs on every three-second poll. It uses lightweight indexed lookups, coalesces same-generation dashboard snapshots, deduplicates ensemble references, and resolves members through a bounded worker pool.
- **Policy freshness and correctness** (#2618, #2621): enforcement reads remain fresh, and invalidations from overlapping storage scans are merged instead of being lost behind stale in-flight work.
- **Stable activation identity** (#2618, #2621): policy-bearing agents survive metadata renames, filename collisions, deactivation, session-policy aggregation, deadlock relief, and restart restoration without being orphaned or conflated.
- **Export and compatibility reliability** (#2618, #2621): policy exports serialize through the newest queued work, and OAuth helper signal handlers are installed before readiness to eliminate the macOS/Node 22 shutdown race found during validation.

There are no intentional API breaks or unrelated product behavior changes in this release. The behavioral changes are confined to preventing redundant policy work, preserving policy identity, maintaining enforcement freshness, and correcting the helper readiness race.

### Release surfaces

Relative to the reviewed current `main`, this PR changes only the established stable-release surfaces:

- `package.json`
- `package-lock.json`
- `manifest.json`
- `server.json`
- `src/generated/version.ts`
- `CHANGELOG.md`

### Validation

- All seven machine-readable version fields resolve to `2.0.41`.
- TypeScript build passed locally.
- Script typecheck passed locally.
- Repository security audit passed with 0 findings.
- npm package dry run produced `@dollhousemcp/mcp-server@2.0.41`.
- The underlying hotfix passed all required PR checks across Ubuntu, Windows, macOS, Node 20, Node 22, amd64, arm64, CodeQL, SonarCloud, dependency review, Docker, and automated code review before merge.

### Post-merge publish plan

1. Create and publish GitHub release `v2.0.41` from the release PR merge commit.
2. Verify npm `latest` publishes `2.0.41` with provenance.
3. Verify MCP Registry publication.
4. Verify the `.mcpb` bundle and SHA-256 asset are attached to the GitHub release.
5. Verify GitHub Packages publication.

