### PR TITLE
Sync v2.0.41 main history into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.0.41] - 2026-08-26
+
+- **Important update — strongly recommended for all users**, especially installations that use the Permissions dashboard, active agents or ensembles, Gatekeeper policy enforcement, or persisted activation restore.
+- Stop overlapping Permissions dashboard polls from expanding complete element catalogs and amplifying into sustained CPU, memory, parsing, activation, validation, and logging work. Active-policy reporting now uses lightweight indexed lookups, coalesces same-generation dashboard snapshots, deduplicates ensemble references, and bounds member resolution concurrency. (#2618, #2621)
+- Keep enforcement decisions fresh while safely merging invalidations from overlapping storage scans, so external policy edits are not hidden by dashboard snapshot reuse or stale in-flight scans. (#2618, #2621)
+- Preserve stable policy and agent identity across external metadata renames, filename collisions, deactivation, session-policy aggregation, deadlock relief, and server restart restoration; legacy name-only activation records are upgraded when they can be resolved safely. (#2618, #2621)
+- Serialize policy exports through their newest queued work and install OAuth helper shutdown handlers before readiness, eliminating the remaining export race and macOS/Node 22 compatibility failure found during hotfix validation. (#2618, #2621)
+
 ## [2.0.40] - 2026-08-05
 
 - Recover stale agent execution policies through a narrow, durable-state-verified path while preserving active restarts, DangerZone requirements, read restrictions, and independent agent executions. This resolves the documented abort-path failure and mitigates the broader interrupted-execution incident while automatic cleanup remains tracked separately. (#2427, #2428, #2441)

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "dollhousemcp",
   "display_name": "DollhouseMCP",
-  "version": "2.0.40",
+  "version": "2.0.41",
   "description": "Open-source AI customization through modular Dollhouse elements — personas, skills, templates, agents, memories, and ensembles.",
   "long_description": "DollhouseMCP is an MCP server that lets you customize your AI with modular Dollhouse elements. Create personas that shape behavior and permissions, skills that add capabilities, templates for consistent outputs, agents for autonomous multi-step goals, memories for persistent context, and ensembles that bundle elements together. Includes MCP-AQL query language with 5 semantic CRUDE endpoints, Gatekeeper permission system, community collection, and a built-in portfolio browser.",
   "author": {

--- a/oauth-helper.mjs
+++ b/oauth-helper.mjs
@@ -330,6 +330,25 @@ async function writePidFile() {
 }
 
 async function main() {
+  let attempts = 0;
+
+  // Install termination handling before the first await and before publishing
+  // the PID file. Callers use that file as the helper readiness signal.
+  process.on('exit', cleanupPidFileSync);
+  process.on('beforeExit', async () => {
+    await log('OAuth helper completing cleanup');
+    await cleanupPidFile();
+  });
+
+  const handleInterruption = () => {
+    writeTerminalResultSync('failed', attempts, 'interrupted');
+    cleanupStateFileSync();
+    cleanupPidFileSync();
+    process.exit(1);
+  };
+  process.once('SIGINT', handleInterruption);
+  process.once('SIGTERM', handleInterruption);
+
   await log(`[START] OAuth helper started - PID: ${process.pid}`);
   await log('[CONFIG] Device code received');
   await log(`[CONFIG] Poll interval: ${pollIntervalSeconds}s, Expires in: ${expiresIn}s`);
@@ -349,35 +368,9 @@ async function main() {
   
   const startTime = Date.now();
   const timeout = startTime + (expiresIn * 1000);
-  let attempts = 0;
   let consecutiveErrors = 0;
   let currentPollIntervalMs = pollIntervalSeconds * 1000;
   const MAX_CONSECUTIVE_ERRORS = 5;
-  
-  // Set up cleanup on exit - use synchronous cleanup for exit event
-  process.on('exit', () => {
-    cleanupPidFileSync();
-  });
-  
-  // Use beforeExit for async cleanup when possible
-  process.on('beforeExit', async () => {
-    await log('OAuth helper completing cleanup');
-    await cleanupPidFile();
-  });
-  
-  process.on('SIGINT', () => {
-    writeTerminalResultSync('failed', attempts, 'interrupted');
-    cleanupStateFileSync();
-    cleanupPidFileSync();
-    process.exit(1);
-  });
-  
-  process.on('SIGTERM', () => {
-    writeTerminalResultSync('failed', attempts, 'interrupted');
-    cleanupStateFileSync();
-    cleanupPidFileSync();
-    process.exit(1);
-  });
 
   async function finish(status, errorCode, exitCode) {
     clearInterval(heartbeatInterval);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.40",
+  "version": "2.0.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.40",
+      "version": "2.0.41",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.40",
+  "version": "2.0.41",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.40",
+  "version": "2.0.41",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.40",
+      "version": "2.0.41",
       "transport": {
         "type": "stdio"
       }

--- a/src/di/Container.ts
+++ b/src/di/Container.ts
@@ -1152,12 +1152,12 @@ export class DollhouseContainer {
           restoredCount++;
         } else {
           logger.debug(`[ActivationStore] Pruning missing persona '${activation.name}'`);
-          store.removeStaleActivation('persona', activation.name);
+          store.removeStaleActivation('persona', activation.name, activation.filename);
           skippedCount++;
         }
       } catch {
         logger.debug(`[ActivationStore] Skipping failed persona '${activation.name}'`);
-        store.removeStaleActivation('persona', activation.name);
+        store.removeStaleActivation('persona', activation.name, activation.filename);
         skippedCount++;
       }
     }
@@ -1192,12 +1192,12 @@ export class DollhouseContainer {
           restoredCount++;
         } else {
           logger.debug(`[ActivationStore] Pruning missing agent '${activation.name}'`);
-          store.removeStaleActivation('agent', activation.name);
+          store.removeStaleActivation('agent', activation.name, activation.filename);
           skippedCount++;
         }
       } catch {
         logger.debug(`[ActivationStore] Skipping failed agent '${activation.name}'`);
-        store.removeStaleActivation('agent', activation.name);
+        store.removeStaleActivation('agent', activation.name, activation.filename);
         skippedCount++;
       }
     }

--- a/src/di/Container.ts
+++ b/src/di/Container.ts
@@ -1181,10 +1181,12 @@ export class DollhouseContainer {
       }
     }
 
-    // Restore agents
+    // Restore agents (uses stable filename when available so metadata renames
+    // cannot orphan a persisted activation between server processes)
     for (const activation of store.getActivations('agent')) {
       try {
-        const result = await agentManager.activateAgent(activation.name);
+        const identifier = activation.filename || activation.name;
+        const result = await agentManager.activateAgent(identifier);
         if (result.success) {
           restoredCount++;
         } else {

--- a/src/di/Container.ts
+++ b/src/di/Container.ts
@@ -1185,8 +1185,9 @@ export class DollhouseContainer {
     // cannot orphan a persisted activation between server processes)
     for (const activation of store.getActivations('agent')) {
       try {
-        const identifier = activation.filename || activation.name;
-        const result = await agentManager.activateAgent(identifier);
+        const result = activation.filename
+          ? await agentManager.activateAgentByFilename(activation.filename)
+          : await agentManager.activateAgent(activation.name);
         if (result.success) {
           restoredCount++;
         } else {

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -990,8 +990,8 @@ export class AgentManager extends BaseElementManager<Agent> {
   /**
    * Get all active agents
    */
-  async getActiveAgents(): Promise<Agent[]> {
-    await this.scanAndEvict();
+  async getActiveAgents(options: { freshAfterInFlight?: boolean } = {}): Promise<Agent[]> {
+    await this.scanAndEvict(options);
     const agents: Agent[] = [];
     for (const name of this.activeAgentNames) {
       const agent = await this.findByName(name);

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -955,6 +955,15 @@ export class AgentManager extends BaseElementManager<Agent> {
   }
 
   /**
+   * Resolve the stable storage identity used to persist an agent activation.
+   * The filename remains unchanged when metadata.name is edited externally.
+   */
+  async getStableActivationFilename(identifier: string): Promise<string | undefined> {
+    const agent = await this.findByName(identifier);
+    return agent ? this.getStableFilename(agent) : undefined;
+  }
+
+  /**
    * Deactivate an agent by name or identifier
    *
    * Issue #24 (LOW PRIORITY): Performance optimization using findByName()

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -67,6 +67,7 @@ import { ElementNotFoundError } from '../../utils/ErrorHandler.js';
 import { normalizeElementStorageIdentity } from '../../utils/filesystem.js';
 import { sanitizeGatekeeperPolicy } from '../../handlers/mcp-aql/policies/ElementPolicies.js';
 import { SECURITY_LIMITS } from '../../security/constants.js';
+import { ElementStatus } from '../../types/elements/IElement.js';
 
 const AGENT_FILE_EXTENSION = '.md';
 const STATE_DIRECTORY = '.state';
@@ -994,7 +995,16 @@ export class AgentManager extends BaseElementManager<Agent> {
     const agents: Agent[] = [];
     for (const name of this.activeAgentNames) {
       const agent = await this.findByName(name);
-      if (agent) agents.push(agent);
+      if (agent) {
+        // scanAndEvict() can discard an externally modified active agent. Its
+        // replacement starts inactive, so restore the lifecycle state once.
+        // Avoid reactivating unchanged instances: Agent.activate() advances
+        // session tracking and must not run on every policy/status poll.
+        if (agent.getStatus() !== ElementStatus.ACTIVE) {
+          await agent.activate();
+        }
+        agents.push(agent);
+      }
     }
     return agents;
   }

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -990,8 +990,12 @@ export class AgentManager extends BaseElementManager<Agent> {
    * Get all active agents
    */
   async getActiveAgents(): Promise<Agent[]> {
-    const agents = await this.list();
-    return agents.filter(a => this.activeAgentNames.has(a.metadata.name));
+    const agents: Agent[] = [];
+    for (const name of this.activeAgentNames) {
+      const agent = await this.findByName(name);
+      if (agent) agents.push(agent);
+    }
+    return agents;
   }
 
   /**

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -983,7 +983,7 @@ export class AgentManager extends BaseElementManager<Agent> {
    * Issue #24 (LOW PRIORITY): Performance optimization using findByName()
    * Issue #24 (LOW PRIORITY): Consistent error messages using ElementMessages
    */
-  async deactivateAgent(identifier: string): Promise<{ success: boolean; message: string }> {
+  async deactivateAgent(identifier: string): Promise<{ success: boolean; message: string; filename?: string }> {
     // Deactivation is a security-sensitive lifecycle change. Refresh first,
     // then fall back to stable active filenames when external metadata edits
     // have made the current display name diverge from its storage path.
@@ -1011,6 +1011,8 @@ export class AgentManager extends BaseElementManager<Agent> {
       };
     }
 
+    const filename = this.getStableFilename(agent);
+
     // Remove the current display name and any pre-rename key that points at
     // the same stable file, so explicit deactivation cannot be undone by a
     // later policy refresh.
@@ -1037,7 +1039,8 @@ export class AgentManager extends BaseElementManager<Agent> {
     return {
       success: true,
       // CONSISTENCY FIX: Use standardized success message format
-      message: ElementMessages.deactivated(ElementType.AGENT, agent.metadata.name)
+      message: ElementMessages.deactivated(ElementType.AGENT, agent.metadata.name),
+      ...(filename ? { filename } : {}),
     };
   }
 

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -119,6 +119,8 @@ type AgentCreateMetadata = (Partial<AgentMetadata> & Partial<AgentMetadataV2>) &
   content?: string;
 };
 
+type AgentActivationResult = { success: boolean; message: string; agent?: Agent };
+
 export class AgentManager extends BaseElementManager<Agent> {
   private readonly stateDir: string;
   private readonly stateCache: Map<string, AgentState> = new Map();
@@ -902,10 +904,22 @@ export class AgentManager extends BaseElementManager<Agent> {
    * Issue #24 (LOW PRIORITY): Consistent error messages using ElementMessages
    * Issue #24 (LOW PRIORITY): Cleanup trigger for memory leak prevention
    */
-  async activateAgent(identifier: string): Promise<{ success: boolean; message: string; agent?: Agent }> {
+  async activateAgent(identifier: string): Promise<AgentActivationResult> {
     // PERFORMANCE FIX: Use findByName() instead of list()
     const agent = await this.findByName(identifier);
+    return this.activateResolvedAgent(agent, identifier);
+  }
 
+  /**
+   * Activate an agent through its authoritative storage filename.
+   * Used for persisted activation restore when metadata.name may have changed.
+   */
+  async activateAgentByFilename(filename: string): Promise<AgentActivationResult> {
+    const agent = await this.findByFilename(filename);
+    return this.activateResolvedAgent(agent, filename);
+  }
+
+  private async activateResolvedAgent(agent: Agent | undefined, identifier: string): Promise<AgentActivationResult> {
     if (!agent) {
       return {
         success: false,

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -128,11 +128,11 @@ export class AgentManager extends BaseElementManager<Agent> {
   private readonly metadataService: MetadataService;
   /** Per-agent tokens retained only while execution or recovery is in flight. */
   private readonly executionGenerations = new Map<string, ExecutionGenerationEntry>();
-  // Track active agents by name (stable identifier)
+  // Fallback identities for agents without attached storage metadata.
   private readonly activeAgentNames: Set<string> = new Set();
-  // Preserve the storage identity captured at activation time. Display names
-  // are editable metadata, while filenames remain stable across those edits.
-  private readonly activeAgentFilenames: Map<string, string> = new Map();
+  // Stable filename -> name used at activation. Filenames are authoritative;
+  // the retained name remains a valid deactivation alias after metadata edits.
+  private readonly activeAgentsByFilename: Map<string, string> = new Map();
 
   // Static resolver for element manager lookup (DI pattern)
   // This allows Agent instances to resolve managers without tight coupling
@@ -879,21 +879,14 @@ export class AgentManager extends BaseElementManager<Agent> {
    */
   override async list(): Promise<Agent[]> {
     const agents = await super.list();
-    const activeNameByFilename = new Map<string, string>();
-    for (const [activeName, filename] of this.activeAgentFilenames) {
-      activeNameByFilename.set(filename, activeName);
-    }
 
     // Apply active status by display name or, when available, stable filename.
     for (const agent of agents) {
       const filename = this.getStableFilename(agent);
-      const priorName = filename
-        ? activeNameByFilename.get(filename)
-        : undefined;
-      if (this.activeAgentNames.has(agent.metadata.name) || priorName) {
-        if (priorName && priorName !== agent.metadata.name) {
-          this.migrateActiveAgentIdentity(priorName, agent.metadata.name, filename);
-        }
+      if (
+        (filename && this.activeAgentsByFilename.has(filename)) ||
+        this.activeAgentNames.has(agent.metadata.name)
+      ) {
         // Activate the agent to set status to ACTIVE
         await agent.activate();
       }
@@ -924,12 +917,13 @@ export class AgentManager extends BaseElementManager<Agent> {
     // MEMORY LEAK FIX: Check if cleanup is needed before adding
     this.checkAndCleanupActiveSet();
 
-    // Keep the display name for compatibility and the filename as the stable
-    // identity used to survive an external metadata rename.
-    this.activeAgentNames.add(agent.metadata.name);
+    // Prefer stable storage identity so external display-name edits cannot
+    // collapse or orphan active agents.
     const filename = this.getStableFilename(agent);
     if (filename) {
-      this.activeAgentFilenames.set(agent.metadata.name, filename);
+      this.activeAgentsByFilename.set(filename, agent.metadata.name);
+    } else {
+      this.activeAgentNames.add(agent.metadata.name);
     }
 
     // Update agent status in memory
@@ -971,17 +965,19 @@ export class AgentManager extends BaseElementManager<Agent> {
     // then fall back to stable active filenames when external metadata edits
     // have made the current display name diverge from its storage path.
     await this.scanAndEvict({ freshAfterInFlight: true });
-    let agent = await this.findByName(identifier);
-    if (!agent) {
-      const normalizedIdentifier = identifier.toLowerCase();
-      for (const filename of new Set(this.activeAgentFilenames.values())) {
-        const candidate = await this.findByFilename(filename);
-        if (candidate?.metadata.name.toLowerCase() === normalizedIdentifier) {
-          agent = candidate;
-          break;
-        }
+    let agent: Agent | undefined;
+    const normalizedIdentifier = identifier.toLowerCase();
+    for (const [filename, activationName] of this.activeAgentsByFilename) {
+      const candidate = await this.findByFilename(filename);
+      if (
+        activationName.toLowerCase() === normalizedIdentifier ||
+        candidate?.metadata.name.toLowerCase() === normalizedIdentifier
+      ) {
+        agent = candidate;
+        if (agent) break;
       }
     }
+    agent ??= await this.findByName(identifier);
 
     if (!agent) {
       return {
@@ -994,7 +990,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     // Remove the current display name and any pre-rename key that points at
     // the same stable file, so explicit deactivation cannot be undone by a
     // later policy refresh.
-    this.removeActiveAgentIdentity(agent);
+    this.removeActiveAgentIdentity(agent, identifier);
 
     // Update agent status in memory
     await agent.deactivate();
@@ -1027,23 +1023,11 @@ export class AgentManager extends BaseElementManager<Agent> {
   async getActiveAgents(options: { freshAfterInFlight?: boolean } = {}): Promise<Agent[]> {
     await this.scanAndEvict(options);
     const agents: Agent[] = [];
-    // Snapshot the keys because a reloaded file may have a new metadata name.
-    // Migrate that identity before restoring lifecycle state so a later
-    // deactivateAgent(newName) removes the authoritative active-set entry.
-    for (const name of Array.from(this.activeAgentNames)) {
-      const stableFilename = this.activeAgentFilenames.get(name);
-      const agent = stableFilename
-        ? await this.findByFilename(stableFilename)
-        : await this.findByName(name);
+    // Stable filenames remain distinct even if externally edited metadata
+    // names collide, so every active agent continues contributing policy.
+    for (const filename of Array.from(this.activeAgentsByFilename.keys())) {
+      const agent = await this.findByFilename(filename);
       if (agent) {
-        if (agent.metadata.name !== name) {
-          this.migrateActiveAgentIdentity(name, agent.metadata.name, stableFilename);
-        } else if (!stableFilename) {
-          const loadedFilename = this.getStableFilename(agent);
-          if (loadedFilename) {
-            this.activeAgentFilenames.set(name, loadedFilename);
-          }
-        }
         // scanAndEvict() can discard an externally modified active agent. Its
         // replacement starts inactive, so restore the lifecycle state once.
         // Avoid reactivating unchanged instances: Agent.activate() advances
@@ -1053,6 +1037,17 @@ export class AgentManager extends BaseElementManager<Agent> {
         }
         agents.push(agent);
       }
+    }
+
+    // Compatibility fallback for synthetic or legacy instances that did not
+    // have filename metadata when activated.
+    for (const name of Array.from(this.activeAgentNames)) {
+      const agent = await this.findByName(name);
+      if (!agent) continue;
+      if (agent.getStatus() !== ElementStatus.ACTIVE) {
+        await agent.activate();
+      }
+      agents.push(agent);
     }
     return agents;
   }
@@ -1064,30 +1059,17 @@ export class AgentManager extends BaseElementManager<Agent> {
       : undefined;
   }
 
-  private migrateActiveAgentIdentity(
-    previousName: string,
-    currentName: string,
-    filename?: string,
-  ): void {
-    this.activeAgentNames.delete(previousName);
-    this.activeAgentNames.add(currentName);
-    this.activeAgentFilenames.delete(previousName);
+  private removeActiveAgentIdentity(agent: Agent, identifier: string): void {
+    const filename = this.getStableFilename(agent);
+    this.activeAgentNames.delete(agent.metadata.name);
+    this.activeAgentNames.delete(identifier);
     if (filename) {
-      this.activeAgentFilenames.set(currentName, filename);
+      this.activeAgentsByFilename.delete(filename);
     }
   }
 
-  private removeActiveAgentIdentity(agent: Agent): void {
-    const filename = this.getStableFilename(agent);
-    this.activeAgentNames.delete(agent.metadata.name);
-    this.activeAgentFilenames.delete(agent.metadata.name);
-
-    if (!filename) return;
-    for (const [activeName, activeFilename] of this.activeAgentFilenames) {
-      if (activeFilename !== filename) continue;
-      this.activeAgentFilenames.delete(activeName);
-      this.activeAgentNames.delete(activeName);
-    }
+  private getActiveAgentCount(): number {
+    return this.activeAgentsByFilename.size + this.activeAgentNames.size;
   }
 
   /**
@@ -1887,12 +1869,13 @@ export class AgentManager extends BaseElementManager<Agent> {
     const { max, cleanupThreshold } = getActiveElementLimitConfig('agents');
 
     // Below threshold — no action needed
-    if (this.activeAgentNames.size < cleanupThreshold) {
+    const activeCount = this.getActiveAgentCount();
+    if (activeCount < cleanupThreshold) {
       return;
     }
 
     // At or above max — warn before cleanup
-    if (this.activeAgentNames.size >= max) {
+    if (activeCount >= max) {
       logger.warn(
         `Active agents limit reached (${max}). ` +
         `Consider deactivating unused agents or setting DOLLHOUSE_MAX_ACTIVE_AGENTS to a higher value.`
@@ -1902,11 +1885,14 @@ export class AgentManager extends BaseElementManager<Agent> {
         type: 'AGENT_ACTIVATED',
         severity: 'MEDIUM',
         source: 'AgentManager.checkAndCleanupActiveSet',
-        details: `Active agents limit reached (${this.activeAgentNames.size}/${max})`,
+        details: `Active agents limit reached (${activeCount}/${max})`,
         additionalData: {
-          activeCount: this.activeAgentNames.size,
+          activeCount,
           maxAllowed: max,
-          activeAgentNames: Array.from(this.activeAgentNames),
+          activeAgentNames: [
+            ...this.activeAgentsByFilename.values(),
+            ...this.activeAgentNames,
+          ],
         }
       });
     }
@@ -1922,20 +1908,28 @@ export class AgentManager extends BaseElementManager<Agent> {
    */
   private async cleanupStaleActiveAgents(): Promise<void> {
     try {
-      const startSize = this.activeAgentNames.size;
+      const startSize = this.getActiveAgentCount();
       const agents = await this.list();
       const existingAgentNames = new Set(agents.map(a => a.metadata.name));
+      const existingAgentFilenames = new Set(
+        agents.map(agent => this.getStableFilename(agent)).filter((filename): filename is string => Boolean(filename)),
+      );
 
       const staleNames: string[] = [];
+      for (const [filename, activationName] of this.activeAgentsByFilename) {
+        if (!existingAgentFilenames.has(filename)) {
+          this.activeAgentsByFilename.delete(filename);
+          staleNames.push(activationName);
+        }
+      }
       for (const activeName of this.activeAgentNames) {
         if (!existingAgentNames.has(activeName)) {
           this.activeAgentNames.delete(activeName);
-          this.activeAgentFilenames.delete(activeName);
           staleNames.push(activeName);
         }
       }
 
-      const endSize = this.activeAgentNames.size;
+      const endSize = this.getActiveAgentCount();
       const removed = startSize - endSize;
 
       if (removed > 0) {

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -990,6 +990,7 @@ export class AgentManager extends BaseElementManager<Agent> {
    * Get all active agents
    */
   async getActiveAgents(): Promise<Agent[]> {
+    await this.scanAndEvict();
     const agents: Agent[] = [];
     for (const name of this.activeAgentNames) {
       const agent = await this.findByName(name);

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -970,6 +970,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     for (const [filename, activationName] of this.activeAgentsByFilename) {
       const candidate = await this.findByFilename(filename);
       if (
+        filename.toLowerCase() === normalizedIdentifier ||
         activationName.toLowerCase() === normalizedIdentifier ||
         candidate?.metadata.name.toLowerCase() === normalizedIdentifier
       ) {

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -130,6 +130,9 @@ export class AgentManager extends BaseElementManager<Agent> {
   private readonly executionGenerations = new Map<string, ExecutionGenerationEntry>();
   // Track active agents by name (stable identifier)
   private readonly activeAgentNames: Set<string> = new Set();
+  // Preserve the storage identity captured at activation time. Display names
+  // are editable metadata, while filenames remain stable across those edits.
+  private readonly activeAgentFilenames: Map<string, string> = new Map();
 
   // Static resolver for element manager lookup (DI pattern)
   // This allows Agent instances to resolve managers without tight coupling
@@ -876,10 +879,21 @@ export class AgentManager extends BaseElementManager<Agent> {
    */
   override async list(): Promise<Agent[]> {
     const agents = await super.list();
+    const activeNameByFilename = new Map<string, string>();
+    for (const [activeName, filename] of this.activeAgentFilenames) {
+      activeNameByFilename.set(filename, activeName);
+    }
 
-    // Apply active status to agents that are in the active set (by name)
+    // Apply active status by display name or, when available, stable filename.
     for (const agent of agents) {
-      if (this.activeAgentNames.has(agent.metadata.name)) {
+      const filename = this.getStableFilename(agent);
+      const priorName = filename
+        ? activeNameByFilename.get(filename)
+        : undefined;
+      if (this.activeAgentNames.has(agent.metadata.name) || priorName) {
+        if (priorName && priorName !== agent.metadata.name) {
+          this.migrateActiveAgentIdentity(priorName, agent.metadata.name, filename);
+        }
         // Activate the agent to set status to ACTIVE
         await agent.activate();
       }
@@ -910,8 +924,13 @@ export class AgentManager extends BaseElementManager<Agent> {
     // MEMORY LEAK FIX: Check if cleanup is needed before adding
     this.checkAndCleanupActiveSet();
 
-    // Add to active set (by name, which is stable across reloads)
+    // Keep the display name for compatibility and the filename as the stable
+    // identity used to survive an external metadata rename.
     this.activeAgentNames.add(agent.metadata.name);
+    const filename = this.getStableFilename(agent);
+    if (filename) {
+      this.activeAgentFilenames.set(agent.metadata.name, filename);
+    }
 
     // Update agent status in memory
     await agent.activate();
@@ -948,8 +967,21 @@ export class AgentManager extends BaseElementManager<Agent> {
    * Issue #24 (LOW PRIORITY): Consistent error messages using ElementMessages
    */
   async deactivateAgent(identifier: string): Promise<{ success: boolean; message: string }> {
-    // PERFORMANCE FIX: Use findByName() instead of list()
-    const agent = await this.findByName(identifier);
+    // Deactivation is a security-sensitive lifecycle change. Refresh first,
+    // then fall back to stable active filenames when external metadata edits
+    // have made the current display name diverge from its storage path.
+    await this.scanAndEvict({ freshAfterInFlight: true });
+    let agent = await this.findByName(identifier);
+    if (!agent) {
+      const normalizedIdentifier = identifier.toLowerCase();
+      for (const filename of new Set(this.activeAgentFilenames.values())) {
+        const candidate = await this.findByFilename(filename);
+        if (candidate?.metadata.name.toLowerCase() === normalizedIdentifier) {
+          agent = candidate;
+          break;
+        }
+      }
+    }
 
     if (!agent) {
       return {
@@ -959,8 +991,10 @@ export class AgentManager extends BaseElementManager<Agent> {
       };
     }
 
-    // Remove from active set
-    this.activeAgentNames.delete(agent.metadata.name);
+    // Remove the current display name and any pre-rename key that points at
+    // the same stable file, so explicit deactivation cannot be undone by a
+    // later policy refresh.
+    this.removeActiveAgentIdentity(agent);
 
     // Update agent status in memory
     await agent.deactivate();
@@ -997,11 +1031,18 @@ export class AgentManager extends BaseElementManager<Agent> {
     // Migrate that identity before restoring lifecycle state so a later
     // deactivateAgent(newName) removes the authoritative active-set entry.
     for (const name of Array.from(this.activeAgentNames)) {
-      const agent = await this.findByName(name);
+      const stableFilename = this.activeAgentFilenames.get(name);
+      const agent = stableFilename
+        ? await this.findByFilename(stableFilename)
+        : await this.findByName(name);
       if (agent) {
         if (agent.metadata.name !== name) {
-          this.activeAgentNames.delete(name);
-          this.activeAgentNames.add(agent.metadata.name);
+          this.migrateActiveAgentIdentity(name, agent.metadata.name, stableFilename);
+        } else if (!stableFilename) {
+          const loadedFilename = this.getStableFilename(agent);
+          if (loadedFilename) {
+            this.activeAgentFilenames.set(name, loadedFilename);
+          }
         }
         // scanAndEvict() can discard an externally modified active agent. Its
         // replacement starts inactive, so restore the lifecycle state once.
@@ -1014,6 +1055,39 @@ export class AgentManager extends BaseElementManager<Agent> {
       }
     }
     return agents;
+  }
+
+  private getStableFilename(agent: Agent): string | undefined {
+    const filename = (agent as Agent & { filename?: unknown }).filename;
+    return typeof filename === 'string' && filename.trim() !== ''
+      ? filename
+      : undefined;
+  }
+
+  private migrateActiveAgentIdentity(
+    previousName: string,
+    currentName: string,
+    filename?: string,
+  ): void {
+    this.activeAgentNames.delete(previousName);
+    this.activeAgentNames.add(currentName);
+    this.activeAgentFilenames.delete(previousName);
+    if (filename) {
+      this.activeAgentFilenames.set(currentName, filename);
+    }
+  }
+
+  private removeActiveAgentIdentity(agent: Agent): void {
+    const filename = this.getStableFilename(agent);
+    this.activeAgentNames.delete(agent.metadata.name);
+    this.activeAgentFilenames.delete(agent.metadata.name);
+
+    if (!filename) return;
+    for (const [activeName, activeFilename] of this.activeAgentFilenames) {
+      if (activeFilename !== filename) continue;
+      this.activeAgentFilenames.delete(activeName);
+      this.activeAgentNames.delete(activeName);
+    }
   }
 
   /**
@@ -1856,6 +1930,7 @@ export class AgentManager extends BaseElementManager<Agent> {
       for (const activeName of this.activeAgentNames) {
         if (!existingAgentNames.has(activeName)) {
           this.activeAgentNames.delete(activeName);
+          this.activeAgentFilenames.delete(activeName);
           staleNames.push(activeName);
         }
       }

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -993,9 +993,16 @@ export class AgentManager extends BaseElementManager<Agent> {
   async getActiveAgents(options: { freshAfterInFlight?: boolean } = {}): Promise<Agent[]> {
     await this.scanAndEvict(options);
     const agents: Agent[] = [];
-    for (const name of this.activeAgentNames) {
+    // Snapshot the keys because a reloaded file may have a new metadata name.
+    // Migrate that identity before restoring lifecycle state so a later
+    // deactivateAgent(newName) removes the authoritative active-set entry.
+    for (const name of Array.from(this.activeAgentNames)) {
       const agent = await this.findByName(name);
       if (agent) {
+        if (agent.metadata.name !== name) {
+          this.activeAgentNames.delete(name);
+          this.activeAgentNames.add(agent.metadata.name);
+        }
         // scanAndEvict() can discard an externally modified active agent. Its
         // replacement starts inactive, so restore the lifecycle state once.
         // Avoid reactivating unchanged instances: Agent.activate() advances

--- a/src/elements/base/BaseElementManager.ts
+++ b/src/elements/base/BaseElementManager.ts
@@ -769,8 +769,16 @@ export abstract class BaseElementManager<T extends IElement> implements IElement
       return undefined;
     }
 
+    const normalizedFilename = filename.trim();
+    const cached = this.getCachedElementByAbsolutePath(
+      this.resolveAbsolutePath(normalizedFilename)
+    );
+    if (cached) {
+      return cached;
+    }
+
     try {
-      return await this.load(filename.trim());
+      return await this.load(normalizedFilename);
     } catch {
       return undefined;
     }

--- a/src/elements/base/BaseElementManager.ts
+++ b/src/elements/base/BaseElementManager.ts
@@ -756,6 +756,27 @@ export abstract class BaseElementManager<T extends IElement> implements IElement
   }
 
   /**
+   * Load an element by its stable storage filename without requiring its
+   * current display name to match that filename. This is intended for trusted
+   * persisted references (for example persona activation records) that must
+   * survive a metadata name change.
+   *
+   * Path validation remains delegated to load(); malformed, missing, or
+   * unreadable filenames are treated as lookup misses.
+   */
+  async findByFilename(filename: string): Promise<T | undefined> {
+    if (typeof filename !== 'string' || filename.trim() === '') {
+      return undefined;
+    }
+
+    try {
+      return await this.load(filename.trim());
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
    * Helper: Search cache for element by name or ID
    * @private
    */

--- a/src/elements/base/BaseElementManager.ts
+++ b/src/elements/base/BaseElementManager.ts
@@ -38,7 +38,7 @@ import { FileOperationsService } from '../../services/FileOperationsService.js';
 import { ValidationRegistry } from '../../services/validation/ValidationRegistry.js';
 import { type ElementValidator } from '../../services/validation/ElementValidator.js';
 import { ElementStorageLayer } from '../../storage/ElementStorageLayer.js';
-import type { IStorageLayer } from '../../storage/IStorageLayer.js';
+import type { IStorageLayer, StorageScanOptions } from '../../storage/IStorageLayer.js';
 import type { ElementIndexEntry } from '../../storage/types.js';
 import { getGatekeeperAuthoringErrors } from '../../handlers/mcp-aql/policies/ElementPolicies.js';
 import { MEMORY_CONSTANTS } from '../memories/constants.js';
@@ -1143,10 +1143,10 @@ export abstract class BaseElementManager<T extends IElement> implements IElement
    * Unlike list(), this does not load all elements — it only evicts stale ones.
    * Fixes #1895 (ensemble activation serving stale cached element list).
    */
-  protected async scanAndEvict(): Promise<void> {
+  protected async scanAndEvict(options: StorageScanOptions = {}): Promise<void> {
     this.storageLayer.invalidate(); // bypass cooldown so the next scan hits disk
     try {
-      const diff = await this.storageLayer.scan();
+      const diff = await this.storageLayer.scan(options);
       for (const relPath of [...diff.modified, ...diff.removed]) {
         const absPath = path.join(this.elementDir, relPath);
         const existingId = this.filePathToId.get(absPath);
@@ -1164,8 +1164,8 @@ export abstract class BaseElementManager<T extends IElement> implements IElement
    * indexed read-only lookups. Unlike list(), this does not load every element or
    * apply manager-specific lifecycle status.
    */
-  async refreshIndex(): Promise<void> {
-    await this.scanAndEvict();
+  async refreshIndex(options: StorageScanOptions = {}): Promise<void> {
+    await this.scanAndEvict(options);
   }
 
   /**

--- a/src/elements/base/BaseElementManager.ts
+++ b/src/elements/base/BaseElementManager.ts
@@ -1139,6 +1139,15 @@ export abstract class BaseElementManager<T extends IElement> implements IElement
   }
 
   /**
+   * Refresh the lightweight metadata index and evict stale cached objects before
+   * indexed read-only lookups. Unlike list(), this does not load every element or
+   * apply manager-specific lifecycle status.
+   */
+  async refreshIndex(): Promise<void> {
+    await this.scanAndEvict();
+  }
+
+  /**
    * Removes an element from both caches by file path
    * This is the preferred method for deletion to avoid stale cache entries
    * @param filePath - File path (relative or absolute)

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -3,7 +3,7 @@
  * Generated at build time by scripts/generate-version.js
  */
 
-export const PACKAGE_VERSION = '2.0.40';
-export const BUILD_TIMESTAMP = '2026-08-05T18:45:06.812Z';
+export const PACKAGE_VERSION = '2.0.41';
+export const BUILD_TIMESTAMP = '2026-08-26T19:05:01.970Z';
 export const BUILD_TYPE: 'npm' | 'git' = 'git';
 export const PACKAGE_NAME = '@dollhousemcp/mcp-server';

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -76,7 +76,11 @@ type PolicyMemberElement = {
 
 export class ElementCRUDHandler {
   private readonly strategies: Map<string, ElementActivationStrategy>;
-  private activePolicySnapshotInFlight?: Promise<PolicyElement[]>;
+  private activePolicySnapshotGeneration = 0;
+  private activePolicySnapshotInFlight?: {
+    generation: number;
+    promise: Promise<PolicyElement[]>;
+  };
 
   constructor(
     private readonly skillManager: SkillManager,
@@ -188,6 +192,10 @@ export class ElementCRUDHandler {
 
   private policyElementKey(type: string, name: string): string {
     return `${this.toPolicyElementType(this.normalizeElementType(type))}:${this.normalizeLookupValue(name)}`;
+  }
+
+  private invalidateActivePolicySnapshot(): void {
+    this.activePolicySnapshotGeneration += 1;
   }
 
   /**
@@ -316,6 +324,7 @@ export class ElementCRUDHandler {
       }
 
       const result = await strategy.activate(name, context);
+      this.invalidateActivePolicySnapshot();
 
       // Issue #598: Persist activation state for session restore
       if (this.activationStore) {
@@ -379,17 +388,19 @@ export class ElementCRUDHandler {
    * Issue #452: Provides active element context for enforce() policy checks.
    */
   async getActiveElementsForPolicy(): Promise<PolicyElement[]> {
-    if (this.activePolicySnapshotInFlight) {
-      return this.activePolicySnapshotInFlight;
+    const generation = this.activePolicySnapshotGeneration;
+    if (this.activePolicySnapshotInFlight?.generation === generation) {
+      return this.activePolicySnapshotInFlight.promise;
     }
 
     const snapshot = this.collectActiveElementsForPolicy();
-    this.activePolicySnapshotInFlight = snapshot;
+    const inFlight = { generation, promise: snapshot };
+    this.activePolicySnapshotInFlight = inFlight;
 
     try {
       return await snapshot;
     } finally {
-      if (this.activePolicySnapshotInFlight === snapshot) {
+      if (this.activePolicySnapshotInFlight === inFlight) {
         this.activePolicySnapshotInFlight = undefined;
       }
     }
@@ -415,7 +426,7 @@ export class ElementCRUDHandler {
 
       const manager = this.getManagerForType(normalizedType);
       const indexed = manager
-        ? manager.listSummaries().then(() => manager)
+        ? manager.refreshIndex().then(() => manager)
         : Promise.resolve(undefined);
       indexedManagers.set(normalizedType, indexed);
       return indexed;
@@ -693,6 +704,7 @@ export class ElementCRUDHandler {
     });
 
     this.activationStore?.clearAll();
+    this.invalidateActivePolicySnapshot();
     this.policyExportService?.exportPolicies().catch(() => {});
 
     const failureSummary = failed.length > 0 ? ` with ${failed.length} failure(s)` : '';
@@ -862,6 +874,7 @@ export class ElementCRUDHandler {
       }
 
       const result = await strategy.deactivate(name);
+      this.invalidateActivePolicySnapshot();
 
       // Issue #598: Persist deactivation state for session restore
       if (this.activationStore) {

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -349,9 +349,7 @@ export class ElementCRUDHandler {
 
       // Issue #598: Persist activation state for session restore
       if (this.activationStore) {
-        const filename = normalizedType === ElementType.PERSONA
-          ? this.personaManager.findPersona(name)?.filename
-          : undefined;
+        const filename = await this.getStableActivationFilename(normalizedType, name);
         this.activationStore.recordActivation(normalizedType, name, filename);
       }
 
@@ -963,6 +961,16 @@ export class ElementCRUDHandler {
     }
 
     await Promise.allSettled(pending);
+  }
+
+  private async getStableActivationFilename(type: string, name: string): Promise<string | undefined> {
+    if (type === ElementType.PERSONA) {
+      return this.personaManager.findPersona(name)?.filename;
+    }
+    if (type === ElementType.AGENT) {
+      return this.agentManager.getStableActivationFilename(name);
+    }
+    return undefined;
   }
 
   async deactivateElement(name: string, type: string) {

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -995,12 +995,15 @@ export class ElementCRUDHandler {
         };
       }
 
+      const filename = this.activationStore
+        ? await this.getStableActivationFilename(normalizedType, name)
+        : undefined;
       const result = await strategy.deactivate(name);
       this.invalidateActivePolicySnapshot();
 
       // Issue #598: Persist deactivation state for session restore
       if (this.activationStore) {
-        this.activationStore.recordDeactivation(normalizedType, name);
+        this.activationStore.recordDeactivation(normalizedType, name, filename);
       }
 
       // Issue #762: Export policies to bridge after deactivation

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -79,7 +79,6 @@ type PolicyMemberElement = {
 type PolicyIndexOptions = { freshAfterInFlight?: boolean };
 type IndexedPolicyManagers = Map<string, Promise<BaseElementManager<any> | undefined>>;
 type PolicyMemberCandidate = { type: string; name: string; key: string };
-type PersistedPolicyElement = PolicyElement;
 
 type DeadlockReliefElement = {
   type: string;
@@ -692,12 +691,12 @@ export class ElementCRUDHandler {
     if (this.activationStore?.isEnabled()) {
       const persistedStates = await this.activationStore.listPersistedActivationStates(sessionId);
       const indexedManagers: IndexedPolicyManagers = new Map();
-      const persistedLookups = new Map<string, Promise<PersistedPolicyElement | null>>();
+      const persistedLookups = new Map<string, Promise<PolicyElement | null>>();
 
       const findPersistedElement = (
         type: string,
         activation: PersistedActivation,
-      ): Promise<PersistedPolicyElement | null> => {
+      ): Promise<PolicyElement | null> => {
         const normalizedType = this.normalizeElementType(type);
         const normalizedName = this.normalizeLookupValue(activation.name);
         const normalizedFilename = this.normalizeLookupValue(activation.filename);
@@ -938,7 +937,7 @@ export class ElementCRUDHandler {
   private async mergePersistedPolicyState(
     state: PersistedActivationStateSnapshot,
     addElement: (element: PolicyElement, sessionIds?: string[]) => void,
-    findPersistedElement: (type: string, activation: PersistedActivation) => Promise<PersistedPolicyElement | null>,
+    findPersistedElement: (type: string, activation: PersistedActivation) => Promise<PolicyElement | null>,
   ): Promise<void> {
     const pending: Promise<void>[] = [];
 

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -396,7 +396,7 @@ export class ElementCRUDHandler {
     // before an external policy-file edit. Dashboard/reporting callers may
     // coalesce overlapping reads to bound polling work.
     if (options.allowCoalescing === false) {
-      return this.collectActiveElementsForPolicy();
+      return this.collectActiveElementsForPolicy({ freshAfterInFlight: true });
     }
 
     const generation = this.activePolicySnapshotGeneration;
@@ -417,7 +417,9 @@ export class ElementCRUDHandler {
     }
   }
 
-  private async collectActiveElementsForPolicy(): Promise<PolicyElement[]> {
+  private async collectActiveElementsForPolicy(
+    indexOptions: { freshAfterInFlight?: boolean } = {},
+  ): Promise<PolicyElement[]> {
     await this.ensureInitialized();
 
     const result: PolicyElement[] = [];
@@ -437,7 +439,7 @@ export class ElementCRUDHandler {
 
       const manager = this.getManagerForType(normalizedType);
       const indexed = manager
-        ? manager.refreshIndex().then(() => manager)
+        ? manager.refreshIndex(indexOptions).then(() => manager)
         : Promise.resolve(undefined);
       indexedManagers.set(normalizedType, indexed);
       return indexed;
@@ -495,7 +497,7 @@ export class ElementCRUDHandler {
 
     try {
       // Active agents (async)
-      const agents = await this.agentManager.getActiveAgents();
+      const agents = await this.agentManager.getActiveAgents(indexOptions);
       for (const agent of agents) {
         const key = this.policyElementKey('agent', agent.metadata.name);
         seen.add(key);

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -391,7 +391,14 @@ export class ElementCRUDHandler {
    *
    * Issue #452: Provides active element context for enforce() policy checks.
    */
-  async getActiveElementsForPolicy(): Promise<PolicyElement[]> {
+  async getActiveElementsForPolicy(options: { allowCoalescing?: boolean } = {}): Promise<PolicyElement[]> {
+    // Security enforcement must not join a snapshot that may have started
+    // before an external policy-file edit. Dashboard/reporting callers may
+    // coalesce overlapping reads to bound polling work.
+    if (options.allowCoalescing === false) {
+      return this.collectActiveElementsForPolicy();
+    }
+
     const generation = this.activePolicySnapshotGeneration;
     if (this.activePolicySnapshotInFlight?.generation === generation) {
       return this.activePolicySnapshotInFlight.promise;

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -76,6 +76,15 @@ type PolicyMemberElement = {
   metadata?: Record<string, unknown>;
 };
 
+type PolicyIndexOptions = { freshAfterInFlight?: boolean };
+type IndexedPolicyManagers = Map<string, Promise<BaseElementManager<any> | undefined>>;
+type PolicyMemberCandidate = { type: string; name: string; key: string };
+type PersistedPolicyElement = {
+  type: string;
+  name: string;
+  metadata: Record<string, unknown>;
+};
+
 type DeadlockReliefElement = {
   type: string;
   name: string;
@@ -426,89 +435,59 @@ export class ElementCRUDHandler {
   }
 
   private async collectActiveElementsForPolicy(
-    indexOptions: { freshAfterInFlight?: boolean } = {},
+    indexOptions: PolicyIndexOptions = {},
   ): Promise<PolicyElement[]> {
     await this.ensureInitialized();
 
     const result: PolicyElement[] = [];
     const seen = new Set<string>();
-    const indexedManagers = new Map<string, Promise<BaseElementManager<any> | undefined>>();
-    const memberLookups = new Map<string, Promise<PolicyMemberElement | undefined>>();
 
-    // Prime each manager's lightweight metadata index once, then resolve only
-    // the referenced members. This prevents findByName() from falling back to a
-    // full list on a miss while avoiding list() lifecycle/status side effects.
-    const getIndexedManager = (type: string): Promise<BaseElementManager<any> | undefined> => {
-      const normalizedType = this.normalizeElementType(type);
-      const existing = indexedManagers.get(normalizedType);
-      if (existing) {
-        return existing;
-      }
+    this.appendActivePersonas(result, seen);
+    await this.appendActiveSkills(result, seen);
+    await this.appendActiveAgents(result, seen, indexOptions);
+    await this.appendActiveEnsembles(result, seen, indexOptions);
 
-      const manager = this.getManagerForType(normalizedType);
-      const indexed = manager
-        ? manager.refreshIndex(indexOptions).then(() => manager)
-        : Promise.resolve(undefined);
-      indexedManagers.set(normalizedType, indexed);
-      return indexed;
-    };
+    return result;
+  }
 
-    const findMember = (
-      type: string,
-      name: string,
-      key: string,
-    ): Promise<PolicyMemberElement | undefined> => {
-      const existing = memberLookups.get(key);
-      if (existing) {
-        return existing;
-      }
-
-      const lookup = getIndexedManager(type).then(async (manager) => {
-        if (!manager) return undefined;
-        return manager.findByName(name) as Promise<PolicyMemberElement | undefined>;
-      });
-      memberLookups.set(key, lookup);
-      return lookup;
-    };
-
+  private appendActivePersonas(result: PolicyElement[], seen: Set<string>): void {
     try {
-      // Active personas (sync)
-      const personas = this.personaManager.getActivePersonas();
-      for (const p of personas) {
-        const key = this.policyElementKey('persona', p.metadata.name);
-        seen.add(key);
+      for (const persona of this.personaManager.getActivePersonas()) {
+        seen.add(this.policyElementKey('persona', persona.metadata.name));
         result.push({
           type: 'persona',
-          name: p.metadata.name,
-          metadata: p.metadata as unknown as Record<string, unknown>,
+          name: persona.metadata.name,
+          metadata: persona.metadata as unknown as Record<string, unknown>,
         });
       }
     } catch (error) {
       logger.warn('Failed to gather active personas for policy evaluation', { error });
     }
+  }
 
+  private async appendActiveSkills(result: PolicyElement[], seen: Set<string>): Promise<void> {
     try {
-      // Active skills (async)
-      const skills = await this.skillManager.getActiveSkills();
-      for (const s of skills) {
-        const key = this.policyElementKey('skill', s.metadata.name);
-        seen.add(key);
+      for (const skill of await this.skillManager.getActiveSkills()) {
+        seen.add(this.policyElementKey('skill', skill.metadata.name));
         result.push({
           type: 'skill',
-          name: s.metadata.name,
-          metadata: s.metadata as unknown as Record<string, unknown>,
+          name: skill.metadata.name,
+          metadata: skill.metadata as unknown as Record<string, unknown>,
         });
       }
     } catch (error) {
       logger.warn('Failed to gather active skills for policy evaluation', { error });
     }
+  }
 
+  private async appendActiveAgents(
+    result: PolicyElement[],
+    seen: Set<string>,
+    indexOptions: PolicyIndexOptions,
+  ): Promise<void> {
     try {
-      // Active agents (async)
-      const agents = await this.agentManager.getActiveAgents(indexOptions);
-      for (const agent of agents) {
-        const key = this.policyElementKey('agent', agent.metadata.name);
-        seen.add(key);
+      for (const agent of await this.agentManager.getActiveAgents(indexOptions)) {
+        seen.add(this.policyElementKey('agent', agent.metadata.name));
         const filename = (agent as typeof agent & { filename?: unknown }).filename;
         result.push({
           type: 'agent',
@@ -522,79 +501,147 @@ export class ElementCRUDHandler {
     } catch (error) {
       logger.warn('Failed to gather active agents for policy evaluation', { error });
     }
+  }
 
+  private async appendActiveEnsembles(
+    result: PolicyElement[],
+    seen: Set<string>,
+    indexOptions: PolicyIndexOptions,
+  ): Promise<void> {
     try {
-      // Active ensembles (async)
       const ensembles = await this.ensembleManager.getActiveEnsembles();
-      const memberCandidates: Array<{ type: string; name: string; key: string }> = [];
-      const queuedMemberKeys = new Set<string>();
-      for (const e of ensembles) {
-        const ensembleKey = this.policyElementKey('ensemble', e.metadata.name);
-        seen.add(ensembleKey);
-        result.push({
-          type: 'ensemble',
-          name: e.metadata.name,
-          metadata: e.metadata as unknown as Record<string, unknown>,
-        });
-
-        // Issue #625 Phase 4: Resolve ensemble member gatekeeper policies
-        const members = (e.metadata as unknown as Record<string, unknown>)?.elements as
-          Array<{ element_name: string; element_type: string }> | undefined;
-        if (Array.isArray(members)) {
-          for (const member of members) {
-            const normalizedType = this.normalizeElementType(member.element_type);
-            const normalizedName = this.normalizeLookupValue(member.element_name);
-            if (normalizedType === '' || normalizedName === '') continue;
-
-            const memberKey = this.policyElementKey(normalizedType, normalizedName);
-            if (seen.has(memberKey)) continue; // Already active individually
-            if (queuedMemberKeys.has(memberKey)) continue;
-            queuedMemberKeys.add(memberKey);
-            memberCandidates.push({ type: normalizedType, name: normalizedName, key: memberKey });
-          }
-        }
-      }
-
-      // Resolve uncached member files concurrently, but cap the work so a
-      // large ensemble cannot create an unbounded I/O burst. Store results by
-      // candidate index to preserve deterministic policy ordering.
-      const resolvedMembers = new Array<PolicyElement | undefined>(memberCandidates.length);
-      let nextCandidateIndex = 0;
-      const resolveNextMember = async (): Promise<void> => {
-        while (nextCandidateIndex < memberCandidates.length) {
-          const candidateIndex = nextCandidateIndex++;
-          const candidate = memberCandidates[candidateIndex];
-          try {
-            const found = await findMember(candidate.type, candidate.name, candidate.key);
-            if (found?.metadata && found.metadata['gatekeeper']) {
-              resolvedMembers[candidateIndex] = {
-                type: this.toPolicyElementType(candidate.type),
-                name: candidate.name,
-                metadata: found.metadata,
-              };
-            }
-          } catch {
-            // Non-fatal: skip member if element type lookup fails
-          }
-        }
-      };
-      const workerCount = Math.min(
-        ACTIVE_POLICY_MEMBER_LOOKUP_CONCURRENCY,
-        memberCandidates.length,
-      );
-      await Promise.all(Array.from({ length: workerCount }, () => resolveNextMember()));
-      for (const resolved of resolvedMembers) {
-        if (!resolved) continue;
-        const memberKey = this.policyElementKey(resolved.type, resolved.name);
-        if (seen.has(memberKey)) continue;
-        seen.add(memberKey);
-        result.push(resolved);
-      }
+      const candidates = this.appendEnsemblesAndCollectMembers(ensembles, result, seen);
+      const resolvedMembers = await this.resolvePolicyMembers(candidates, indexOptions);
+      this.appendResolvedPolicyMembers(resolvedMembers, result, seen);
     } catch (error) {
       logger.warn('Failed to gather active ensembles for policy evaluation', { error });
     }
+  }
 
-    return result;
+  private appendEnsemblesAndCollectMembers(
+    ensembles: Awaited<ReturnType<EnsembleManager['getActiveEnsembles']>>,
+    result: PolicyElement[],
+    seen: Set<string>,
+  ): PolicyMemberCandidate[] {
+    const candidates: PolicyMemberCandidate[] = [];
+    const queuedMemberKeys = new Set<string>();
+
+    for (const ensemble of ensembles) {
+      seen.add(this.policyElementKey('ensemble', ensemble.metadata.name));
+      result.push({
+        type: 'ensemble',
+        name: ensemble.metadata.name,
+        metadata: ensemble.metadata as unknown as Record<string, unknown>,
+      });
+
+      const members = (ensemble.metadata as unknown as Record<string, unknown>)?.elements as
+        Array<{ element_name: string; element_type: string }> | undefined;
+      if (!Array.isArray(members)) continue;
+
+      for (const member of members) {
+        const normalizedType = this.normalizeElementType(member.element_type);
+        const normalizedName = this.normalizeLookupValue(member.element_name);
+        if (normalizedType === '' || normalizedName === '') continue;
+
+        const key = this.policyElementKey(normalizedType, normalizedName);
+        if (seen.has(key) || queuedMemberKeys.has(key)) continue;
+        queuedMemberKeys.add(key);
+        candidates.push({ type: normalizedType, name: normalizedName, key });
+      }
+    }
+
+    return candidates;
+  }
+
+  private async resolvePolicyMembers(
+    candidates: PolicyMemberCandidate[],
+    indexOptions: PolicyIndexOptions,
+  ): Promise<Array<PolicyElement | undefined>> {
+    const resolvedMembers = new Array<PolicyElement | undefined>(candidates.length);
+    const indexedManagers: IndexedPolicyManagers = new Map();
+    const memberLookups = new Map<string, Promise<PolicyMemberElement | undefined>>();
+    let nextCandidateIndex = 0;
+
+    const resolveNextMember = async (): Promise<void> => {
+      // The increment is synchronous before the first await, so each worker
+      // claims a unique candidate while preserving deterministic result slots.
+      while (nextCandidateIndex < candidates.length) {
+        const candidateIndex = nextCandidateIndex++;
+        const candidate = candidates[candidateIndex];
+        try {
+          const found = await this.findPolicyMember(
+            candidate,
+            indexedManagers,
+            memberLookups,
+            indexOptions,
+          );
+          if (found?.metadata?.['gatekeeper']) {
+            resolvedMembers[candidateIndex] = {
+              type: this.toPolicyElementType(candidate.type),
+              name: candidate.name,
+              metadata: found.metadata,
+            };
+          }
+        } catch {
+          // Non-fatal: skip member if element type lookup fails.
+        }
+      }
+    };
+
+    const workerCount = Math.min(ACTIVE_POLICY_MEMBER_LOOKUP_CONCURRENCY, candidates.length);
+    await Promise.all(Array.from({ length: workerCount }, () => resolveNextMember()));
+    return resolvedMembers;
+  }
+
+  private appendResolvedPolicyMembers(
+    resolvedMembers: Array<PolicyElement | undefined>,
+    result: PolicyElement[],
+    seen: Set<string>,
+  ): void {
+    for (const resolved of resolvedMembers) {
+      if (!resolved) continue;
+      const key = this.policyElementKey(resolved.type, resolved.name);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      result.push(resolved);
+    }
+  }
+
+  private findPolicyMember(
+    candidate: PolicyMemberCandidate,
+    indexedManagers: IndexedPolicyManagers,
+    memberLookups: Map<string, Promise<PolicyMemberElement | undefined>>,
+    indexOptions: PolicyIndexOptions,
+  ): Promise<PolicyMemberElement | undefined> {
+    const existing = memberLookups.get(candidate.key);
+    if (existing) return existing;
+
+    const lookup = this.getIndexedPolicyManager(
+      candidate.type,
+      indexedManagers,
+      indexOptions,
+    ).then(async (manager) => manager
+      ? manager.findByName(candidate.name) as Promise<PolicyMemberElement | undefined>
+      : undefined);
+    memberLookups.set(candidate.key, lookup);
+    return lookup;
+  }
+
+  private getIndexedPolicyManager(
+    type: string,
+    indexedManagers: IndexedPolicyManagers,
+    indexOptions: PolicyIndexOptions,
+  ): Promise<BaseElementManager<any> | undefined> {
+    const normalizedType = this.normalizeElementType(type);
+    const existing = indexedManagers.get(normalizedType);
+    if (existing) return existing;
+
+    const manager = this.getManagerForType(normalizedType);
+    const indexed = manager
+      ? manager.refreshIndex(indexOptions).then(() => manager)
+      : Promise.resolve(undefined);
+    indexedManagers.set(normalizedType, indexed);
+    return indexed;
   }
 
   async getPolicyElementsForReport(
@@ -650,28 +697,13 @@ export class ElementCRUDHandler {
 
     if (this.activationStore?.isEnabled()) {
       const persistedStates = await this.activationStore.listPersistedActivationStates(sessionId);
-      const indexedManagers = new Map<string, Promise<BaseElementManager<any> | undefined>>();
-      const persistedLookups = new Map<string, Promise<{ type: string; name: string; metadata: Record<string, unknown> } | null>>();
-
-      const getIndexedManager = (type: string): Promise<BaseElementManager<any> | undefined> => {
-        const normalizedType = this.normalizeElementType(type);
-        const existing = indexedManagers.get(normalizedType);
-        if (existing) {
-          return existing;
-        }
-
-        const manager = this.getManagerForType(normalizedType);
-        const indexed = manager
-          ? manager.refreshIndex(indexOptions).then(() => manager)
-          : Promise.resolve(undefined);
-        indexedManagers.set(normalizedType, indexed);
-        return indexed;
-      };
+      const indexedManagers: IndexedPolicyManagers = new Map();
+      const persistedLookups = new Map<string, Promise<PersistedPolicyElement | null>>();
 
       const findPersistedElement = (
         type: string,
         activation: PersistedActivation,
-      ): Promise<{ type: string; name: string; metadata: Record<string, unknown> } | null> => {
+      ): Promise<PersistedPolicyElement | null> => {
         const normalizedType = this.normalizeElementType(type);
         const normalizedName = this.normalizeLookupValue(activation.name);
         const normalizedFilename = this.normalizeLookupValue(activation.filename);
@@ -681,7 +713,11 @@ export class ElementCRUDHandler {
           return existing;
         }
 
-        const lookup = getIndexedManager(normalizedType).then(async (manager) => {
+        const lookup = this.getIndexedPolicyManager(
+          normalizedType,
+          indexedManagers,
+          indexOptions,
+        ).then(async (manager) => {
           if (!manager) return null;
           let found = normalizedFilename !== ''
             ? await manager.findByFilename(normalizedFilename) as PolicyMemberElement | undefined

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -585,7 +585,10 @@ export class ElementCRUDHandler {
     return result;
   }
 
-  async getPolicyElementsForReport(sessionId?: string): Promise<Array<{
+  async getPolicyElementsForReport(
+    sessionId?: string,
+    options: { allowCoalescing?: boolean } = {},
+  ): Promise<Array<{
     type: string;
     name: string;
     metadata: Record<string, unknown>;
@@ -623,9 +626,12 @@ export class ElementCRUDHandler {
 
     const currentSessionId = this.activationStore?.getSessionId();
     const includeCurrentSession = !sessionId || !currentSessionId || currentSessionId === sessionId;
+    const indexOptions = options.allowCoalescing === false
+      ? { freshAfterInFlight: true }
+      : {};
 
     if (includeCurrentSession) {
-      for (const activeElement of await this.getActiveElementsForPolicy()) {
+      for (const activeElement of await this.getActiveElementsForPolicy(options)) {
         addElement(activeElement, currentSessionId ? [currentSessionId] : []);
       }
     }
@@ -644,7 +650,7 @@ export class ElementCRUDHandler {
 
         const manager = this.getManagerForType(normalizedType);
         const indexed = manager
-          ? manager.refreshIndex().then(() => manager)
+          ? manager.refreshIndex(indexOptions).then(() => manager)
           : Promise.resolve(undefined);
         indexedManagers.set(normalizedType, indexed);
         return indexed;

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -656,11 +656,11 @@ export class ElementCRUDHandler {
 
         const lookup = getIndexedManager(normalizedType).then(async (manager) => {
           if (!manager) return null;
-          let found = normalizedName !== ''
-            ? await manager.findByName(normalizedName) as PolicyMemberElement | undefined
+          let found = normalizedFilename !== ''
+            ? await manager.findByFilename(normalizedFilename) as PolicyMemberElement | undefined
             : undefined;
-          if (!found && normalizedFilename !== '') {
-            found = await manager.findByFilename(normalizedFilename) as PolicyMemberElement | undefined;
+          if (!found && normalizedName !== '') {
+            found = await manager.findByName(normalizedName) as PolicyMemberElement | undefined;
           }
 
           if (!found?.metadata || !this.hasGatekeeperPolicy(found.metadata)) {

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -74,6 +74,8 @@ type PolicyMemberElement = {
   metadata?: Record<string, unknown>;
 };
 
+const ACTIVE_POLICY_MEMBER_LOOKUP_CONCURRENCY = 8;
+
 export class ElementCRUDHandler {
   private readonly strategies: Map<string, ElementActivationStrategy>;
   private activePolicySnapshotGeneration = 0;
@@ -501,6 +503,8 @@ export class ElementCRUDHandler {
     try {
       // Active ensembles (async)
       const ensembles = await this.ensembleManager.getActiveEnsembles();
+      const memberCandidates: Array<{ type: string; name: string; key: string }> = [];
+      const queuedMemberKeys = new Set<string>();
       for (const e of ensembles) {
         const ensembleKey = this.policyElementKey('ensemble', e.metadata.name);
         seen.add(ensembleKey);
@@ -521,21 +525,47 @@ export class ElementCRUDHandler {
 
             const memberKey = this.policyElementKey(normalizedType, normalizedName);
             if (seen.has(memberKey)) continue; // Already active individually
-            try {
-              const found = await findMember(normalizedType, normalizedName, memberKey);
-              if (found?.metadata && found.metadata['gatekeeper']) {
-                seen.add(memberKey);
-                result.push({
-                  type: this.toPolicyElementType(normalizedType),
-                  name: normalizedName,
-                  metadata: found.metadata,
-                });
-              }
-            } catch {
-              // Non-fatal: skip member if element type lookup fails
-            }
+            if (queuedMemberKeys.has(memberKey)) continue;
+            queuedMemberKeys.add(memberKey);
+            memberCandidates.push({ type: normalizedType, name: normalizedName, key: memberKey });
           }
         }
+      }
+
+      // Resolve uncached member files concurrently, but cap the work so a
+      // large ensemble cannot create an unbounded I/O burst. Store results by
+      // candidate index to preserve deterministic policy ordering.
+      const resolvedMembers = new Array<PolicyElement | undefined>(memberCandidates.length);
+      let nextCandidateIndex = 0;
+      const resolveNextMember = async (): Promise<void> => {
+        while (nextCandidateIndex < memberCandidates.length) {
+          const candidateIndex = nextCandidateIndex++;
+          const candidate = memberCandidates[candidateIndex];
+          try {
+            const found = await findMember(candidate.type, candidate.name, candidate.key);
+            if (found?.metadata && found.metadata['gatekeeper']) {
+              resolvedMembers[candidateIndex] = {
+                type: this.toPolicyElementType(candidate.type),
+                name: candidate.name,
+                metadata: found.metadata,
+              };
+            }
+          } catch {
+            // Non-fatal: skip member if element type lookup fails
+          }
+        }
+      };
+      const workerCount = Math.min(
+        ACTIVE_POLICY_MEMBER_LOOKUP_CONCURRENCY,
+        memberCandidates.length,
+      );
+      await Promise.all(Array.from({ length: workerCount }, () => resolveNextMember()));
+      for (const resolved of resolvedMembers) {
+        if (!resolved) continue;
+        const memberKey = this.policyElementKey(resolved.type, resolved.name);
+        if (seen.has(memberKey)) continue;
+        seen.add(memberKey);
+        result.push(resolved);
       }
     } catch (error) {
       logger.warn('Failed to gather active ensembles for policy evaluation', { error });

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -68,6 +68,8 @@ type PolicyElement = {
   type: string;
   name: string;
   metadata: Record<string, unknown>;
+  /** Stable storage identity used only to avoid unsafe display-name deduplication. */
+  identity?: string;
 };
 
 type PolicyMemberElement = {
@@ -501,10 +503,14 @@ export class ElementCRUDHandler {
       for (const agent of agents) {
         const key = this.policyElementKey('agent', agent.metadata.name);
         seen.add(key);
+        const filename = (agent as typeof agent & { filename?: unknown }).filename;
         result.push({
           type: 'agent',
           name: agent.metadata.name,
           metadata: agent.metadata as unknown as Record<string, unknown>,
+          ...(typeof filename === 'string' && filename.trim() !== ''
+            ? { identity: filename }
+            : {}),
         });
       }
     } catch (error) {
@@ -602,14 +608,14 @@ export class ElementCRUDHandler {
     }>();
 
     const addElement = (
-      element: { type: string; name: string; metadata: Record<string, unknown> },
+      element: PolicyElement,
       sessionIds: string[] = [],
     ): void => {
       if (!this.hasGatekeeperPolicy(element.metadata)) {
         return;
       }
 
-      const key = `${element.type}:${element.name}`;
+      const key = `${element.type}:${element.identity ?? element.name}`;
       const existing = merged.get(key);
       if (existing) {
         sessionIds.forEach(id => existing.sessionIds.add(id));

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -76,6 +76,12 @@ type PolicyMemberElement = {
   metadata?: Record<string, unknown>;
 };
 
+type DeadlockReliefElement = {
+  type: string;
+  name: string;
+  deactivationIdentifier?: string;
+};
+
 const ACTIVE_POLICY_MEMBER_LOOKUP_CONCURRENCY = 8;
 
 export class ElementCRUDHandler {
@@ -726,6 +732,7 @@ export class ElementCRUDHandler {
     snapshotFile?: string;
   }> {
     const activeElements = await this.collectActiveElementsForDeadlockRelief();
+    const activeBeforeReset = activeElements.map(({ type, name }) => ({ type, name }));
     const activePolicyElements = await this.getActiveElementsForPolicy();
     const sandboxingElement = findConfirmDenyingElement(activePolicyElements);
     const advisoryElements = findConfirmAdvisoryElements(activePolicyElements);
@@ -744,8 +751,8 @@ export class ElementCRUDHandler {
       }
 
       try {
-        await strategy.deactivate(element.name);
-        deactivated.push(element);
+        await strategy.deactivate(element.deactivationIdentifier ?? element.name);
+        deactivated.push({ type: element.type, name: element.name });
       } catch (error) {
         failed.push({
           type: element.type,
@@ -758,7 +765,7 @@ export class ElementCRUDHandler {
     const persistedStateCleared = Boolean(this.activationStore?.isEnabled());
     const snapshotFile = await this.writeDeadlockReliefSnapshot({
       sessionId: this.activationStore?.getSessionId(),
-      activeBeforeReset: activeElements,
+      activeBeforeReset,
       deactivated,
       failed,
       likelyDeadlockCause: {
@@ -781,7 +788,7 @@ export class ElementCRUDHandler {
       details: `Deadlock relief deactivated ${deactivated.length} element(s)${failureSummary}`,
       additionalData: {
         sessionId: this.activationStore?.getSessionId(),
-        activeBeforeReset: activeElements,
+        activeBeforeReset,
         deactivated,
         failed,
         persistedStateCleared,
@@ -797,7 +804,7 @@ export class ElementCRUDHandler {
       ...(this.activationStore?.getSessionId()
         ? { sessionId: this.activationStore.getSessionId() }
         : {}),
-      activeBeforeReset: activeElements,
+      activeBeforeReset,
       deactivated,
       failed,
       persistedStateCleared,
@@ -809,8 +816,8 @@ export class ElementCRUDHandler {
     };
   }
 
-  private async collectActiveElementsForDeadlockRelief(): Promise<Array<{ type: string; name: string }>> {
-    const activeElements: Array<{ type: string; name: string }> = [];
+  private async collectActiveElementsForDeadlockRelief(): Promise<DeadlockReliefElement[]> {
+    const activeElements: DeadlockReliefElement[] = [];
 
     const activePersonas = this.personaManager.getActivePersonas();
     activeElements.push(...activePersonas.map((persona) => ({
@@ -825,10 +832,16 @@ export class ElementCRUDHandler {
     })));
 
     const activeAgents = await this.agentManager.getActiveAgents();
-    activeElements.push(...activeAgents.map((agent) => ({
-      type: ElementType.AGENT,
-      name: agent.metadata.name,
-    })));
+    activeElements.push(...activeAgents.map((agent) => {
+      const filename = (agent as typeof agent & { filename?: unknown }).filename;
+      return {
+        type: ElementType.AGENT,
+        name: agent.metadata.name,
+        ...(typeof filename === 'string' && filename.trim() !== ''
+          ? { deactivationIdentifier: filename }
+          : {}),
+      };
+    }));
 
     const activeMemories = await this.memoryManager.getActiveMemories();
     activeElements.push(...activeMemories.map((memory) => ({
@@ -844,7 +857,7 @@ export class ElementCRUDHandler {
 
     const seen = new Set<string>();
     return activeElements.filter((element) => {
-      const key = `${element.type}:${element.name}`;
+      const key = `${element.type}:${element.deactivationIdentifier ?? element.name}`;
       if (seen.has(key)) {
         return false;
       }

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -621,46 +621,58 @@ export class ElementCRUDHandler {
 
     if (this.activationStore?.isEnabled()) {
       const persistedStates = await this.activationStore.listPersistedActivationStates(sessionId);
-      const catalogs = new Map<string, Array<{ metadata?: Record<string, unknown>; filename?: string }>>();
+      const indexedManagers = new Map<string, Promise<BaseElementManager<any> | undefined>>();
+      const persistedLookups = new Map<string, Promise<{ type: string; name: string; metadata: Record<string, unknown> } | null>>();
 
-      const getCatalog = async (type: string) => {
+      const getIndexedManager = (type: string): Promise<BaseElementManager<any> | undefined> => {
         const normalizedType = this.normalizeElementType(type);
-        if (!catalogs.has(normalizedType)) {
-          catalogs.set(
-            normalizedType,
-            (await this.getElements(normalizedType)) as Array<{ metadata?: Record<string, unknown>; filename?: string }>,
-          );
+        const existing = indexedManagers.get(normalizedType);
+        if (existing) {
+          return existing;
         }
-        return catalogs.get(normalizedType) ?? [];
+
+        const manager = this.getManagerForType(normalizedType);
+        const indexed = manager
+          ? manager.refreshIndex().then(() => manager)
+          : Promise.resolve(undefined);
+        indexedManagers.set(normalizedType, indexed);
+        return indexed;
       };
 
-      const findPersistedElement = async (
+      const findPersistedElement = (
         type: string,
         activation: PersistedActivation,
       ): Promise<{ type: string; name: string; metadata: Record<string, unknown> } | null> => {
-        const catalog = await getCatalog(type);
+        const normalizedType = this.normalizeElementType(type);
         const normalizedName = this.normalizeLookupValue(activation.name);
         const normalizedFilename = this.normalizeLookupValue(activation.filename);
-
-        const found = catalog.find((element) => {
-          const metadata = element.metadata ?? {};
-          const elementName = this.normalizeLookupValue(metadata['name']);
-          const elementFilename = this.normalizeLookupValue(
-            element.filename ?? metadata['filename'] ?? metadata['sourceFile'],
-          );
-
-          return elementName === normalizedName || (normalizedFilename !== '' && elementFilename === normalizedFilename);
-        });
-
-        if (!found?.metadata || !this.hasGatekeeperPolicy(found.metadata)) {
-          return null;
+        const lookupKey = `${normalizedType}:${normalizedName}:${normalizedFilename}`;
+        const existing = persistedLookups.get(lookupKey);
+        if (existing) {
+          return existing;
         }
 
-        return {
-          type: this.toPolicyElementType(type),
-          name: (found.metadata['name'] as string) ?? activation.name,
-          metadata: found.metadata,
-        };
+        const lookup = getIndexedManager(normalizedType).then(async (manager) => {
+          if (!manager) return null;
+          let found = normalizedName !== ''
+            ? await manager.findByName(normalizedName) as PolicyMemberElement | undefined
+            : undefined;
+          if (!found && normalizedFilename !== '') {
+            found = await manager.findByName(normalizedFilename) as PolicyMemberElement | undefined;
+          }
+
+          if (!found?.metadata || !this.hasGatekeeperPolicy(found.metadata)) {
+            return null;
+          }
+
+          return {
+            type: this.toPolicyElementType(normalizedType),
+            name: (found.metadata['name'] as string) ?? activation.name,
+            metadata: found.metadata,
+          };
+        });
+        persistedLookups.set(lookupKey, lookup);
+        return lookup;
       };
 
       for (const state of persistedStates) {

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -79,11 +79,7 @@ type PolicyMemberElement = {
 type PolicyIndexOptions = { freshAfterInFlight?: boolean };
 type IndexedPolicyManagers = Map<string, Promise<BaseElementManager<any> | undefined>>;
 type PolicyMemberCandidate = { type: string; name: string; key: string };
-type PersistedPolicyElement = {
-  type: string;
-  name: string;
-  metadata: Record<string, unknown>;
-};
+type PersistedPolicyElement = PolicyElement;
 
 type DeadlockReliefElement = {
   type: string;
@@ -732,6 +728,7 @@ export class ElementCRUDHandler {
             type: this.toPolicyElementType(normalizedType),
             name: (found.metadata['name'] as string) ?? activation.name,
             metadata: found.metadata,
+            ...(normalizedFilename !== '' ? { identity: normalizedFilename } : {}),
           };
         });
         persistedLookups.set(lookupKey, lookup);
@@ -940,8 +937,8 @@ export class ElementCRUDHandler {
 
   private async mergePersistedPolicyState(
     state: PersistedActivationStateSnapshot,
-    addElement: (element: { type: string; name: string; metadata: Record<string, unknown> }, sessionIds?: string[]) => void,
-    findPersistedElement: (type: string, activation: PersistedActivation) => Promise<{ type: string; name: string; metadata: Record<string, unknown> } | null>,
+    addElement: (element: PolicyElement, sessionIds?: string[]) => void,
+    findPersistedElement: (type: string, activation: PersistedActivation) => Promise<PersistedPolicyElement | null>,
   ): Promise<void> {
     const pending: Promise<void>[] = [];
 
@@ -995,21 +992,22 @@ export class ElementCRUDHandler {
         };
       }
 
-      const filename = this.activationStore
-        ? await this.getStableActivationFilename(normalizedType, name)
-        : undefined;
       const result = await strategy.deactivate(name);
       this.invalidateActivePolicySnapshot();
 
       // Issue #598: Persist deactivation state for session restore
       if (this.activationStore) {
+        // Agent deactivation returns the exact stable identity selected by its
+        // freshness scan. Other element types resolve from their live cache.
+        const filename = result.stableIdentity
+          ?? await this.getStableActivationFilename(normalizedType, name);
         this.activationStore.recordDeactivation(normalizedType, name, filename);
       }
 
       // Issue #762: Export policies to bridge after deactivation
       this.policyExportService?.exportPolicies().catch(() => {});
 
-      return result;
+      return { content: result.content };
     } catch (error) {
       // Re-throw ElementNotFoundError to propagate to MCP-AQL layer
       // This ensures operations return success=false instead of success=true with error text

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -64,8 +64,19 @@ import {
   getGatekeeperDiagnostics,
 } from './mcp-aql/policies/ElementPolicies.js';
 
+type PolicyElement = {
+  type: string;
+  name: string;
+  metadata: Record<string, unknown>;
+};
+
+type PolicyMemberElement = {
+  metadata?: Record<string, unknown>;
+};
+
 export class ElementCRUDHandler {
   private readonly strategies: Map<string, ElementActivationStrategy>;
+  private activePolicySnapshotInFlight?: Promise<PolicyElement[]>;
 
   constructor(
     private readonly skillManager: SkillManager,
@@ -173,6 +184,10 @@ export class ElementCRUDHandler {
       default:
         return normalizedType;
     }
+  }
+
+  private policyElementKey(type: string, name: string): string {
+    return `${this.toPolicyElementType(this.normalizeElementType(type))}:${this.normalizeLookupValue(name)}`;
   }
 
   /**
@@ -363,15 +378,72 @@ export class ElementCRUDHandler {
    *
    * Issue #452: Provides active element context for enforce() policy checks.
    */
-  async getActiveElementsForPolicy(): Promise<Array<{ type: string; name: string; metadata: Record<string, unknown> }>> {
-    const result: Array<{ type: string; name: string; metadata: Record<string, unknown> }> = [];
+  async getActiveElementsForPolicy(): Promise<PolicyElement[]> {
+    if (this.activePolicySnapshotInFlight) {
+      return this.activePolicySnapshotInFlight;
+    }
+
+    const snapshot = this.collectActiveElementsForPolicy();
+    this.activePolicySnapshotInFlight = snapshot;
+
+    try {
+      return await snapshot;
+    } finally {
+      if (this.activePolicySnapshotInFlight === snapshot) {
+        this.activePolicySnapshotInFlight = undefined;
+      }
+    }
+  }
+
+  private async collectActiveElementsForPolicy(): Promise<PolicyElement[]> {
+    await this.ensureInitialized();
+
+    const result: PolicyElement[] = [];
     const seen = new Set<string>();
+    const indexedManagers = new Map<string, Promise<BaseElementManager<any> | undefined>>();
+    const memberLookups = new Map<string, Promise<PolicyMemberElement | undefined>>();
+
+    // Prime each manager's lightweight metadata index once, then resolve only
+    // the referenced members. This prevents findByName() from falling back to a
+    // full list on a miss while avoiding list() lifecycle/status side effects.
+    const getIndexedManager = (type: string): Promise<BaseElementManager<any> | undefined> => {
+      const normalizedType = this.normalizeElementType(type);
+      const existing = indexedManagers.get(normalizedType);
+      if (existing) {
+        return existing;
+      }
+
+      const manager = this.getManagerForType(normalizedType);
+      const indexed = manager
+        ? manager.listSummaries().then(() => manager)
+        : Promise.resolve(undefined);
+      indexedManagers.set(normalizedType, indexed);
+      return indexed;
+    };
+
+    const findMember = (
+      type: string,
+      name: string,
+      key: string,
+    ): Promise<PolicyMemberElement | undefined> => {
+      const existing = memberLookups.get(key);
+      if (existing) {
+        return existing;
+      }
+
+      const lookup = getIndexedManager(type).then(async (manager) => {
+        if (!manager) return undefined;
+        return manager.findByName(name) as Promise<PolicyMemberElement | undefined>;
+      });
+      memberLookups.set(key, lookup);
+      return lookup;
+    };
 
     try {
       // Active personas (sync)
       const personas = this.personaManager.getActivePersonas();
       for (const p of personas) {
-        const key = `persona:${p.metadata.name}`;
+        const key = this.policyElementKey('persona', p.metadata.name);
         seen.add(key);
         result.push({
           type: 'persona',
@@ -387,7 +459,7 @@ export class ElementCRUDHandler {
       // Active skills (async)
       const skills = await this.skillManager.getActiveSkills();
       for (const s of skills) {
-        const key = `skill:${s.metadata.name}`;
+        const key = this.policyElementKey('skill', s.metadata.name);
         seen.add(key);
         result.push({
           type: 'skill',
@@ -403,7 +475,7 @@ export class ElementCRUDHandler {
       // Active agents (async)
       const agents = await this.agentManager.getActiveAgents();
       for (const agent of agents) {
-        const key = `agent:${agent.metadata.name}`;
+        const key = this.policyElementKey('agent', agent.metadata.name);
         seen.add(key);
         result.push({
           type: 'agent',
@@ -419,7 +491,7 @@ export class ElementCRUDHandler {
       // Active ensembles (async)
       const ensembles = await this.ensembleManager.getActiveEnsembles();
       for (const e of ensembles) {
-        const ensembleKey = `ensemble:${e.metadata.name}`;
+        const ensembleKey = this.policyElementKey('ensemble', e.metadata.name);
         seen.add(ensembleKey);
         result.push({
           type: 'ensemble',
@@ -432,19 +504,20 @@ export class ElementCRUDHandler {
           Array<{ element_name: string; element_type: string }> | undefined;
         if (Array.isArray(members)) {
           for (const member of members) {
-            const memberKey = `${member.element_type}:${member.element_name}`;
+            const normalizedType = this.normalizeElementType(member.element_type);
+            const normalizedName = this.normalizeLookupValue(member.element_name);
+            if (normalizedType === '' || normalizedName === '') continue;
+
+            const memberKey = this.policyElementKey(normalizedType, normalizedName);
             if (seen.has(memberKey)) continue; // Already active individually
             try {
-              const memberElements = await this.getElements(member.element_type);
-              const found = (memberElements as Array<{ metadata: Record<string, unknown> }>).find(
-                el => (el?.metadata as Record<string, unknown>)?.name === member.element_name
-              );
-              if (found?.metadata && (found.metadata as Record<string, unknown>)?.gatekeeper) {
+              const found = await findMember(normalizedType, normalizedName, memberKey);
+              if (found?.metadata && found.metadata['gatekeeper']) {
                 seen.add(memberKey);
                 result.push({
-                  type: member.element_type,
-                  name: member.element_name,
-                  metadata: found.metadata as Record<string, unknown>,
+                  type: this.toPolicyElementType(normalizedType),
+                  name: normalizedName,
+                  metadata: found.metadata,
                 });
               }
             } catch {

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -181,6 +181,8 @@ export class ElementCRUDHandler {
         return 'persona';
       case 'skills':
         return 'skill';
+      case 'templates':
+        return 'template';
       case 'agents':
         return 'agent';
       case 'memories':
@@ -658,7 +660,7 @@ export class ElementCRUDHandler {
             ? await manager.findByName(normalizedName) as PolicyMemberElement | undefined
             : undefined;
           if (!found && normalizedFilename !== '') {
-            found = await manager.findByName(normalizedFilename) as PolicyMemberElement | undefined;
+            found = await manager.findByFilename(normalizedFilename) as PolicyMemberElement | undefined;
           }
 
           if (!found?.metadata || !this.hasGatekeeperPolicy(found.metadata)) {

--- a/src/handlers/mcp-aql/MCPAQLHandler.ts
+++ b/src/handlers/mcp-aql/MCPAQLHandler.ts
@@ -733,7 +733,7 @@ export class MCPAQLHandler {
     try {
       const rawElements = sessionId
         ? await this.handlers.elementCRUD.getPolicyElementsForReport(sessionId)
-        : await this.handlers.elementCRUD.getActiveElementsForPolicy();
+        : await this.handlers.elementCRUD.getActiveElementsForPolicy({ allowCoalescing: false });
       const activeElements: ActiveElement[] = rawElements.map((el) => ({
         type: el.type,
         name: el.name,

--- a/src/handlers/mcp-aql/MCPAQLHandler.ts
+++ b/src/handlers/mcp-aql/MCPAQLHandler.ts
@@ -732,7 +732,10 @@ export class MCPAQLHandler {
   private async getActiveElements(sessionId?: string): Promise<ActiveElement[]> {
     try {
       const rawElements = sessionId
-        ? await this.handlers.elementCRUD.getPolicyElementsForReport(sessionId)
+        ? await this.handlers.elementCRUD.getPolicyElementsForReport(
+          sessionId,
+          { allowCoalescing: false },
+        )
         : await this.handlers.elementCRUD.getActiveElementsForPolicy({ allowCoalescing: false });
       const activeElements: ActiveElement[] = rawElements.map((el) => ({
         type: el.type,

--- a/src/handlers/strategies/AgentActivationStrategy.ts
+++ b/src/handlers/strategies/AgentActivationStrategy.ts
@@ -228,7 +228,10 @@ export class AgentActivationStrategy extends BaseActivationStrategy implements E
       this.throwNotFoundError(name, 'Agent');
     }
 
-    return this.createSuccessResponse(result.message);
+    return {
+      ...this.createSuccessResponse(result.message),
+      ...(result.filename ? { stableIdentity: result.filename } : {}),
+    };
   }
 
   /**

--- a/src/handlers/strategies/ElementActivationStrategy.ts
+++ b/src/handlers/strategies/ElementActivationStrategy.ts
@@ -14,6 +14,8 @@ export interface MCPResponse {
     type: string;
     text: string;
   }>;
+  /** Internal stable identity consumed by ElementCRUDHandler before response return. */
+  stableIdentity?: string;
 }
 
 /**

--- a/src/services/ActivationStore.ts
+++ b/src/services/ActivationStore.ts
@@ -241,10 +241,23 @@ export class ActivationStore {
     // Deduplicate. Upgrade legacy name-only records when a stable filename is
     // now available so future restarts survive external metadata renames.
     const existing = this.state.activations[type]!;
-    const activeRecord = existing.find(a => a.name === normalizedName);
+    let activeRecord = normalizedFilename
+      ? existing.find(a => a.filename === normalizedFilename)
+      : undefined;
+    activeRecord ??= existing.find(a =>
+      a.name === normalizedName && (!normalizedFilename || !a.filename)
+    );
     if (activeRecord) {
+      let changed = false;
+      if (activeRecord.name !== normalizedName) {
+        activeRecord.name = normalizedName;
+        changed = true;
+      }
       if (normalizedFilename && activeRecord.filename !== normalizedFilename) {
         activeRecord.filename = normalizedFilename;
+        changed = true;
+      }
+      if (changed) {
         this.persistAsync();
       }
       return;
@@ -262,19 +275,26 @@ export class ActivationStore {
   /**
    * Record an element deactivation. Fire-and-forget persist.
    */
-  recordDeactivation(elementType: string, name: string): void {
+  recordDeactivation(elementType: string, name: string, filename?: string): void {
     if (!this.enabled) return;
 
     const type = normalizeType(elementType);
     if (!ACTIVATABLE_TYPES.has(type)) return;
     const normalizedName = normalizeActivationIdentifier(name);
     if (!normalizedName) return;
+    const normalizedFilename = typeof filename === 'string'
+      ? normalizeActivationIdentifier(filename)
+      : undefined;
 
     const activations = this.state.activations[type];
     if (!activations) return;
 
     const initialLength = activations.length;
-    this.state.activations[type] = activations.filter(a => a.name !== normalizedName);
+    this.state.activations[type] = activations.filter(a =>
+      a.name !== normalizedName
+      && a.filename !== normalizedName
+      && (!normalizedFilename || a.filename !== normalizedFilename)
+    );
 
     // Only persist if something actually changed
     if (this.state.activations[type]!.length !== initialLength) {

--- a/src/services/ActivationStore.ts
+++ b/src/services/ActivationStore.ts
@@ -37,7 +37,7 @@ import {
 export interface PersistedActivation {
   /** Element name (human-readable, used for all types) */
   name: string;
-  /** For personas only: the filename key used by PersonaManager */
+  /** Stable filename for element types whose display names may change */
   filename?: string;
   /** ISO-8601 timestamp of when activation was persisted */
   activatedAt: string;
@@ -238,10 +238,17 @@ export class ActivationStore {
       this.state.activations[type] = [];
     }
 
-    // Deduplicate — don't add if already present
+    // Deduplicate. Upgrade legacy name-only records when a stable filename is
+    // now available so future restarts survive external metadata renames.
     const existing = this.state.activations[type]!;
-    const alreadyActive = existing.some(a => a.name === normalizedName);
-    if (alreadyActive) return;
+    const activeRecord = existing.find(a => a.name === normalizedName);
+    if (activeRecord) {
+      if (normalizedFilename && activeRecord.filename !== normalizedFilename) {
+        activeRecord.filename = normalizedFilename;
+        this.persistAsync();
+      }
+      return;
+    }
 
     existing.push({
       name: normalizedName,

--- a/src/services/ActivationStore.ts
+++ b/src/services/ActivationStore.ts
@@ -304,10 +304,11 @@ export class ActivationStore {
   }
 
   /**
-   * Remove a specific activation by name (used during restore to prune stale entries).
+   * Remove a specific activation by stable identity when available.
+   * Used during restore to prune stale entries.
    */
-  removeStaleActivation(elementType: string, name: string): void {
-    this.recordDeactivation(elementType, name);
+  removeStaleActivation(elementType: string, name: string, filename?: string): void {
+    this.recordDeactivation(elementType, name, filename);
   }
 
   /**

--- a/src/services/ActivationStore.ts
+++ b/src/services/ActivationStore.ts
@@ -290,11 +290,12 @@ export class ActivationStore {
     if (!activations) return;
 
     const initialLength = activations.length;
-    this.state.activations[type] = activations.filter(a =>
-      a.name !== normalizedName
-      && a.filename !== normalizedName
-      && (!normalizedFilename || a.filename !== normalizedFilename)
-    );
+    this.state.activations[type] = activations.filter(a => {
+      const shouldRemove = normalizedFilename
+        ? a.filename === normalizedFilename || (!a.filename && a.name === normalizedName)
+        : a.name === normalizedName || a.filename === normalizedName;
+      return !shouldRemove;
+    });
 
     // Only persist if something actually changed
     if (this.state.activations[type]!.length !== initialLength) {

--- a/src/services/PolicyExportService.ts
+++ b/src/services/PolicyExportService.ts
@@ -34,11 +34,13 @@ interface ElementPolicyEntry {
 }
 
 export class PolicyExportService {
-  private deps: PolicyExportDeps;
+  private exportInFlight?: Promise<void>;
+  private exportQueued = false;
 
-  constructor(deps: PolicyExportDeps) {
-    this.deps = deps;
-  }
+  constructor(
+    private readonly deps: PolicyExportDeps,
+    private readonly policyDir: string = POLICY_DIR,
+  ) {}
 
   /**
    * Export current policy state to the bridge imports folder.
@@ -48,14 +50,42 @@ export class PolicyExportService {
    *
    * Skips silently if the bridge imports directory doesn't exist.
    */
-  async exportPolicies(): Promise<void> {
+  exportPolicies(): Promise<void> {
     if (!env.DOLLHOUSE_POLICY_EXPORT_ENABLED) {
-      return;
+      return Promise.resolve();
     }
 
+    this.exportQueued = true;
+    if (!this.exportInFlight) {
+      const drain = this.drainExports();
+      const inFlight = drain.finally(() => {
+        if (this.exportInFlight === inFlight) {
+          this.exportInFlight = undefined;
+        }
+
+        // A request can arrive as the drain promise settles. Preserve it as a
+        // trailing export instead of silently losing the newest policy state.
+        if (this.exportQueued) {
+          void this.exportPolicies();
+        }
+      });
+      this.exportInFlight = inFlight;
+    }
+
+    return this.exportInFlight;
+  }
+
+  private async drainExports(): Promise<void> {
+    while (this.exportQueued) {
+      this.exportQueued = false;
+      await this.performExport();
+    }
+  }
+
+  private async performExport(): Promise<void> {
     try {
       // Check if bridge imports directory exists — skip if not
-      await access(POLICY_DIR);
+      await access(this.policyDir);
     } catch {
       // Bridge not installed or imports dir not created — skip silently
       return;
@@ -89,7 +119,7 @@ export class PolicyExportService {
         risk_scores: staticRules.risk_scores,
       };
 
-      const filePath = join(POLICY_DIR, POLICY_FILENAME);
+      const filePath = join(this.policyDir, POLICY_FILENAME);
       await writeFile(filePath, JSON.stringify(policy, null, 2), 'utf-8');
       logger.info('[PolicyExportService] Policies exported', { filePath, elementCount: elementPolicies.active_element_count });
     } catch (err) {

--- a/src/services/PolicyExportService.ts
+++ b/src/services/PolicyExportService.ts
@@ -56,9 +56,7 @@ export class PolicyExportService {
     }
 
     this.exportQueued = true;
-    if (!this.exportInFlight) {
-      this.exportInFlight = this.runExportLoop();
-    }
+    this.exportInFlight ??= this.runExportLoop();
 
     return this.exportInFlight;
   }

--- a/src/services/PolicyExportService.ts
+++ b/src/services/PolicyExportService.ts
@@ -57,22 +57,27 @@ export class PolicyExportService {
 
     this.exportQueued = true;
     if (!this.exportInFlight) {
-      const drain = this.drainExports();
-      const inFlight = drain.finally(() => {
-        if (this.exportInFlight === inFlight) {
-          this.exportInFlight = undefined;
-        }
-
-        // A request can arrive as the drain promise settles. Preserve it as a
-        // trailing export instead of silently losing the newest policy state.
-        if (this.exportQueued) {
-          void this.exportPolicies();
-        }
-      });
-      this.exportInFlight = inFlight;
+      this.exportInFlight = this.runExportLoop();
     }
 
     return this.exportInFlight;
+  }
+
+  private async runExportLoop(): Promise<void> {
+    try {
+      await this.drainExports();
+    } finally {
+      this.exportInFlight = undefined;
+
+      // A request can arrive after drainExports() settles but before this
+      // continuation runs. Chain that trailing drain into the current promise
+      // so the request that queued it cannot resolve before its write finishes.
+      if (this.exportQueued) {
+        const trailing = this.runExportLoop();
+        this.exportInFlight = trailing;
+        await trailing;
+      }
+    }
   }
 
   private async drainExports(): Promise<void> {

--- a/src/storage/ElementStorageLayer.ts
+++ b/src/storage/ElementStorageLayer.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import { logger } from '../utils/logger.js';
 import type { IStorageBackend } from './IStorageBackend.js';
 import type { IStorageLayer, StorageScanOptions } from './IStorageLayer.js';
-import type { ElementIndexEntry, ManifestDiffResult } from './types.js';
+import { mergeManifestDiffResults, type ElementIndexEntry, type ManifestDiffResult } from './types.js';
 import { StorageManifest } from './StorageManifest.js';
 import { MetadataIndex } from './MetadataIndex.js';
 import { FrontmatterParser } from './FrontmatterParser.js';
@@ -63,6 +63,7 @@ export class ElementStorageLayer implements IStorageLayer {
    * - Updates index and manifest based on diff
    */
   async scan(options: StorageScanOptions = {}): Promise<ManifestDiffResult> {
+    let drainedDiff: ManifestDiffResult | undefined;
     const existingScan = this.scanInProgress;
     if (existingScan) {
       if (!options.freshAfterInFlight) {
@@ -72,7 +73,7 @@ export class ElementStorageLayer implements IStorageLayer {
       // A security-sensitive caller must not inherit a directory snapshot that
       // began before the caller. Drain it, then force a trailing disk scan.
       try {
-        await existingScan;
+        drainedDiff = await existingScan;
       } catch {
         // The trailing scan gets an independent chance to recover.
       }
@@ -91,13 +92,15 @@ export class ElementStorageLayer implements IStorageLayer {
     // Deduplicate a scan that started after the freshness wait above. Such a
     // scan is new enough for this caller and can safely be shared.
     if (this.scanInProgress) {
-      return this.scanInProgress;
+      const result = await this.scanInProgress;
+      return drainedDiff ? mergeManifestDiffResults(drainedDiff, result) : result;
     }
 
     const scan = this.performScan();
     this.scanInProgress = scan;
     try {
-      return await scan;
+      const result = await scan;
+      return drainedDiff ? mergeManifestDiffResults(drainedDiff, result) : result;
     } finally {
       if (this.scanInProgress === scan) {
         this.scanInProgress = null;

--- a/src/storage/ElementStorageLayer.ts
+++ b/src/storage/ElementStorageLayer.ts
@@ -8,7 +8,7 @@
 import * as path from 'path';
 import { logger } from '../utils/logger.js';
 import type { IStorageBackend } from './IStorageBackend.js';
-import type { IStorageLayer } from './IStorageLayer.js';
+import type { IStorageLayer, StorageScanOptions } from './IStorageLayer.js';
 import type { ElementIndexEntry, ManifestDiffResult } from './types.js';
 import { StorageManifest } from './StorageManifest.js';
 import { MetadataIndex } from './MetadataIndex.js';
@@ -62,23 +62,46 @@ export class ElementStorageLayer implements IStorageLayer {
    * - Deduplicates concurrent calls (returns same promise)
    * - Updates index and manifest based on diff
    */
-  async scan(): Promise<ManifestDiffResult> {
+  async scan(options: StorageScanOptions = {}): Promise<ManifestDiffResult> {
+    const existingScan = this.scanInProgress;
+    if (existingScan) {
+      if (!options.freshAfterInFlight) {
+        return existingScan;
+      }
+
+      // A security-sensitive caller must not inherit a directory snapshot that
+      // began before the caller. Drain it, then force a trailing disk scan.
+      try {
+        await existingScan;
+      } catch {
+        // The trailing scan gets an independent chance to recover.
+      }
+      if (this.scanInProgress === existingScan) {
+        this.scanInProgress = null;
+      }
+      this.invalidate();
+    }
+
     const now = Date.now();
     if (now - this.lastScanTimestamp < this.scanCooldownMs) {
       logger.debug(`ElementStorageLayer.scan: COOLDOWN ACTIVE for ${path.basename(this.elementDir)} — skipping disk I/O (${this.scanCooldownMs - (now - this.lastScanTimestamp)}ms remaining)`);
       return EMPTY_DIFF;
     }
 
-    // Deduplicate concurrent scans
+    // Deduplicate a scan that started after the freshness wait above. Such a
+    // scan is new enough for this caller and can safely be shared.
     if (this.scanInProgress) {
       return this.scanInProgress;
     }
 
-    this.scanInProgress = this.performScan();
+    const scan = this.performScan();
+    this.scanInProgress = scan;
     try {
-      return await this.scanInProgress;
+      return await scan;
     } finally {
-      this.scanInProgress = null;
+      if (this.scanInProgress === scan) {
+        this.scanInProgress = null;
+      }
     }
   }
 

--- a/src/storage/IStorageLayer.ts
+++ b/src/storage/IStorageLayer.ts
@@ -8,12 +8,20 @@
 
 import type { ElementIndexEntry, ManifestDiffResult } from './types.js';
 
+export interface StorageScanOptions {
+  /**
+   * If a scan was already running when this call began, wait for it and then
+   * force a trailing disk scan instead of reusing its potentially older view.
+   */
+  freshAfterInFlight?: boolean;
+}
+
 export interface IStorageLayer {
   /**
    * Scan the filesystem for changes relative to the last snapshot.
    * Implementations should enforce cooldown and deduplicate concurrent calls.
    */
-  scan(): Promise<ManifestDiffResult>;
+  scan(options?: StorageScanOptions): Promise<ManifestDiffResult>;
 
   /**
    * Trigger scan and return all indexed entries.

--- a/src/storage/MemoryStorageLayer.ts
+++ b/src/storage/MemoryStorageLayer.ts
@@ -14,7 +14,7 @@
 
 import * as path from 'path';
 import { logger } from '../utils/logger.js';
-import type { IStorageLayer } from './IStorageLayer.js';
+import type { IStorageLayer, StorageScanOptions } from './IStorageLayer.js';
 import type { IStorageBackend } from './IStorageBackend.js';
 import type { ElementIndexEntry, ManifestDiffResult } from './types.js';
 import { StorageManifest } from './StorageManifest.js';
@@ -76,29 +76,49 @@ export class MemoryStorageLayer implements IStorageLayer {
 
   // ---- IStorageLayer implementation ----
 
-  async scan(): Promise<ManifestDiffResult> {
+  async scan(options: StorageScanOptions = {}): Promise<ManifestDiffResult> {
+    const existingScan = this.scanInProgress;
+    if (existingScan) {
+      if (!options.freshAfterInFlight) {
+        return existingScan;
+      }
+
+      try {
+        await existingScan;
+      } catch {
+        // The trailing scan gets an independent chance to recover.
+      }
+      if (this.scanInProgress === existingScan) {
+        this.scanInProgress = null;
+      }
+      this.invalidate();
+    }
+
     // Cold start: try loading from _index.json first
+    let scan: Promise<ManifestDiffResult>;
     if (!this.coldStartDone) {
       this.coldStartDone = true;
-      return this.coldStart();
+      scan = this.coldStart();
+    } else {
+      const now = Date.now();
+      if (now - this.lastScanTimestamp < this.scanCooldownMs) {
+        logger.debug(`MemoryStorageLayer.scan: COOLDOWN ACTIVE — skipping disk I/O (${this.scanCooldownMs - (now - this.lastScanTimestamp)}ms remaining)`);
+        return EMPTY_DIFF;
+      }
+
+      if (this.scanInProgress) {
+        return this.scanInProgress;
+      }
+      scan = this.performScan();
     }
 
-    const now = Date.now();
-    if (now - this.lastScanTimestamp < this.scanCooldownMs) {
-      logger.debug(`MemoryStorageLayer.scan: COOLDOWN ACTIVE — skipping disk I/O (${this.scanCooldownMs - (now - this.lastScanTimestamp)}ms remaining)`);
-      return EMPTY_DIFF;
-    }
-
-    // Deduplicate concurrent scans
-    if (this.scanInProgress) {
-      return this.scanInProgress;
-    }
-
-    this.scanInProgress = this.performScan();
+    this.scanInProgress = scan;
     try {
-      return await this.scanInProgress;
+      return await scan;
     } finally {
-      this.scanInProgress = null;
+      if (this.scanInProgress === scan) {
+        this.scanInProgress = null;
+      }
     }
   }
 

--- a/src/storage/MemoryStorageLayer.ts
+++ b/src/storage/MemoryStorageLayer.ts
@@ -16,7 +16,7 @@ import * as path from 'path';
 import { logger } from '../utils/logger.js';
 import type { IStorageLayer, StorageScanOptions } from './IStorageLayer.js';
 import type { IStorageBackend } from './IStorageBackend.js';
-import type { ElementIndexEntry, ManifestDiffResult } from './types.js';
+import { mergeManifestDiffResults, type ElementIndexEntry, type ManifestDiffResult } from './types.js';
 import { StorageManifest } from './StorageManifest.js';
 import { MetadataIndex } from './MetadataIndex.js';
 import { FileStorageBackend } from './FileStorageBackend.js';
@@ -77,6 +77,7 @@ export class MemoryStorageLayer implements IStorageLayer {
   // ---- IStorageLayer implementation ----
 
   async scan(options: StorageScanOptions = {}): Promise<ManifestDiffResult> {
+    let drainedDiff: ManifestDiffResult | undefined;
     const existingScan = this.scanInProgress;
     if (existingScan) {
       if (!options.freshAfterInFlight) {
@@ -84,7 +85,7 @@ export class MemoryStorageLayer implements IStorageLayer {
       }
 
       try {
-        await existingScan;
+        drainedDiff = await existingScan;
       } catch {
         // The trailing scan gets an independent chance to recover.
       }
@@ -107,14 +108,16 @@ export class MemoryStorageLayer implements IStorageLayer {
       }
 
       if (this.scanInProgress) {
-        return this.scanInProgress;
+        const result = await this.scanInProgress;
+        return drainedDiff ? mergeManifestDiffResults(drainedDiff, result) : result;
       }
       scan = this.performScan();
     }
 
     this.scanInProgress = scan;
     try {
-      return await scan;
+      const result = await scan;
+      return drainedDiff ? mergeManifestDiffResults(drainedDiff, result) : result;
     } finally {
       if (this.scanInProgress === scan) {
         this.scanInProgress = null;

--- a/src/storage/MemoryStorageLayer.ts
+++ b/src/storage/MemoryStorageLayer.ts
@@ -84,14 +84,7 @@ export class MemoryStorageLayer implements IStorageLayer {
         return existingScan;
       }
 
-      try {
-        drainedDiff = await existingScan;
-      } catch {
-        // The trailing scan gets an independent chance to recover.
-      }
-      if (this.scanInProgress === existingScan) {
-        this.scanInProgress = null;
-      }
+      drainedDiff = await this.drainInFlightScan(existingScan);
       this.invalidate();
     }
 
@@ -123,6 +116,21 @@ export class MemoryStorageLayer implements IStorageLayer {
         this.scanInProgress = null;
       }
     }
+  }
+
+  private async drainInFlightScan(
+    existingScan: Promise<ManifestDiffResult>,
+  ): Promise<ManifestDiffResult | undefined> {
+    let drainedDiff: ManifestDiffResult | undefined;
+    try {
+      drainedDiff = await existingScan;
+    } catch {
+      // The trailing scan gets an independent chance to recover.
+    }
+    if (this.scanInProgress === existingScan) {
+      this.scanInProgress = null;
+    }
+    return drainedDiff;
   }
 
   async listSummaries(): Promise<ElementIndexEntry[]> {

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -67,3 +67,24 @@ export interface ManifestDiffResult {
   /** Files whose mtime matches the manifest (no change) */
   unchanged: string[];
 }
+
+/**
+ * Merge sequential scan results without losing an earlier invalidation when a
+ * trailing scan observes the same path as unchanged. Changed categories are
+ * intentionally retained as unions; consumers that evict caches must see any
+ * modification/removal observed during the freshness window.
+ */
+export function mergeManifestDiffResults(
+  first: ManifestDiffResult,
+  second: ManifestDiffResult,
+): ManifestDiffResult {
+  const unique = (values: string[]): string[] => Array.from(new Set(values));
+  const added = unique([...first.added, ...second.added]);
+  const modified = unique([...first.modified, ...second.modified]);
+  const removed = unique([...first.removed, ...second.removed]);
+  const changed = new Set([...added, ...modified, ...removed]);
+  const unchanged = unique([...first.unchanged, ...second.unchanged])
+    .filter((filePath) => !changed.has(filePath));
+
+  return { added, modified, removed, unchanged };
+}

--- a/tests/unit/Container.startup-behavior.test.ts
+++ b/tests/unit/Container.startup-behavior.test.ts
@@ -278,7 +278,7 @@ describe('Container Startup - Behavior (Non-Flaky)', () => {
         }
         return [];
       });
-      const activateAgentSpy = jest.spyOn(agentManager, 'activateAgent').mockResolvedValue({
+      const activateAgentSpy = jest.spyOn(agentManager, 'activateAgentByFilename').mockResolvedValue({
         success: true,
         message: 'Activated renamed agent',
       });

--- a/tests/unit/Container.startup-behavior.test.ts
+++ b/tests/unit/Container.startup-behavior.test.ts
@@ -238,20 +238,26 @@ describe('Container Startup - Behavior (Non-Flaky)', () => {
       expect(removeStalespy).not.toHaveBeenCalledWith('skill', 'real-skill');
     });
 
-    it('should prune stale agent activations when activateAgent returns failure', async () => {
+    it('should prune filename-backed stale agent activations by stable identity', async () => {
       const agentManager = container.resolve<any>('AgentManager');
       const activationStore = container.resolve<any>('ActivationStore');
 
       jest.spyOn(activationStore, 'isEnabled').mockReturnValue(true);
       jest.spyOn(activationStore, 'initialize').mockResolvedValue(undefined);
       jest.spyOn(activationStore, 'getActivations').mockImplementation((type: string) => {
-        if (type === 'agent') return [{ name: 'missing-agent', activatedAt: new Date().toISOString() }];
+        if (type === 'agent') {
+          return [{
+            name: 'Colliding Agent',
+            filename: 'missing-agent.md',
+            activatedAt: new Date().toISOString(),
+          }];
+        }
         return [];
       });
       const removeStaleSpy = jest.spyOn(activationStore, 'removeStaleActivation')
         .mockImplementation(() => {});
 
-      jest.spyOn(agentManager, 'activateAgent').mockResolvedValue({
+      jest.spyOn(agentManager, 'activateAgentByFilename').mockResolvedValue({
         success: false,
         message: 'Agent not found'
       });
@@ -259,7 +265,11 @@ describe('Container Startup - Behavior (Non-Flaky)', () => {
       await container.preparePortfolio();
       await container.completeDeferredSetup();
 
-      expect(removeStaleSpy).toHaveBeenCalledWith('agent', 'missing-agent');
+      expect(removeStaleSpy).toHaveBeenCalledWith(
+        'agent',
+        'Colliding Agent',
+        'missing-agent.md',
+      );
     });
 
     it('should restore renamed agents by stable filename', async () => {
@@ -313,7 +323,7 @@ describe('Container Startup - Behavior (Non-Flaky)', () => {
       await container.preparePortfolio();
       await container.completeDeferredSetup();
 
-      expect(removeStaleSpy).toHaveBeenCalledWith('persona', 'deleted-persona');
+      expect(removeStaleSpy).toHaveBeenCalledWith('persona', 'deleted-persona', undefined);
     });
 
     it('should still prune on thrown exceptions (defensive)', async () => {

--- a/tests/unit/Container.startup-behavior.test.ts
+++ b/tests/unit/Container.startup-behavior.test.ts
@@ -262,6 +262,36 @@ describe('Container Startup - Behavior (Non-Flaky)', () => {
       expect(removeStaleSpy).toHaveBeenCalledWith('agent', 'missing-agent');
     });
 
+    it('should restore renamed agents by stable filename', async () => {
+      const agentManager = container.resolve<any>('AgentManager');
+      const activationStore = container.resolve<any>('ActivationStore');
+
+      jest.spyOn(activationStore, 'isEnabled').mockReturnValue(true);
+      jest.spyOn(activationStore, 'initialize').mockResolvedValue(undefined);
+      jest.spyOn(activationStore, 'getActivations').mockImplementation((type: string) => {
+        if (type === 'agent') {
+          return [{
+            name: 'Pre-Rename Agent',
+            filename: 'stable-agent.md',
+            activatedAt: new Date().toISOString(),
+          }];
+        }
+        return [];
+      });
+      const activateAgentSpy = jest.spyOn(agentManager, 'activateAgent').mockResolvedValue({
+        success: true,
+        message: 'Activated renamed agent',
+      });
+      const removeStaleSpy = jest.spyOn(activationStore, 'removeStaleActivation')
+        .mockImplementation(() => {});
+
+      await container.preparePortfolio();
+      await container.completeDeferredSetup();
+
+      expect(activateAgentSpy).toHaveBeenCalledWith('stable-agent.md');
+      expect(removeStaleSpy).not.toHaveBeenCalledWith('agent', 'Pre-Rename Agent');
+    });
+
     it('should prune stale persona activations when activatePersona returns failure', async () => {
       const personaManager = container.resolve<any>('PersonaManager');
       const activationStore = container.resolve<any>('ActivationStore');

--- a/tests/unit/base/BaseElementManager.test.ts
+++ b/tests/unit/base/BaseElementManager.test.ts
@@ -797,6 +797,19 @@ describe('BaseElementManager - Requirements & Contract', () => {
   // ============================================
 
   describe('findByName() Cache Key Consistency', () => {
+    it('findByFilename() loads a stable path when the display name has changed', async () => {
+      await fs.writeFile(
+        path.join(elementsDir, 'stable-element.md'),
+        `---\nname: Renamed Element\n---\n\nContent`
+      );
+
+      const found = await manager.findByFilename('stable-element.md');
+
+      expect(found).toBeDefined();
+      expect(found?.metadata.name).toBe('Renamed Element');
+      expect((found as TestElement & { filename?: string })?.filename).toBe('stable-element.md');
+    });
+
     it('findByName() hits cache after list() populates it', async () => {
       // Setup: create files on disk
       await fs.writeFile(

--- a/tests/unit/elements/agents/AgentManager.test.ts
+++ b/tests/unit/elements/agents/AgentManager.test.ts
@@ -155,6 +155,25 @@ describe('AgentManager', () => {
       expect(result).toEqual([reloadedAgent]);
       expect(activate).toHaveBeenCalledTimes(1);
     });
+
+    it('migrates the active-set key when a reloaded agent was renamed', async () => {
+      const activate = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+      const reloadedAgent = {
+        metadata: { name: 'renamed-agent' },
+        getStatus: () => ElementStatus.INACTIVE,
+        activate,
+      } as Agent;
+      const activeNames = (agentManager as any).activeAgentNames as Set<string>;
+      activeNames.add('original-agent');
+      jest.spyOn(agentManager as any, 'scanAndEvict').mockResolvedValue(undefined);
+      jest.spyOn(agentManager, 'findByName').mockResolvedValue(reloadedAgent);
+
+      await agentManager.getActiveAgents();
+
+      expect(activeNames.has('original-agent')).toBe(false);
+      expect(activeNames.has('renamed-agent')).toBe(true);
+      expect(activate).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('Create', () => {

--- a/tests/unit/elements/agents/AgentManager.test.ts
+++ b/tests/unit/elements/agents/AgentManager.test.ts
@@ -160,19 +160,52 @@ describe('AgentManager', () => {
       const activate = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
       const reloadedAgent = {
         metadata: { name: 'renamed-agent' },
+        filename: 'original-agent.md',
         getStatus: () => ElementStatus.INACTIVE,
         activate,
       } as Agent;
       const activeNames = (agentManager as any).activeAgentNames as Set<string>;
+      const activeFilenames = (agentManager as any).activeAgentFilenames as Map<string, string>;
       activeNames.add('original-agent');
+      activeFilenames.set('original-agent', 'original-agent.md');
       jest.spyOn(agentManager as any, 'scanAndEvict').mockResolvedValue(undefined);
-      jest.spyOn(agentManager, 'findByName').mockResolvedValue(reloadedAgent);
+      const findByName = jest.spyOn(agentManager, 'findByName').mockResolvedValue(undefined);
+      const findByFilename = jest.spyOn(agentManager, 'findByFilename').mockResolvedValue(reloadedAgent);
 
       await agentManager.getActiveAgents();
 
+      expect(findByFilename).toHaveBeenCalledWith('original-agent.md');
+      expect(findByName).not.toHaveBeenCalled();
       expect(activeNames.has('original-agent')).toBe(false);
       expect(activeNames.has('renamed-agent')).toBe(true);
+      expect(activeFilenames.get('renamed-agent')).toBe('original-agent.md');
       expect(activate).toHaveBeenCalledTimes(1);
+    });
+
+    it('deactivates a renamed agent by its stable filename before a policy refresh', async () => {
+      const deactivate = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+      const renamedAgent = {
+        metadata: { name: 'renamed-agent', version: '1.0.0' },
+        filename: 'original-agent.md',
+        id: 'renamed-agent-id',
+        deactivate,
+      } as unknown as Agent;
+      const activeNames = (agentManager as any).activeAgentNames as Set<string>;
+      const activeFilenames = (agentManager as any).activeAgentFilenames as Map<string, string>;
+      activeNames.add('original-agent');
+      activeFilenames.set('original-agent', 'original-agent.md');
+      const scanAndEvict = jest.spyOn(agentManager as any, 'scanAndEvict').mockResolvedValue(undefined);
+      jest.spyOn(agentManager, 'findByName').mockResolvedValue(undefined);
+      const findByFilename = jest.spyOn(agentManager, 'findByFilename').mockResolvedValue(renamedAgent);
+
+      const result = await agentManager.deactivateAgent('renamed-agent');
+
+      expect(result.success).toBe(true);
+      expect(scanAndEvict).toHaveBeenCalledWith({ freshAfterInFlight: true });
+      expect(findByFilename).toHaveBeenCalledWith('original-agent.md');
+      expect(activeNames.size).toBe(0);
+      expect(activeFilenames.size).toBe(0);
+      expect(deactivate).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/tests/unit/elements/agents/AgentManager.test.ts
+++ b/tests/unit/elements/agents/AgentManager.test.ts
@@ -118,6 +118,18 @@ describe('AgentManager', () => {
   });
 
   describe('Active agents', () => {
+    it('exposes the stable filename used for activation persistence', async () => {
+      const agent = {
+        metadata: { name: 'Renamed Agent' },
+        filename: 'stable-agent.md',
+      } as Agent;
+      const findByName = jest.spyOn(agentManager, 'findByName').mockResolvedValue(agent);
+
+      await expect(agentManager.getStableActivationFilename('Renamed Agent'))
+        .resolves.toBe('stable-agent.md');
+      expect(findByName).toHaveBeenCalledWith('Renamed Agent');
+    });
+
     it('resolves only active names without listing the full agent catalog', async () => {
       const activate = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
       const activeAgent = {

--- a/tests/unit/elements/agents/AgentManager.test.ts
+++ b/tests/unit/elements/agents/AgentManager.test.ts
@@ -231,6 +231,26 @@ describe('AgentManager', () => {
       expect(firstActivate).toHaveBeenCalledTimes(1);
       expect(secondActivate).toHaveBeenCalledTimes(1);
     });
+
+    it('deactivates an active agent by stable filename', async () => {
+      const deactivate = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+      const agent = {
+        metadata: { name: 'colliding-name', version: '1.0.0' },
+        filename: 'stable-agent.md',
+        id: 'stable-agent-id',
+        deactivate,
+      } as unknown as Agent;
+      const activeByFilename = (agentManager as any).activeAgentsByFilename as Map<string, string>;
+      activeByFilename.set('stable-agent.md', 'original-name');
+      jest.spyOn(agentManager as any, 'scanAndEvict').mockResolvedValue(undefined);
+      jest.spyOn(agentManager, 'findByFilename').mockResolvedValue(agent);
+
+      const result = await agentManager.deactivateAgent('stable-agent.md');
+
+      expect(result.success).toBe(true);
+      expect(activeByFilename.size).toBe(0);
+      expect(deactivate).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('Create', () => {

--- a/tests/unit/elements/agents/AgentManager.test.ts
+++ b/tests/unit/elements/agents/AgentManager.test.ts
@@ -130,6 +130,26 @@ describe('AgentManager', () => {
       expect(findByName).toHaveBeenCalledWith('Renamed Agent');
     });
 
+    it('restores an externally renamed agent through its stable filename', async () => {
+      const activate = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+      const renamedAgent = {
+        id: 'renamed-agent-id',
+        metadata: { name: 'Renamed Agent', version: '1.0.0' },
+        filename: 'stable-agent.md',
+        activate,
+      } as unknown as Agent;
+      const findByFilename = jest.spyOn(agentManager, 'findByFilename').mockResolvedValue(renamedAgent);
+      const findByName = jest.spyOn(agentManager, 'findByName');
+
+      const result = await agentManager.activateAgentByFilename('stable-agent.md');
+
+      expect(result.success).toBe(true);
+      expect(result.agent).toBe(renamedAgent);
+      expect(findByFilename).toHaveBeenCalledWith('stable-agent.md');
+      expect(findByName).not.toHaveBeenCalled();
+      expect(activate).toHaveBeenCalledTimes(1);
+    });
+
     it('resolves only active names without listing the full agent catalog', async () => {
       const activate = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
       const activeAgent = {

--- a/tests/unit/elements/agents/AgentManager.test.ts
+++ b/tests/unit/elements/agents/AgentManager.test.ts
@@ -28,6 +28,7 @@ import { TriggerValidationService } from '../../../../src/services/validation/Tr
 import { ValidationService } from '../../../../src/services/validation/ValidationService.js';
 import { SerializationService } from '../../../../src/services/SerializationService.js';
 import { SECURITY_LIMITS } from '../../../../src/security/constants.js';
+import { ElementStatus } from '../../../../src/types/elements/IElement.js';
 
 const metadataService: MetadataService = createTestMetadataService();
 
@@ -118,8 +119,11 @@ describe('AgentManager', () => {
 
   describe('Active agents', () => {
     it('resolves only active names without listing the full agent catalog', async () => {
+      const activate = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
       const activeAgent = {
         metadata: { name: 'active-agent' },
+        getStatus: () => ElementStatus.ACTIVE,
+        activate,
       } as Agent;
       (agentManager as any).activeAgentNames.add('active-agent');
       const scanAndEvict = jest.spyOn(agentManager as any, 'scanAndEvict').mockResolvedValue(undefined);
@@ -131,7 +135,25 @@ describe('AgentManager', () => {
       expect(result).toEqual([activeAgent]);
       expect(scanAndEvict).toHaveBeenCalledTimes(1);
       expect(findByName).toHaveBeenCalledWith('active-agent');
+      expect(activate).not.toHaveBeenCalled();
       expect(list).not.toHaveBeenCalled();
+    });
+
+    it('restores active status when a refreshed active agent was evicted and reloaded', async () => {
+      const activate = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+      const reloadedAgent = {
+        metadata: { name: 'active-agent' },
+        getStatus: () => ElementStatus.INACTIVE,
+        activate,
+      } as Agent;
+      (agentManager as any).activeAgentNames.add('active-agent');
+      jest.spyOn(agentManager as any, 'scanAndEvict').mockResolvedValue(undefined);
+      jest.spyOn(agentManager, 'findByName').mockResolvedValue(reloadedAgent);
+
+      const result = await agentManager.getActiveAgents();
+
+      expect(result).toEqual([reloadedAgent]);
+      expect(activate).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/tests/unit/elements/agents/AgentManager.test.ts
+++ b/tests/unit/elements/agents/AgentManager.test.ts
@@ -116,6 +116,23 @@ describe('AgentManager', () => {
     });
   });
 
+  describe('Active agents', () => {
+    it('resolves only active names without listing the full agent catalog', async () => {
+      const activeAgent = {
+        metadata: { name: 'active-agent' },
+      } as Agent;
+      (agentManager as any).activeAgentNames.add('active-agent');
+      const findByName = jest.spyOn(agentManager, 'findByName').mockResolvedValue(activeAgent);
+      const list = jest.spyOn(agentManager, 'list');
+
+      const result = await agentManager.getActiveAgents();
+
+      expect(result).toEqual([activeAgent]);
+      expect(findByName).toHaveBeenCalledWith('active-agent');
+      expect(list).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Create', () => {
     it('should create a new agent', async () => {
       const result = await agentManager.create(

--- a/tests/unit/elements/agents/AgentManager.test.ts
+++ b/tests/unit/elements/agents/AgentManager.test.ts
@@ -178,6 +178,28 @@ describe('AgentManager', () => {
       expect(activate).toHaveBeenCalledTimes(1);
     });
 
+    it('reuses the cached active agent for stable filename policy reads', async () => {
+      const cachedAgent = new Agent({
+        name: 'cached-agent',
+        description: 'Cached active agent',
+      }, metadataService);
+      await cachedAgent.activate();
+      (agentManager as any).cacheElement(cachedAgent, 'cached-agent.md');
+      (agentManager as any).activeAgentsByFilename.set('cached-agent.md', 'cached-agent');
+      jest.spyOn(agentManager as any, 'scanAndEvict').mockResolvedValue(undefined);
+      fileOperationsService.readFile.mockClear();
+
+      const first = await agentManager.getActiveAgents();
+      const second = await agentManager.getActiveAgents();
+
+      expect(first).toEqual([cachedAgent]);
+      expect(second).toEqual([cachedAgent]);
+      expect(first[0]).toBe(cachedAgent);
+      expect(second[0]).toBe(cachedAgent);
+      expect(cachedAgent.getState().sessionCount).toBe(1);
+      expect(fileOperationsService.readFile).not.toHaveBeenCalled();
+    });
+
     it('deactivates a renamed agent using its pre-rename activation name', async () => {
       const deactivate = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
       const renamedAgent = {

--- a/tests/unit/elements/agents/AgentManager.test.ts
+++ b/tests/unit/elements/agents/AgentManager.test.ts
@@ -249,6 +249,7 @@ describe('AgentManager', () => {
       const result = await agentManager.deactivateAgent('original-agent');
 
       expect(result.success).toBe(true);
+      expect(result.filename).toBe('original-agent.md');
       expect(scanAndEvict).toHaveBeenCalledWith({ freshAfterInFlight: true });
       expect(findByFilename).toHaveBeenCalledWith('original-agent.md');
       expect(activeByFilename.size).toBe(0);
@@ -302,6 +303,7 @@ describe('AgentManager', () => {
       const result = await agentManager.deactivateAgent('stable-agent.md');
 
       expect(result.success).toBe(true);
+      expect(result.filename).toBe('stable-agent.md');
       expect(activeByFilename.size).toBe(0);
       expect(deactivate).toHaveBeenCalledTimes(1);
     });

--- a/tests/unit/elements/agents/AgentManager.test.ts
+++ b/tests/unit/elements/agents/AgentManager.test.ts
@@ -122,12 +122,14 @@ describe('AgentManager', () => {
         metadata: { name: 'active-agent' },
       } as Agent;
       (agentManager as any).activeAgentNames.add('active-agent');
+      const scanAndEvict = jest.spyOn(agentManager as any, 'scanAndEvict').mockResolvedValue(undefined);
       const findByName = jest.spyOn(agentManager, 'findByName').mockResolvedValue(activeAgent);
       const list = jest.spyOn(agentManager, 'list');
 
       const result = await agentManager.getActiveAgents();
 
       expect(result).toEqual([activeAgent]);
+      expect(scanAndEvict).toHaveBeenCalledTimes(1);
       expect(findByName).toHaveBeenCalledWith('active-agent');
       expect(list).not.toHaveBeenCalled();
     });

--- a/tests/unit/elements/agents/AgentManager.test.ts
+++ b/tests/unit/elements/agents/AgentManager.test.ts
@@ -156,7 +156,7 @@ describe('AgentManager', () => {
       expect(activate).toHaveBeenCalledTimes(1);
     });
 
-    it('migrates the active-set key when a reloaded agent was renamed', async () => {
+    it('resolves a renamed active agent through its stable filename', async () => {
       const activate = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
       const reloadedAgent = {
         metadata: { name: 'renamed-agent' },
@@ -164,10 +164,8 @@ describe('AgentManager', () => {
         getStatus: () => ElementStatus.INACTIVE,
         activate,
       } as Agent;
-      const activeNames = (agentManager as any).activeAgentNames as Set<string>;
-      const activeFilenames = (agentManager as any).activeAgentFilenames as Map<string, string>;
-      activeNames.add('original-agent');
-      activeFilenames.set('original-agent', 'original-agent.md');
+      const activeByFilename = (agentManager as any).activeAgentsByFilename as Map<string, string>;
+      activeByFilename.set('original-agent.md', 'original-agent');
       jest.spyOn(agentManager as any, 'scanAndEvict').mockResolvedValue(undefined);
       const findByName = jest.spyOn(agentManager, 'findByName').mockResolvedValue(undefined);
       const findByFilename = jest.spyOn(agentManager, 'findByFilename').mockResolvedValue(reloadedAgent);
@@ -176,13 +174,11 @@ describe('AgentManager', () => {
 
       expect(findByFilename).toHaveBeenCalledWith('original-agent.md');
       expect(findByName).not.toHaveBeenCalled();
-      expect(activeNames.has('original-agent')).toBe(false);
-      expect(activeNames.has('renamed-agent')).toBe(true);
-      expect(activeFilenames.get('renamed-agent')).toBe('original-agent.md');
+      expect(activeByFilename.get('original-agent.md')).toBe('original-agent');
       expect(activate).toHaveBeenCalledTimes(1);
     });
 
-    it('deactivates a renamed agent by its stable filename before a policy refresh', async () => {
+    it('deactivates a renamed agent using its pre-rename activation name', async () => {
       const deactivate = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
       const renamedAgent = {
         metadata: { name: 'renamed-agent', version: '1.0.0' },
@@ -190,22 +186,50 @@ describe('AgentManager', () => {
         id: 'renamed-agent-id',
         deactivate,
       } as unknown as Agent;
-      const activeNames = (agentManager as any).activeAgentNames as Set<string>;
-      const activeFilenames = (agentManager as any).activeAgentFilenames as Map<string, string>;
-      activeNames.add('original-agent');
-      activeFilenames.set('original-agent', 'original-agent.md');
+      const activeByFilename = (agentManager as any).activeAgentsByFilename as Map<string, string>;
+      activeByFilename.set('original-agent.md', 'original-agent');
       const scanAndEvict = jest.spyOn(agentManager as any, 'scanAndEvict').mockResolvedValue(undefined);
       jest.spyOn(agentManager, 'findByName').mockResolvedValue(undefined);
       const findByFilename = jest.spyOn(agentManager, 'findByFilename').mockResolvedValue(renamedAgent);
 
-      const result = await agentManager.deactivateAgent('renamed-agent');
+      const result = await agentManager.deactivateAgent('original-agent');
 
       expect(result.success).toBe(true);
       expect(scanAndEvict).toHaveBeenCalledWith({ freshAfterInFlight: true });
       expect(findByFilename).toHaveBeenCalledWith('original-agent.md');
-      expect(activeNames.size).toBe(0);
-      expect(activeFilenames.size).toBe(0);
+      expect(activeByFilename.size).toBe(0);
       expect(deactivate).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps colliding renamed active agents distinct by stable filename', async () => {
+      const firstActivate = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+      const secondActivate = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+      const firstAgent = {
+        metadata: { name: 'colliding-name' },
+        filename: 'first-agent.md',
+        getStatus: () => ElementStatus.INACTIVE,
+        activate: firstActivate,
+      } as Agent;
+      const secondAgent = {
+        metadata: { name: 'colliding-name' },
+        filename: 'second-agent.md',
+        getStatus: () => ElementStatus.INACTIVE,
+        activate: secondActivate,
+      } as Agent;
+      const activeByFilename = (agentManager as any).activeAgentsByFilename as Map<string, string>;
+      activeByFilename.set('first-agent.md', 'first-agent');
+      activeByFilename.set('second-agent.md', 'second-agent');
+      jest.spyOn(agentManager as any, 'scanAndEvict').mockResolvedValue(undefined);
+      jest.spyOn(agentManager, 'findByFilename').mockImplementation(async (filename: string) =>
+        filename === 'first-agent.md' ? firstAgent : secondAgent,
+      );
+
+      const result = await agentManager.getActiveAgents();
+
+      expect(result).toEqual([firstAgent, secondAgent]);
+      expect(activeByFilename.size).toBe(2);
+      expect(firstActivate).toHaveBeenCalledTimes(1);
+      expect(secondActivate).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -252,6 +252,33 @@ describe('ElementCRUDHandler (DI)', () => {
       ]));
     });
 
+    it('preserves filename-distinct colliding agent policies in session reports', async () => {
+      agentManager.getActiveAgents.mockResolvedValue([
+        {
+          filename: 'first-agent.md',
+          metadata: {
+            name: 'colliding-name',
+            gatekeeper: { externalRestrictions: { denyPatterns: ['Bash:rm*'] } },
+          },
+        } as any,
+        {
+          filename: 'second-agent.md',
+          metadata: {
+            name: 'colliding-name',
+            gatekeeper: { externalRestrictions: { confirmPatterns: ['Bash:git push*'] } },
+          },
+        } as any,
+      ]);
+
+      const result = await handler.getPolicyElementsForReport('session-demo');
+
+      expect(result).toHaveLength(2);
+      expect(result.map(element => element.metadata.gatekeeper)).toEqual([
+        { externalRestrictions: { denyPatterns: ['Bash:rm*'] } },
+        { externalRestrictions: { confirmPatterns: ['Bash:git push*'] } },
+      ]);
+    });
+
     it('indexes each ensemble-member type once without lifecycle-bearing list calls', async () => {
       ensembleManager.getActiveEnsembles.mockResolvedValue([{
         metadata: {

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -262,6 +262,7 @@ describe('ElementCRUDHandler (DI)', () => {
             { element_type: 'skill', element_name: 'ordinary-skill' },
             { element_type: 'memory', element_name: 'policy-memory' },
             { element_type: 'memories', element_name: 'policy-memory' },
+            { element_type: 'template', element_name: 'policy-template' },
           ],
         },
       } as any]);
@@ -285,17 +286,29 @@ describe('ElementCRUDHandler (DI)', () => {
           gatekeeper: { externalRestrictions: { confirmPatterns: ['Bash:git push*'] } },
         },
       } as any);
+      templateManager.refreshIndex = jest.fn().mockResolvedValue(undefined);
+      templateManager.findByName = jest.fn().mockResolvedValue({
+        metadata: {
+          name: 'policy-template',
+          gatekeeper: { externalRestrictions: { denyPatterns: ['Write:*'] } },
+        },
+      } as any);
 
       const result = await handler.getActiveElementsForPolicy();
 
       expect(skillManager.refreshIndex).toHaveBeenCalledTimes(1);
       expect(memoryManager.refreshIndex).toHaveBeenCalledTimes(1);
+      expect(templateManager.refreshIndex).toHaveBeenCalledTimes(1);
       expect(skillManager.findByName).toHaveBeenCalledTimes(2);
       expect(memoryManager.findByName).toHaveBeenCalledTimes(1);
+      expect(templateManager.findByName).toHaveBeenCalledTimes(1);
       expect(skillManager.list).not.toHaveBeenCalled();
       expect(memoryManager.list).not.toHaveBeenCalled();
       expect(result.filter((element) => element.name === 'policy-skill')).toHaveLength(1);
       expect(result.filter((element) => element.name === 'policy-memory')).toHaveLength(1);
+      expect(result).toEqual(expect.arrayContaining([
+        expect.objectContaining({ type: 'template', name: 'policy-template' }),
+      ]));
       expect(result).not.toEqual(expect.arrayContaining([
         expect.objectContaining({ name: 'ordinary-skill' }),
       ]));
@@ -561,6 +574,63 @@ describe('ElementCRUDHandler (DI)', () => {
       expect(skillManager.refreshIndex).toHaveBeenCalledTimes(1);
       expect(skillManager.findByName).toHaveBeenCalledTimes(1);
       expect(skillManager.list).not.toHaveBeenCalled();
+    });
+
+    it('recovers a renamed persisted persona by its stable filename', async () => {
+      const activationStore = {
+        isEnabled: jest.fn().mockReturnValue(true),
+        getSessionId: jest.fn().mockReturnValue('leader-session'),
+        listPersistedActivationStates: jest.fn().mockResolvedValue([{
+          sessionId: 'session-other',
+          lastUpdated: new Date().toISOString(),
+          activations: {
+            persona: [{
+              name: 'Old Display Name',
+              filename: 'stable-persona.md',
+              activatedAt: new Date().toISOString(),
+            }],
+          },
+        }]),
+      } as unknown as jest.Mocked<ActivationStore>;
+
+      personaHandler.refreshIndex = jest.fn().mockResolvedValue(undefined);
+      personaHandler.findByName = jest.fn().mockResolvedValue(undefined);
+      personaHandler.findByFilename = jest.fn().mockResolvedValue({
+        metadata: {
+          name: 'New Display Name',
+          gatekeeper: { externalRestrictions: { denyPatterns: ['Bash:rm*'] } },
+        },
+      } as any);
+
+      const reportHandler = new ElementCRUDHandler(
+        skillManager,
+        templateManager,
+        templateRenderer,
+        agentManager,
+        memoryManager,
+        ensembleManager,
+        personaHandler,
+        portfolioManager,
+        initService,
+        indicatorService,
+        fileOperations,
+        undefined as any,
+        undefined as any,
+        activationStore,
+      );
+
+      const result = await reportHandler.getPolicyElementsForReport('session-other');
+
+      expect(personaHandler.refreshIndex).toHaveBeenCalledTimes(1);
+      expect(personaHandler.findByName).toHaveBeenCalledWith('Old Display Name');
+      expect(personaHandler.findByFilename).toHaveBeenCalledWith('stable-persona.md');
+      expect(result).toEqual([
+        expect.objectContaining({
+          type: 'persona',
+          name: 'New Display Name',
+          sessionIds: ['session-other'],
+        }),
+      ]);
     });
   });
 

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -48,6 +48,7 @@ describe('ElementCRUDHandler (DI)', () => {
 
     agentManager = {
       create: jest.fn(),
+      getStableActivationFilename: jest.fn(),
       getActiveAgents: jest.fn().mockResolvedValue([]),
       deactivateAgent: jest.fn().mockResolvedValue({ success: true, message: 'deactivated' }),
       list: jest.fn().mockResolvedValue([]),
@@ -113,6 +114,47 @@ describe('ElementCRUDHandler (DI)', () => {
       initService,
       indicatorService,
       fileOperations
+    );
+  });
+
+  it('persists the stable filename when activating an agent', async () => {
+    const activationStore = {
+      recordActivation: jest.fn(),
+    } as unknown as jest.Mocked<ActivationStore>;
+    agentManager.activateAgent = jest.fn().mockResolvedValue({
+      success: true,
+      message: 'activated',
+      agent: {
+        metadata: { name: 'Renamed Agent' },
+        getState: jest.fn().mockReturnValue({ sessionCount: 1, goals: [] }),
+      },
+    } as any);
+    agentManager.persistState = jest.fn().mockResolvedValue(undefined);
+    agentManager.getStableActivationFilename.mockResolvedValue('stable-agent.md');
+    const handlerWithPersistence = new ElementCRUDHandler(
+      skillManager,
+      templateManager,
+      templateRenderer,
+      agentManager,
+      memoryManager,
+      ensembleManager,
+      personaHandler,
+      portfolioManager,
+      initService,
+      indicatorService,
+      fileOperations,
+      undefined as any,
+      undefined as any,
+      activationStore,
+    );
+
+    await handlerWithPersistence.activateElement('Renamed Agent', ElementType.AGENT);
+
+    expect(agentManager.getStableActivationFilename).toHaveBeenCalledWith('Renamed Agent');
+    expect(activationStore.recordActivation).toHaveBeenCalledWith(
+      ElementType.AGENT,
+      'Renamed Agent',
+      'stable-agent.md',
     );
   });
 

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -604,6 +604,55 @@ describe('ElementCRUDHandler (DI)', () => {
       expect(skillManager.list).not.toHaveBeenCalled();
     });
 
+    it('forces a trailing persisted-policy index scan for enforcement reports', async () => {
+      const activationStore = {
+        isEnabled: jest.fn().mockReturnValue(true),
+        getSessionId: jest.fn().mockReturnValue('leader-session'),
+        listPersistedActivationStates: jest.fn().mockResolvedValue([{
+          sessionId: 'session-other',
+          lastUpdated: new Date().toISOString(),
+          activations: {
+            skill: [{ name: 'fresh-policy', activatedAt: new Date().toISOString() }],
+          },
+        }]),
+      } as unknown as jest.Mocked<ActivationStore>;
+
+      skillManager.refreshIndex = jest.fn().mockResolvedValue(undefined);
+      skillManager.findByName = jest.fn().mockResolvedValue({
+        metadata: {
+          name: 'fresh-policy',
+          gatekeeper: { externalRestrictions: { denyPatterns: ['Bash:rm*'] } },
+        },
+      } as any);
+
+      const reportHandler = new ElementCRUDHandler(
+        skillManager,
+        templateManager,
+        templateRenderer,
+        agentManager,
+        memoryManager,
+        ensembleManager,
+        personaHandler,
+        portfolioManager,
+        initService,
+        indicatorService,
+        fileOperations,
+        undefined as any,
+        undefined as any,
+        activationStore,
+      );
+
+      const result = await reportHandler.getPolicyElementsForReport(
+        'session-other',
+        { allowCoalescing: false },
+      );
+
+      expect(skillManager.refreshIndex).toHaveBeenCalledWith({ freshAfterInFlight: true });
+      expect(result).toEqual([
+        expect.objectContaining({ type: 'skill', name: 'fresh-policy' }),
+      ]);
+    });
+
     it('uses a persisted persona stable filename before a reused display name', async () => {
       const activationStore = {
         isEnabled: jest.fn().mockReturnValue(true),

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -338,6 +338,33 @@ describe('ElementCRUDHandler (DI)', () => {
       expect(ensembleManager.getActiveEnsembles).toHaveBeenCalledTimes(1);
     });
 
+    it('does not coalesce a security-critical policy read onto an in-flight dashboard snapshot', async () => {
+      let markDashboardStarted!: () => void;
+      let releaseDashboard!: () => void;
+      const dashboardStarted = new Promise<void>((resolve) => {
+        markDashboardStarted = resolve;
+      });
+      const dashboardBlocked = new Promise<void>((resolve) => {
+        releaseDashboard = resolve;
+      });
+      ensembleManager.getActiveEnsembles
+        .mockImplementationOnce(async () => {
+          markDashboardStarted();
+          await dashboardBlocked;
+          return [];
+        })
+        .mockResolvedValueOnce([]);
+
+      const dashboardSnapshot = handler.getActiveElementsForPolicy();
+      await dashboardStarted;
+      const enforcementSnapshot = handler.getActiveElementsForPolicy({ allowCoalescing: false });
+
+      await enforcementSnapshot;
+      expect(ensembleManager.getActiveEnsembles).toHaveBeenCalledTimes(2);
+      releaseDashboard();
+      await dashboardSnapshot;
+    });
+
     it('does not reuse an in-flight snapshot after activation state changes', async () => {
       let markFirstSnapshotStarted!: () => void;
       let releaseFirstSnapshot!: () => void;

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -252,6 +252,98 @@ describe('ElementCRUDHandler (DI)', () => {
       ]));
     });
 
+    it('indexes each ensemble-member type once without lifecycle-bearing list calls', async () => {
+      ensembleManager.getActiveEnsembles.mockResolvedValue([{
+        metadata: {
+          name: 'large-policy-team',
+          elements: [
+            { element_type: 'skill', element_name: 'policy-skill' },
+            { element_type: 'skills', element_name: 'policy-skill' },
+            { element_type: 'skill', element_name: 'ordinary-skill' },
+            { element_type: 'memory', element_name: 'policy-memory' },
+            { element_type: 'memories', element_name: 'policy-memory' },
+          ],
+        },
+      } as any]);
+      const skillsByName = new Map<string, any>([
+        ['policy-skill', {
+          metadata: {
+            name: 'policy-skill',
+            gatekeeper: { externalRestrictions: { denyPatterns: ['Bash:rm*'] } },
+          },
+        }],
+        ['ordinary-skill', { metadata: { name: 'ordinary-skill' } }],
+      ]);
+      skillManager.list = jest.fn();
+      skillManager.listSummaries = jest.fn().mockResolvedValue([]);
+      skillManager.findByName = jest.fn(async (name: string) => skillsByName.get(name));
+      memoryManager.list = jest.fn();
+      memoryManager.listSummaries = jest.fn().mockResolvedValue([]);
+      memoryManager.findByName = jest.fn().mockResolvedValue({
+        metadata: {
+          name: 'policy-memory',
+          gatekeeper: { externalRestrictions: { confirmPatterns: ['Bash:git push*'] } },
+        },
+      } as any);
+
+      const result = await handler.getActiveElementsForPolicy();
+
+      expect(skillManager.listSummaries).toHaveBeenCalledTimes(1);
+      expect(memoryManager.listSummaries).toHaveBeenCalledTimes(1);
+      expect(skillManager.findByName).toHaveBeenCalledTimes(2);
+      expect(memoryManager.findByName).toHaveBeenCalledTimes(1);
+      expect(skillManager.list).not.toHaveBeenCalled();
+      expect(memoryManager.list).not.toHaveBeenCalled();
+      expect(result.filter((element) => element.name === 'policy-skill')).toHaveLength(1);
+      expect(result.filter((element) => element.name === 'policy-memory')).toHaveLength(1);
+      expect(result).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: 'ordinary-skill' }),
+      ]));
+    });
+
+    it('coalesces concurrent active-policy snapshots', async () => {
+      let releaseEnsembles!: () => void;
+      const ensemblesBlocked = new Promise<void>((resolve) => {
+        releaseEnsembles = resolve;
+      });
+      ensembleManager.getActiveEnsembles.mockImplementation(async () => {
+        await ensemblesBlocked;
+        return [];
+      });
+
+      const snapshots = [
+        handler.getActiveElementsForPolicy(),
+        handler.getActiveElementsForPolicy(),
+        handler.getActiveElementsForPolicy(),
+      ];
+      releaseEnsembles();
+      await Promise.all(snapshots);
+
+      expect(personaHandler.getActivePersonas).toHaveBeenCalledTimes(1);
+      expect(skillManager.getActiveSkills).toHaveBeenCalledTimes(1);
+      expect(agentManager.getActiveAgents).toHaveBeenCalledTimes(1);
+      expect(ensembleManager.getActiveEnsembles).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps large ensemble policy scans linear in unique member count', async () => {
+      const members = Array.from({ length: 500 }, (_, index) => ({
+        element_type: index % 2 === 0 ? 'skill' : 'skills',
+        element_name: `member-${index % 250}`,
+      }));
+      ensembleManager.getActiveEnsembles.mockResolvedValue([{
+        metadata: { name: 'large-ensemble', elements: members },
+      } as any]);
+      skillManager.list = jest.fn();
+      skillManager.listSummaries = jest.fn().mockResolvedValue([]);
+      skillManager.findByName = jest.fn().mockResolvedValue(undefined);
+
+      await handler.getActiveElementsForPolicy();
+
+      expect(skillManager.listSummaries).toHaveBeenCalledTimes(1);
+      expect(skillManager.findByName).toHaveBeenCalledTimes(250);
+      expect(skillManager.list).not.toHaveBeenCalled();
+    });
+
     it('merges persisted activation snapshots into reportable policy elements', async () => {
       const activationStore = {
         isEnabled: jest.fn().mockReturnValue(true),

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -376,6 +376,47 @@ describe('ElementCRUDHandler (DI)', () => {
       expect(skillManager.list).not.toHaveBeenCalled();
     });
 
+    it('resolves unique ensemble members concurrently with a bounded I/O ceiling', async () => {
+      const members = Array.from({ length: 20 }, (_, index) => ({
+        element_type: 'skill',
+        element_name: `member-${index}`,
+      }));
+      ensembleManager.getActiveEnsembles.mockResolvedValue([{
+        metadata: { name: 'concurrent-ensemble', elements: members },
+      } as any]);
+      skillManager.refreshIndex = jest.fn().mockResolvedValue(undefined);
+
+      let inFlight = 0;
+      let maxInFlight = 0;
+      let releaseLookups!: () => void;
+      let markCeilingReached!: () => void;
+      const lookupsBlocked = new Promise<void>((resolve) => {
+        releaseLookups = resolve;
+      });
+      const ceilingReached = new Promise<void>((resolve) => {
+        markCeilingReached = resolve;
+      });
+      skillManager.findByName = jest.fn(async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        if (maxInFlight === 8) markCeilingReached();
+        await lookupsBlocked;
+        inFlight--;
+        return undefined;
+      });
+
+      const snapshot = handler.getActiveElementsForPolicy();
+      await ceilingReached;
+
+      expect(skillManager.findByName).toHaveBeenCalledTimes(8);
+      expect(maxInFlight).toBe(8);
+      releaseLookups();
+      await snapshot;
+
+      expect(skillManager.findByName).toHaveBeenCalledTimes(20);
+      expect(maxInFlight).toBe(8);
+    });
+
     it('merges persisted activation snapshots into reportable policy elements', async () => {
       const activationStore = {
         isEnabled: jest.fn().mockReturnValue(true),

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -162,8 +162,11 @@ describe('ElementCRUDHandler (DI)', () => {
     const activationStore = {
       recordDeactivation: jest.fn(),
     } as unknown as jest.Mocked<ActivationStore>;
-    agentManager.getStableActivationFilename.mockResolvedValue('stable-agent.md');
-    agentManager.deactivateAgent.mockResolvedValue({ success: true, message: 'deactivated' });
+    agentManager.deactivateAgent.mockResolvedValue({
+      success: true,
+      message: 'deactivated',
+      filename: 'stable-agent.md',
+    });
     const handlerWithPersistence = new ElementCRUDHandler(
       skillManager,
       templateManager,
@@ -188,6 +191,60 @@ describe('ElementCRUDHandler (DI)', () => {
       'Renamed Agent',
       'stable-agent.md',
     );
+    expect(agentManager.getStableActivationFilename).not.toHaveBeenCalled();
+  });
+
+  it('preserves stable identities for colliding persisted agent policies', async () => {
+    const activationStore = {
+      isEnabled: jest.fn().mockReturnValue(true),
+      getSessionId: jest.fn().mockReturnValue('leader-session'),
+      listPersistedActivationStates: jest.fn().mockResolvedValue([{
+        sessionId: 'session-other',
+        lastUpdated: new Date().toISOString(),
+        activations: {
+          agent: [
+            { name: 'First Agent', filename: 'first-agent.md', activatedAt: new Date().toISOString() },
+            { name: 'Second Agent', filename: 'second-agent.md', activatedAt: new Date().toISOString() },
+          ],
+        },
+      }]),
+    } as unknown as jest.Mocked<ActivationStore>;
+    agentManager.refreshIndex = jest.fn().mockResolvedValue(undefined);
+    agentManager.findByFilename = jest.fn(async (filename: string) => ({
+      metadata: {
+        name: 'Colliding Agent',
+        gatekeeper: {
+          externalRestrictions: filename === 'first-agent.md'
+            ? { denyPatterns: ['Bash:rm*'] }
+            : { confirmPatterns: ['Bash:git push*'] },
+        },
+      },
+    } as any));
+    const reportHandler = new ElementCRUDHandler(
+      skillManager,
+      templateManager,
+      templateRenderer,
+      agentManager,
+      memoryManager,
+      ensembleManager,
+      personaHandler,
+      portfolioManager,
+      initService,
+      indicatorService,
+      fileOperations,
+      undefined as any,
+      undefined as any,
+      activationStore,
+    );
+
+    const result = await reportHandler.getPolicyElementsForReport('session-other');
+
+    expect(result).toHaveLength(2);
+    expect(result.map(element => element.metadata.gatekeeper)).toEqual([
+      { externalRestrictions: { denyPatterns: ['Bash:rm*'] } },
+      { externalRestrictions: { confirmPatterns: ['Bash:git push*'] } },
+    ]);
+    expect(agentManager.findByFilename).toHaveBeenCalledTimes(2);
   });
 
   it('ensures initialization and delegates to skill manager for create', async () => {

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -158,6 +158,38 @@ describe('ElementCRUDHandler (DI)', () => {
     );
   });
 
+  it('removes a renamed agent activation by stable filename', async () => {
+    const activationStore = {
+      recordDeactivation: jest.fn(),
+    } as unknown as jest.Mocked<ActivationStore>;
+    agentManager.getStableActivationFilename.mockResolvedValue('stable-agent.md');
+    agentManager.deactivateAgent.mockResolvedValue({ success: true, message: 'deactivated' });
+    const handlerWithPersistence = new ElementCRUDHandler(
+      skillManager,
+      templateManager,
+      templateRenderer,
+      agentManager,
+      memoryManager,
+      ensembleManager,
+      personaHandler,
+      portfolioManager,
+      initService,
+      indicatorService,
+      fileOperations,
+      undefined as any,
+      undefined as any,
+      activationStore,
+    );
+
+    await handlerWithPersistence.deactivateElement('Renamed Agent', ElementType.AGENT);
+
+    expect(activationStore.recordDeactivation).toHaveBeenCalledWith(
+      ElementType.AGENT,
+      'Renamed Agent',
+      'stable-agent.md',
+    );
+  });
+
   it('ensures initialization and delegates to skill manager for create', async () => {
     skillManager.create.mockResolvedValue({ metadata: { name: 'created' } } as any);
 

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -817,5 +817,22 @@ describe('ElementCRUDHandler (DI)', () => {
       expect(fileOperations.createDirectory).toHaveBeenCalled();
       expect(fileOperations.writeFile).toHaveBeenCalled();
     });
+
+    it('deactivates filename-distinct agents even when their display names collide', async () => {
+      agentManager.getActiveAgents.mockResolvedValue([
+        { filename: 'first-agent.md', metadata: { name: 'colliding-name' } } as any,
+        { filename: 'second-agent.md', metadata: { name: 'colliding-name' } } as any,
+      ]);
+
+      const result = await handler.releaseDeadlock();
+
+      expect(agentManager.deactivateAgent).toHaveBeenNthCalledWith(1, 'first-agent.md');
+      expect(agentManager.deactivateAgent).toHaveBeenNthCalledWith(2, 'second-agent.md');
+      expect(result.activeBeforeReset).toEqual([
+        { type: ElementType.AGENT, name: 'colliding-name' },
+        { type: ElementType.AGENT, name: 'colliding-name' },
+      ]);
+      expect(result.deactivated).toHaveLength(2);
+    });
   });
 });

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -433,18 +433,18 @@ describe('ElementCRUDHandler (DI)', () => {
       } as unknown as jest.Mocked<ActivationStore>;
 
       skillManager.getActiveSkills = jest.fn().mockResolvedValue([]);
-      skillManager.list = jest.fn().mockResolvedValue([
-        {
-          metadata: {
-            name: 'audit-trace-demo',
-            gatekeeper: {
-              externalRestrictions: {
-                confirmPatterns: ['Bash:git push*'],
-              },
+      skillManager.list = jest.fn();
+      skillManager.refreshIndex = jest.fn().mockResolvedValue(undefined);
+      skillManager.findByName = jest.fn().mockResolvedValue({
+        metadata: {
+          name: 'audit-trace-demo',
+          gatekeeper: {
+            externalRestrictions: {
+              confirmPatterns: ['Bash:git push*'],
             },
           },
-        } as any,
-      ]);
+        },
+      } as any);
 
       const reportHandler = new ElementCRUDHandler(
         skillManager,
@@ -473,6 +473,9 @@ describe('ElementCRUDHandler (DI)', () => {
         }),
       ]);
       expect(activationStore.listPersistedActivationStates).toHaveBeenCalledWith('session-other');
+      expect(skillManager.refreshIndex).toHaveBeenCalledTimes(1);
+      expect(skillManager.findByName).toHaveBeenCalledWith('audit-trace-demo');
+      expect(skillManager.list).not.toHaveBeenCalled();
     });
 
     it('does not leak the current session in-memory policies into another session report', async () => {
@@ -502,28 +505,33 @@ describe('ElementCRUDHandler (DI)', () => {
           },
         } as any,
       ]);
-      skillManager.list = jest.fn().mockResolvedValue([
-        {
-          metadata: {
-            name: 'audit-trace-demo',
-            gatekeeper: {
-              externalRestrictions: {
-                confirmPatterns: ['Bash:git push*'],
+      skillManager.list = jest.fn();
+      skillManager.refreshIndex = jest.fn().mockResolvedValue(undefined);
+      skillManager.findByName = jest.fn(async (name: string) => {
+        const elements = [
+          {
+            metadata: {
+              name: 'audit-trace-demo',
+              gatekeeper: {
+                externalRestrictions: {
+                  confirmPatterns: ['Bash:git push*'],
+                },
               },
             },
           },
-        } as any,
-        {
-          metadata: {
-            name: 'leader-only-skill',
-            gatekeeper: {
-              externalRestrictions: {
-                denyPatterns: ['Bash:rm*'],
+          {
+            metadata: {
+              name: 'leader-only-skill',
+              gatekeeper: {
+                externalRestrictions: {
+                  denyPatterns: ['Bash:rm*'],
+                },
               },
             },
           },
-        } as any,
-      ]);
+        ];
+        return elements.find((element) => element.metadata.name === name) as any;
+      });
 
       const reportHandler = new ElementCRUDHandler(
         skillManager,
@@ -550,6 +558,9 @@ describe('ElementCRUDHandler (DI)', () => {
           sessionIds: ['session-other'],
         }),
       ]);
+      expect(skillManager.refreshIndex).toHaveBeenCalledTimes(1);
+      expect(skillManager.findByName).toHaveBeenCalledTimes(1);
+      expect(skillManager.list).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -361,6 +361,7 @@ describe('ElementCRUDHandler (DI)', () => {
 
       await enforcementSnapshot;
       expect(ensembleManager.getActiveEnsembles).toHaveBeenCalledTimes(2);
+      expect(agentManager.getActiveAgents).toHaveBeenCalledWith({ freshAfterInFlight: true });
       releaseDashboard();
       await dashboardSnapshot;
     });

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -275,10 +275,10 @@ describe('ElementCRUDHandler (DI)', () => {
         ['ordinary-skill', { metadata: { name: 'ordinary-skill' } }],
       ]);
       skillManager.list = jest.fn();
-      skillManager.listSummaries = jest.fn().mockResolvedValue([]);
+      skillManager.refreshIndex = jest.fn().mockResolvedValue(undefined);
       skillManager.findByName = jest.fn(async (name: string) => skillsByName.get(name));
       memoryManager.list = jest.fn();
-      memoryManager.listSummaries = jest.fn().mockResolvedValue([]);
+      memoryManager.refreshIndex = jest.fn().mockResolvedValue(undefined);
       memoryManager.findByName = jest.fn().mockResolvedValue({
         metadata: {
           name: 'policy-memory',
@@ -288,8 +288,8 @@ describe('ElementCRUDHandler (DI)', () => {
 
       const result = await handler.getActiveElementsForPolicy();
 
-      expect(skillManager.listSummaries).toHaveBeenCalledTimes(1);
-      expect(memoryManager.listSummaries).toHaveBeenCalledTimes(1);
+      expect(skillManager.refreshIndex).toHaveBeenCalledTimes(1);
+      expect(memoryManager.refreshIndex).toHaveBeenCalledTimes(1);
       expect(skillManager.findByName).toHaveBeenCalledTimes(2);
       expect(memoryManager.findByName).toHaveBeenCalledTimes(1);
       expect(skillManager.list).not.toHaveBeenCalled();
@@ -325,6 +325,38 @@ describe('ElementCRUDHandler (DI)', () => {
       expect(ensembleManager.getActiveEnsembles).toHaveBeenCalledTimes(1);
     });
 
+    it('does not reuse an in-flight snapshot after activation state changes', async () => {
+      let markFirstSnapshotStarted!: () => void;
+      let releaseFirstSnapshot!: () => void;
+      const firstSnapshotStarted = new Promise<void>((resolve) => {
+        markFirstSnapshotStarted = resolve;
+      });
+      const firstSnapshotBlocked = new Promise<void>((resolve) => {
+        releaseFirstSnapshot = resolve;
+      });
+      ensembleManager.getActiveEnsembles
+        .mockImplementationOnce(async () => {
+          markFirstSnapshotStarted();
+          await firstSnapshotBlocked;
+          return [];
+        })
+        .mockResolvedValueOnce([]);
+      skillManager.activateSkill = jest.fn().mockResolvedValue({
+        success: true,
+        message: 'activated',
+      });
+
+      const beforeActivation = handler.getActiveElementsForPolicy();
+      await firstSnapshotStarted;
+      await handler.activateElement('new-policy-skill', 'skill');
+      const afterActivation = handler.getActiveElementsForPolicy();
+
+      await afterActivation;
+      expect(ensembleManager.getActiveEnsembles).toHaveBeenCalledTimes(2);
+      releaseFirstSnapshot();
+      await beforeActivation;
+    });
+
     it('keeps large ensemble policy scans linear in unique member count', async () => {
       const members = Array.from({ length: 500 }, (_, index) => ({
         element_type: index % 2 === 0 ? 'skill' : 'skills',
@@ -334,12 +366,12 @@ describe('ElementCRUDHandler (DI)', () => {
         metadata: { name: 'large-ensemble', elements: members },
       } as any]);
       skillManager.list = jest.fn();
-      skillManager.listSummaries = jest.fn().mockResolvedValue([]);
+      skillManager.refreshIndex = jest.fn().mockResolvedValue(undefined);
       skillManager.findByName = jest.fn().mockResolvedValue(undefined);
 
       await handler.getActiveElementsForPolicy();
 
-      expect(skillManager.listSummaries).toHaveBeenCalledTimes(1);
+      expect(skillManager.refreshIndex).toHaveBeenCalledTimes(1);
       expect(skillManager.findByName).toHaveBeenCalledTimes(250);
       expect(skillManager.list).not.toHaveBeenCalled();
     });

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -576,7 +576,7 @@ describe('ElementCRUDHandler (DI)', () => {
       expect(skillManager.list).not.toHaveBeenCalled();
     });
 
-    it('recovers a renamed persisted persona by its stable filename', async () => {
+    it('uses a persisted persona stable filename before a reused display name', async () => {
       const activationStore = {
         isEnabled: jest.fn().mockReturnValue(true),
         getSessionId: jest.fn().mockReturnValue('leader-session'),
@@ -594,7 +594,12 @@ describe('ElementCRUDHandler (DI)', () => {
       } as unknown as jest.Mocked<ActivationStore>;
 
       personaHandler.refreshIndex = jest.fn().mockResolvedValue(undefined);
-      personaHandler.findByName = jest.fn().mockResolvedValue(undefined);
+      personaHandler.findByName = jest.fn().mockResolvedValue({
+        metadata: {
+          name: 'Old Display Name',
+          gatekeeper: { externalRestrictions: { confirmPatterns: ['Bash:rm*'] } },
+        },
+      } as any);
       personaHandler.findByFilename = jest.fn().mockResolvedValue({
         metadata: {
           name: 'New Display Name',
@@ -622,8 +627,8 @@ describe('ElementCRUDHandler (DI)', () => {
       const result = await reportHandler.getPolicyElementsForReport('session-other');
 
       expect(personaHandler.refreshIndex).toHaveBeenCalledTimes(1);
-      expect(personaHandler.findByName).toHaveBeenCalledWith('Old Display Name');
       expect(personaHandler.findByFilename).toHaveBeenCalledWith('stable-persona.md');
+      expect(personaHandler.findByName).not.toHaveBeenCalled();
       expect(result).toEqual([
         expect.objectContaining({
           type: 'persona',

--- a/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
+++ b/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
@@ -1769,6 +1769,8 @@ describe('MCPAQLHandler', () => {
       const result = await enforcingHandler.handleRead(input);
       // list_elements should be denied by the active persona's policy
       expect(result.success).toBe(false);
+      expect(enforcingRegistry.elementCRUD.getActiveElementsForPolicy)
+        .toHaveBeenCalledWith({ allowCoalescing: false });
     });
 
     it('confirm_operation should be auto-approved (no infinite loop)', async () => {

--- a/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
+++ b/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
@@ -472,7 +472,10 @@ describe('MCPAQLHandler', () => {
       });
 
       expect(result.success).toBe(true);
-      expect(mockRegistry.elementCRUD.getPolicyElementsForReport).toHaveBeenCalledWith('session-follower-1');
+      expect(mockRegistry.elementCRUD.getPolicyElementsForReport).toHaveBeenCalledWith(
+        'session-follower-1',
+        { allowCoalescing: false },
+      );
     });
   });
 

--- a/tests/unit/services/ActivationStore.test.ts
+++ b/tests/unit/services/ActivationStore.test.ts
@@ -301,6 +301,29 @@ describe('ActivationStore', () => {
       expect(activations[0].filename).toBe('creative-dev-abc.md');
     });
 
+    it('should store stable filenames for agents', () => {
+      store.recordActivation('agent', 'Renamed Agent', 'stable-agent.md');
+
+      expect(store.getActivations('agent')).toEqual([
+        expect.objectContaining({
+          name: 'Renamed Agent',
+          filename: 'stable-agent.md',
+        }),
+      ]);
+    });
+
+    it('should upgrade a legacy name-only activation with its stable filename', () => {
+      store.recordActivation('agent', 'Renamed Agent');
+      store.recordActivation('agent', 'Renamed Agent', 'stable-agent.md');
+
+      expect(store.getActivations('agent')).toEqual([
+        expect.objectContaining({
+          name: 'Renamed Agent',
+          filename: 'stable-agent.md',
+        }),
+      ]);
+    });
+
     it('should not include filename field for non-persona types', () => {
       store.recordActivation('skill', 'my-skill');
 

--- a/tests/unit/services/ActivationStore.test.ts
+++ b/tests/unit/services/ActivationStore.test.ts
@@ -464,6 +464,20 @@ describe('ActivationStore', () => {
 
       expect(store.getActivations('agent')).toHaveLength(0);
     });
+
+    it('should preserve filename-distinct agents with colliding display names', () => {
+      store.recordActivation('agent', 'Colliding Agent', 'first-agent.md');
+      store.recordActivation('agent', 'Colliding Agent', 'second-agent.md');
+
+      store.recordDeactivation('agent', 'Colliding Agent', 'second-agent.md');
+
+      expect(store.getActivations('agent')).toEqual([
+        expect.objectContaining({
+          name: 'Colliding Agent',
+          filename: 'first-agent.md',
+        }),
+      ]);
+    });
   });
 
   describe('removeStaleActivation()', () => {

--- a/tests/unit/services/ActivationStore.test.ts
+++ b/tests/unit/services/ActivationStore.test.ts
@@ -324,6 +324,16 @@ describe('ActivationStore', () => {
       ]);
     });
 
+    it('should keep filename-distinct agents with colliding display names', () => {
+      store.recordActivation('agent', 'Colliding Agent', 'first-agent.md');
+      store.recordActivation('agent', 'Colliding Agent', 'second-agent.md');
+
+      expect(store.getActivations('agent')).toEqual([
+        expect.objectContaining({ filename: 'first-agent.md' }),
+        expect.objectContaining({ filename: 'second-agent.md' }),
+      ]);
+    });
+
     it('should not include filename field for non-persona types', () => {
       store.recordActivation('skill', 'my-skill');
 
@@ -437,6 +447,22 @@ describe('ActivationStore', () => {
 
       store.recordDeactivation('skill', 'Café Skill');
       expect(store.getActivations('skill')).toHaveLength(0);
+    });
+
+    it('should deactivate a renamed agent by stable filename', () => {
+      store.recordActivation('agent', 'Pre-Rename Agent', 'stable-agent.md');
+
+      store.recordDeactivation('agent', 'Renamed Agent', 'stable-agent.md');
+
+      expect(store.getActivations('agent')).toHaveLength(0);
+    });
+
+    it('should accept the stable filename as the deactivation identifier', () => {
+      store.recordActivation('agent', 'Pre-Rename Agent', 'stable-agent.md');
+
+      store.recordDeactivation('agent', 'stable-agent.md');
+
+      expect(store.getActivations('agent')).toHaveLength(0);
     });
   });
 

--- a/tests/unit/services/PolicyExportService.test.ts
+++ b/tests/unit/services/PolicyExportService.test.ts
@@ -91,6 +91,51 @@ describe('PolicyExportService', () => {
       expect(getActiveElementsForPolicy).toHaveBeenCalledTimes(2);
     });
 
+    it('keeps a settlement-race caller pending until its trailing export finishes', async () => {
+      const service = createServiceWithDir(policyDir);
+      let releaseFirstDrain!: () => void;
+      let releaseTrailingDrain!: () => void;
+      let markTrailingDrainStarted!: () => void;
+      const firstDrainBlocked = new Promise<void>((resolve) => {
+        releaseFirstDrain = resolve;
+      });
+      const trailingDrainBlocked = new Promise<void>((resolve) => {
+        releaseTrailingDrain = resolve;
+      });
+      const trailingDrainStarted = new Promise<void>((resolve) => {
+        markTrailingDrainStarted = resolve;
+      });
+      const drainExports = jest.spyOn(service as any, 'drainExports')
+        .mockImplementationOnce(async () => {
+          (service as any).exportQueued = false;
+          await firstDrainBlocked;
+        })
+        .mockImplementationOnce(async () => {
+          (service as any).exportQueued = false;
+          markTrailingDrainStarted();
+          await trailingDrainBlocked;
+        });
+
+      const first = service.exportPolicies();
+      releaseFirstDrain();
+      // Queue after the first drain is resolved but before runExportLoop's
+      // continuation clears the in-flight promise.
+      const settlementRaceRequest = service.exportPolicies();
+      let requestSettled = false;
+      void settlementRaceRequest.then(() => {
+        requestSettled = true;
+      });
+
+      await trailingDrainStarted;
+      await Promise.resolve();
+      expect(requestSettled).toBe(false);
+
+      releaseTrailingDrain();
+      await Promise.all([first, settlementRaceRequest]);
+      expect(requestSettled).toBe(true);
+      expect(drainExports).toHaveBeenCalledTimes(2);
+    });
+
     it('should produce valid schema v1.0 structure', async () => {
       const service = createServiceWithDir(policyDir);
       await service.exportPolicies();

--- a/tests/unit/services/PolicyExportService.test.ts
+++ b/tests/unit/services/PolicyExportService.test.ts
@@ -11,7 +11,7 @@
  * Uses a real temp directory to avoid ESM mocking complexity.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import { PolicyExportService, type PolicyExportDeps } from '../../../src/services/PolicyExportService.js';
 import { getStaticPolicyData } from '../../../src/handlers/mcp-aql/policies/ToolClassification.js';
 import * as fs from 'node:fs/promises';
@@ -34,44 +34,7 @@ function createMockDeps(overrides: Partial<PolicyExportDeps> = {}): PolicyExport
  * instead of the real bridge imports path.
  */
 function createServiceWithDir(dir: string, deps: Partial<PolicyExportDeps> = {}): PolicyExportService {
-  const service = new PolicyExportService(createMockDeps(deps));
-  // Override the private POLICY_DIR via a subclass to test with temp dir
-  // We access the internal method through the public API and override writeFile path
-  // by monkey-patching exportPolicies to use our test dir
-  service.exportPolicies = async () => {
-    // Temporarily replace the module-level constants by overriding the method
-    const staticRules = getStaticPolicyData();
-    const activeElements = await createMockDeps(deps).getActiveElementsForPolicy();
-    const version = createMockDeps(deps).getServerVersion();
-
-    const elementPolicies = (service as any).buildElementPolicies(activeElements);
-
-    const policy = {
-      schema_version: '1.0',
-      server: {
-        name: 'DollhouseMCP-V2-Refactor CRUDE',
-        version,
-      },
-      exported_at: new Date().toISOString(),
-      static_rules: {
-        safe_tools: staticRules.safe_tools,
-        safe_bash_patterns: staticRules.safe_bash_patterns,
-        dangerous_bash_patterns: staticRules.dangerous_bash_patterns,
-        blocked_bash_patterns: staticRules.blocked_bash_patterns,
-        irreversible_patterns: staticRules.irreversible_patterns,
-        sensitive_path_prefixes: staticRules.sensitive_path_prefixes,
-        gatekeeper_essential_operations: staticRules.gatekeeper_essential_operations,
-        safe_mcp_operations: staticRules.safe_mcp_operations,
-      },
-      element_policies: elementPolicies,
-      risk_scores: staticRules.risk_scores,
-    };
-
-    const filePath = path.join(dir, 'dollhousemcp-crude-policies.json');
-    await fs.writeFile(filePath, JSON.stringify(policy, null, 2), 'utf-8');
-  };
-
-  return service;
+  return new PolicyExportService(createMockDeps(deps), dir);
 }
 
 async function readPolicyFile(): Promise<Record<string, any>> {
@@ -91,11 +54,41 @@ describe('PolicyExportService', () => {
 
   describe('exportPolicies', () => {
     it('should skip silently when bridge directory does not exist', async () => {
-      // Use the real service pointing at real (non-existent) path
-      // This verifies the access() check works
-      const service = new PolicyExportService(createMockDeps());
+      const service = new PolicyExportService(createMockDeps(), path.join(testDir, 'missing'));
       // If bridge dir doesn't exist, this should not throw
       await expect(service.exportPolicies()).resolves.toBeUndefined();
+    });
+
+    it('coalesces overlapping requests and runs one trailing export for newer state', async () => {
+      let releaseFirstSnapshot!: () => void;
+      let markFirstSnapshotStarted!: () => void;
+      const firstSnapshotBlocked = new Promise<void>((resolve) => {
+        releaseFirstSnapshot = resolve;
+      });
+      const firstSnapshotStarted = new Promise<void>((resolve) => {
+        markFirstSnapshotStarted = resolve;
+      });
+      let snapshotCount = 0;
+      const getActiveElementsForPolicy = jest.fn(async () => {
+        snapshotCount += 1;
+        if (snapshotCount === 1) {
+          markFirstSnapshotStarted();
+          await firstSnapshotBlocked;
+        }
+        return [];
+      });
+      const service = createServiceWithDir(policyDir, { getActiveElementsForPolicy });
+
+      const first = service.exportPolicies();
+      const second = service.exportPolicies();
+      const third = service.exportPolicies();
+      await firstSnapshotStarted;
+      expect(getActiveElementsForPolicy).toHaveBeenCalledTimes(1);
+
+      releaseFirstSnapshot();
+      await Promise.all([first, second, third]);
+
+      expect(getActiveElementsForPolicy).toHaveBeenCalledTimes(2);
     });
 
     it('should produce valid schema v1.0 structure', async () => {

--- a/tests/unit/storage/ElementStorageLayer.test.ts
+++ b/tests/unit/storage/ElementStorageLayer.test.ts
@@ -133,6 +133,47 @@ describe('ElementStorageLayer', () => {
       // Backend should only be called once
       expect(backend.listFiles).toHaveBeenCalledTimes(1);
     });
+
+    it('runs a trailing scan for freshness-sensitive callers', async () => {
+      await layer.scan();
+      layer.invalidate();
+
+      let markOlderScanStarted!: () => void;
+      let releaseOlderScan!: () => void;
+      const olderScanStarted = new Promise<void>((resolve) => {
+        markOlderScanStarted = resolve;
+      });
+      const olderScanBlocked = new Promise<void>((resolve) => {
+        releaseOlderScan = resolve;
+      });
+      (backend.statMany as jest.Mock<any>)
+        .mockImplementationOnce(async () => {
+          markOlderScanStarted();
+          await olderScanBlocked;
+          return new Map([
+            ['alpha.md', makeMeta('alpha.md', 1000)],
+            ['beta.md', makeMeta('beta.md', 2000)],
+          ]);
+        })
+        .mockResolvedValue(new Map([
+          ['alpha.md', makeMeta('alpha.md', 1000)],
+          ['beta.md', makeMeta('beta.md', 5000)],
+        ]));
+      (backend.readFile as jest.Mock<any>).mockImplementation((absPath: string) => {
+        if (absPath.includes('alpha')) return Promise.resolve(makeContent('Alpha', 'Alpha desc'));
+        if (absPath.includes('beta')) return Promise.resolve(makeContent('Beta Updated', 'New desc'));
+        return Promise.resolve(makeContent('Unknown'));
+      });
+
+      const olderScan = layer.scan();
+      await olderScanStarted;
+      const freshScan = layer.scan({ freshAfterInFlight: true });
+      releaseOlderScan();
+      await Promise.all([olderScan, freshScan]);
+
+      expect(backend.listFiles).toHaveBeenCalledTimes(3);
+      expect(layer.getPathByName('Beta Updated')).toBe('beta.md');
+    });
   });
 
   describe('change detection', () => {

--- a/tests/unit/storage/ElementStorageLayer.test.ts
+++ b/tests/unit/storage/ElementStorageLayer.test.ts
@@ -152,7 +152,7 @@ describe('ElementStorageLayer', () => {
           await olderScanBlocked;
           return new Map([
             ['alpha.md', makeMeta('alpha.md', 1000)],
-            ['beta.md', makeMeta('beta.md', 2000)],
+            ['beta.md', makeMeta('beta.md', 5000)],
           ]);
         })
         .mockResolvedValue(new Map([
@@ -169,9 +169,10 @@ describe('ElementStorageLayer', () => {
       await olderScanStarted;
       const freshScan = layer.scan({ freshAfterInFlight: true });
       releaseOlderScan();
-      await Promise.all([olderScan, freshScan]);
+      const [, freshDiff] = await Promise.all([olderScan, freshScan]);
 
       expect(backend.listFiles).toHaveBeenCalledTimes(3);
+      expect(freshDiff.modified).toContain('beta.md');
       expect(layer.getPathByName('Beta Updated')).toBe('beta.md');
     });
   });

--- a/tests/unit/storage/MemoryStorageLayer.test.ts
+++ b/tests/unit/storage/MemoryStorageLayer.test.ts
@@ -270,6 +270,36 @@ describe('MemoryStorageLayer', () => {
       expect(d1).toBe(d2);
       expect(d2).toBe(d3);
     });
+
+    it('runs a trailing scan for a freshness-sensitive caller', async () => {
+      await layer.scan();
+      (backend.directoryExists as jest.Mock<any>).mockClear();
+      layer.invalidate();
+
+      let markOlderScanStarted!: () => void;
+      let releaseOlderScan!: () => void;
+      const olderScanStarted = new Promise<void>((resolve) => {
+        markOlderScanStarted = resolve;
+      });
+      const olderScanBlocked = new Promise<void>((resolve) => {
+        releaseOlderScan = resolve;
+      });
+      (backend.directoryExists as jest.Mock<any>)
+        .mockImplementationOnce(async () => {
+          markOlderScanStarted();
+          await olderScanBlocked;
+          return true;
+        })
+        .mockResolvedValue(true);
+
+      const olderScan = layer.scan();
+      await olderScanStarted;
+      const freshScan = layer.scan({ freshAfterInFlight: true });
+      releaseOlderScan();
+      await Promise.all([olderScan, freshScan]);
+
+      expect(backend.directoryExists).toHaveBeenCalledTimes(2);
+    });
   });
 
   // ----------------------------------------------------------------

--- a/tests/unit/storage/MemoryStorageLayer.test.ts
+++ b/tests/unit/storage/MemoryStorageLayer.test.ts
@@ -291,14 +291,18 @@ describe('MemoryStorageLayer', () => {
           return true;
         })
         .mockResolvedValue(true);
+      (backend.statMany as jest.Mock<any>).mockResolvedValue(new Map([
+        ['system/baseline.yaml', makeMeta('system/baseline.yaml', 2000)],
+      ]));
 
       const olderScan = layer.scan();
       await olderScanStarted;
       const freshScan = layer.scan({ freshAfterInFlight: true });
       releaseOlderScan();
-      await Promise.all([olderScan, freshScan]);
+      const [, freshDiff] = await Promise.all([olderScan, freshScan]);
 
       expect(backend.directoryExists).toHaveBeenCalledTimes(2);
+      expect(freshDiff.modified).toContain('system/baseline.yaml');
     });
   });
 


### PR DESCRIPTION
## Summary

Synchronizes the released v2.0.41 `main` history into `develop` with a two-parent merge commit.

- preserves the complete `main` ancestry through `5b0050bfc9f2dc42e114f61c80604f7bd1344d84`, including hotfix merge `60002c1d4518335916390b78f4e0ee3f088ed1db`
- preserves the complete pre-existing `develop` ancestry through `8fb70780645e0c701844e535314b5efaff310df2`
- advances the develop baseline consistently to `2.0.41`
- retains develop-only behavior, including the publish-channel guard and concurrent-abort protection
- does not alter or target `beta`

The merge was conflict-free. Its tree exactly matches the independently generated `git merge-tree --write-tree origin/develop origin/main` preview (`2d0fecfdb06669b09f9c180dfcdd0e337028a5f4`).

## Local verification

- focused hotfix/regression set: 10 suites, 412 tests passed
- build: passed
- lint: passed
- script typecheck: passed
- repository security audit: passed, 0 findings across 231 files
- package asset verification: passed
- npm tarball dry-run: passed for `@dollhousemcp/mcp-server@2.0.41`
- full Jest run: 398 suites / 10,537 tests passed; two local-harness failures remain for protected CI to adjudicate:
  - a machine-load-sensitive 250 ms timing assertion measured approximately 633 ms, including when isolated
  - a path-security test assumes `.git` is a directory, while this dedicated Git worktree correctly represents `.git` as a file

Closes #2626
