### PR TITLE
[BETA HOTFIX 1/3] Bound active-policy freshness and export ordering

### DIFF
--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -50,7 +50,7 @@ import {
   createExecutionContext,
 } from './safetyTierService.js';
 import { BaseElementManager, ElementManagerDeps } from '../base/BaseElementManager.js';
-import { isWritableStorageLayer } from '../../storage/IStorageLayer.js';
+import { isWritableStorageLayer, type StorageScanOptions } from '../../storage/IStorageLayer.js';
 import {
   AGENT_STATE_MAX_YAML_SIZE,
   AgentStateReductionRequiredError,
@@ -1020,9 +1020,14 @@ export class AgentManager extends BaseElementManager<Agent> {
   /**
    * Get all active agents
    */
-  async getActiveAgents(): Promise<Agent[]> {
-    const agents = await this.list();
-    return agents.filter(a => this.getActivationSet().has(a.metadata.name));
+  async getActiveAgents(options: StorageScanOptions = {}): Promise<Agent[]> {
+    await this.scanAndEvict(options);
+    const agents: Agent[] = [];
+    for (const name of this.getActivationSet()) {
+      const agent = await this.findByName(name);
+      if (agent) agents.push(agent);
+    }
+    return agents;
   }
 
   /**

--- a/src/elements/base/BaseElementManager.ts
+++ b/src/elements/base/BaseElementManager.ts
@@ -38,7 +38,11 @@ import type { FileWatchService } from '../../services/FileWatchService.js';
 import type { FileOperationsService } from '../../services/FileOperationsService.js';
 import type { ValidationRegistry } from '../../services/validation/ValidationRegistry.js';
 import { type ElementValidator } from '../../services/validation/ElementValidator.js';
-import { type IStorageLayer, isWritableStorageLayer } from '../../storage/IStorageLayer.js';
+import {
+  type IStorageLayer,
+  type StorageScanOptions,
+  isWritableStorageLayer,
+} from '../../storage/IStorageLayer.js';
 import type { IStorageLayerFactory } from '../../storage/IStorageLayerFactory.js';
 import type { ElementIndexEntry } from '../../storage/types.js';
 import {
@@ -639,8 +643,13 @@ export abstract class BaseElementManager<T extends IElement> implements IElement
    * Unlike list(), this does not load all elements — it only evicts stale ones.
    * Fixes #1895 (ensemble activation serving stale cached element list).
    */
-  protected async scanAndEvict(): Promise<void> {
-    return this._listOps.scanAndEvict();
+  protected async scanAndEvict(options?: StorageScanOptions): Promise<void> {
+    return this._listOps.scanAndEvict(options);
+  }
+
+  /** Refresh the storage index without loading the full element catalog. */
+  public async refreshIndex(options?: StorageScanOptions): Promise<void> {
+    return this._listOps.scanAndEvict(options);
   }
 
   // ============================================

--- a/src/elements/base/ElementListOperations.ts
+++ b/src/elements/base/ElementListOperations.ts
@@ -15,7 +15,11 @@ import { ElementType } from '../../portfolio/types.js';
 import { logger } from '../../utils/logger.js';
 import { PortfolioManager } from '../../portfolio/PortfolioManager.js';
 import { FileOperationsService } from '../../services/FileOperationsService.js';
-import { type IStorageLayer, isWritableStorageLayer } from '../../storage/IStorageLayer.js';
+import {
+  type IStorageLayer,
+  type StorageScanOptions,
+  isWritableStorageLayer,
+} from '../../storage/IStorageLayer.js';
 import type { ElementIndexEntry } from '../../storage/types.js';
 import type { ElementCache } from './ElementCache.js';
 import type { PublicElementDiscovery } from '../../collection/shared-pool/PublicElementDiscovery.js';
@@ -197,13 +201,15 @@ export class ElementListOperations<T extends IElement> {
    * Force a fresh disk scan and evict modified/removed cache entries.
    * Unlike list(), this does not load all elements — it only evicts stale ones.
    */
-  async scanAndEvict(): Promise<void> {
+  async scanAndEvict(options?: StorageScanOptions): Promise<void> {
     this.storageLayer.invalidate();
     try {
-      const diff = await this.storageLayer.scan();
+      const diff = await this.storageLayer.scan(options);
       for (const relPath of [...diff.modified, ...diff.removed]) {
-        const absPath = path.join(this.host.elementDir, relPath);
-        this.cache.uncacheByPath(absPath);
+        const cachePath = isWritableStorageLayer(this.storageLayer)
+          ? relPath
+          : path.join(this.host.elementDir, relPath);
+        this.cache.uncacheByPath(cachePath);
       }
     } catch { /* non-fatal — cache may be slightly stale, but activation proceeds */ }
   }

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -80,7 +80,26 @@ type PolicyIndexOptions = { freshAfterInFlight?: boolean };
 type IndexedPolicyManagers = Map<string, Promise<BaseElementManager<any> | undefined>>;
 type PolicyMemberCandidate = { type: string; name: string; key: string };
 
-const ACTIVE_POLICY_MEMBER_LOOKUP_CONCURRENCY = 8;
+const ACTIVE_POLICY_LOOKUP_CONCURRENCY = 8;
+
+async function mapPolicyLookups<TInput, TOutput>(
+  candidates: readonly TInput[],
+  lookup: (candidate: TInput, index: number) => Promise<TOutput>,
+): Promise<TOutput[]> {
+  const resolved = new Array<TOutput>(candidates.length);
+  let nextCandidateIndex = 0;
+
+  const resolveNext = async (): Promise<void> => {
+    while (nextCandidateIndex < candidates.length) {
+      const candidateIndex = nextCandidateIndex++;
+      resolved[candidateIndex] = await lookup(candidates[candidateIndex], candidateIndex);
+    }
+  };
+
+  const workerCount = Math.min(ACTIVE_POLICY_LOOKUP_CONCURRENCY, candidates.length);
+  await Promise.all(Array.from({ length: workerCount }, () => resolveNext()));
+  return resolved;
+}
 
 export class ElementCRUDHandler {
   private readonly strategies: Map<string, ElementActivationStrategy>;
@@ -582,37 +601,27 @@ export class ElementCRUDHandler {
     indexOptions: PolicyIndexOptions,
     indexedManagers: IndexedPolicyManagers,
   ): Promise<Array<PolicyElement | undefined>> {
-    const resolved = new Array<PolicyElement | undefined>(candidates.length);
     const memberLookups = new Map<string, Promise<PolicyMemberElement | undefined>>();
-    let nextCandidateIndex = 0;
-
-    const resolveNext = async (): Promise<void> => {
-      while (nextCandidateIndex < candidates.length) {
-        const candidateIndex = nextCandidateIndex++;
-        const candidate = candidates[candidateIndex];
-        try {
-          const found = await this.findPolicyMember(
-            candidate,
-            indexedManagers,
-            memberLookups,
-            indexOptions,
-          );
-          if (found?.metadata?.['gatekeeper']) {
-            resolved[candidateIndex] = {
-              type: this.toPolicyElementType(candidate.type),
-              name: candidate.name,
-              metadata: found.metadata,
-            };
-          }
-        } catch {
-          // A malformed or missing member must not break evaluation of others.
+    return mapPolicyLookups(candidates, async (candidate) => {
+      try {
+        const found = await this.findPolicyMember(
+          candidate,
+          indexedManagers,
+          memberLookups,
+          indexOptions,
+        );
+        if (found?.metadata?.['gatekeeper']) {
+          return {
+            type: this.toPolicyElementType(candidate.type),
+            name: candidate.name,
+            metadata: found.metadata,
+          };
         }
+      } catch {
+        // A malformed or missing member must not break evaluation of others.
       }
-    };
-
-    const workerCount = Math.min(ACTIVE_POLICY_MEMBER_LOOKUP_CONCURRENCY, candidates.length);
-    await Promise.all(Array.from({ length: workerCount }, () => resolveNext()));
-    return resolved;
+      return undefined;
+    });
   }
 
   private appendResolvedPolicyMembers(
@@ -953,24 +962,27 @@ export class ElementCRUDHandler {
     addElement: (element: { type: string; name: string; metadata: Record<string, unknown> }, sessionIds?: string[]) => void,
     findPersistedElement: (type: string, activation: PersistedActivation) => Promise<{ type: string; name: string; metadata: Record<string, unknown> } | null>,
   ): Promise<void> {
-    const pending: Promise<void>[] = [];
+    const candidates: Array<{ type: string; activation: PersistedActivation }> = [];
 
     for (const [type, activations] of Object.entries(state.activations)) {
       for (const activation of activations ?? []) {
-        pending.push((async () => {
-          const found = await findPersistedElement(type, activation);
-          if (found) {
-            addElement(found, [state.sessionId]);
-          }
-        })());
+        candidates.push({ type, activation });
       }
     }
 
-    if (pending.length === 0) {
-      return;
-    }
+    const resolved = await mapPolicyLookups(candidates, async (candidate) => {
+      try {
+        return await findPersistedElement(candidate.type, candidate.activation);
+      } catch {
+        // Match the previous allSettled behavior: one unreadable activation
+        // must not prevent other persisted policies from being reported.
+        return null;
+      }
+    });
 
-    await Promise.allSettled(pending);
+    for (const found of resolved) {
+      if (found) addElement(found, [state.sessionId]);
+    }
   }
 
   async deactivateElement(name: string, type: string) {

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -66,8 +66,25 @@ import {
   getGatekeeperDiagnostics,
 } from './mcp-aql/policies/ElementPolicies.js';
 
+type PolicyElement = {
+  type: string;
+  name: string;
+  metadata: Record<string, unknown>;
+};
+
+type PolicyMemberElement = {
+  metadata?: Record<string, unknown>;
+};
+
+type PolicyIndexOptions = { freshAfterInFlight?: boolean };
+type IndexedPolicyManagers = Map<string, Promise<BaseElementManager<any> | undefined>>;
+type PolicyMemberCandidate = { type: string; name: string; key: string };
+
+const ACTIVE_POLICY_MEMBER_LOOKUP_CONCURRENCY = 8;
+
 export class ElementCRUDHandler {
   private readonly strategies: Map<string, ElementActivationStrategy>;
+  private readonly activePolicySnapshots = new Map<string, Promise<PolicyElement[]>>();
 
   constructor(
     private readonly skillManager: SkillManager,
@@ -186,6 +203,8 @@ export class ElementCRUDHandler {
         return 'persona';
       case 'skills':
         return 'skill';
+      case 'templates':
+        return 'template';
       case 'agents':
         return 'agent';
       case 'memories':
@@ -195,6 +214,20 @@ export class ElementCRUDHandler {
       default:
         return normalizedType;
     }
+  }
+
+  private policyElementKey(type: string, name: string): string {
+    return `${this.toPolicyElementType(this.normalizeElementType(type))}:${this.normalizeLookupValue(name)}`;
+  }
+
+  private getPolicySnapshotScope(): string {
+    return this.contextTracker?.getSessionContext()?.sessionId
+      ?? this.getSessionActivationStore()?.getSessionId()
+      ?? 'default';
+  }
+
+  private invalidateActivePolicySnapshot(): void {
+    this.activePolicySnapshots.delete(this.getPolicySnapshotScope());
   }
 
   /**
@@ -323,6 +356,7 @@ export class ElementCRUDHandler {
       }
 
       const result = await strategy.activate(name, context);
+      this.invalidateActivePolicySnapshot();
 
       // Issue #598, #1946: Persist activation state for session restore (per-session)
       const sessionStore = this.getSessionActivationStore();
@@ -386,48 +420,102 @@ export class ElementCRUDHandler {
    *
    * Issue #452: Provides active element context for enforce() policy checks.
    */
-  async getActiveElementsForPolicy(): Promise<Array<{ type: string; name: string; metadata: Record<string, unknown> }>> {
-    const result: Array<{ type: string; name: string; metadata: Record<string, unknown> }> = [];
-    const seen = new Set<string>();
+  async getActiveElementsForPolicy(
+    options: { allowCoalescing?: boolean } = {},
+  ): Promise<PolicyElement[]> {
+    // Enforcement reads cannot join work that may have started before an
+    // external policy edit. Reporting callers may share overlapping snapshots.
+    if (options.allowCoalescing === false) {
+      return this.collectActiveElementsForPolicy({ freshAfterInFlight: true });
+    }
+
+    const scope = this.getPolicySnapshotScope();
+    const existing = this.activePolicySnapshots.get(scope);
+    if (existing) return existing;
+
+    const snapshot = this.collectActiveElementsForPolicy();
+    this.activePolicySnapshots.set(scope, snapshot);
 
     try {
-      // Active personas (sync)
-      const personas = this.personaManager.getActivePersonas();
-      for (const p of personas) {
-        const key = `persona:${p.metadata.name}`;
-        seen.add(key);
+      return await snapshot;
+    } finally {
+      if (this.activePolicySnapshots.get(scope) === snapshot) {
+        this.activePolicySnapshots.delete(scope);
+      }
+    }
+  }
+
+  private async collectActiveElementsForPolicy(
+    indexOptions: PolicyIndexOptions = {},
+  ): Promise<PolicyElement[]> {
+    await this.ensureInitialized();
+
+    const result: PolicyElement[] = [];
+    const seen = new Set<string>();
+    const indexedManagers: IndexedPolicyManagers = new Map();
+    const requiresFreshIndex = indexOptions.freshAfterInFlight === true;
+
+    if (requiresFreshIndex) {
+      await Promise.all([
+        this.getIndexedPolicyManager(ElementType.PERSONA, indexedManagers, indexOptions),
+        this.getIndexedPolicyManager(ElementType.SKILL, indexedManagers, indexOptions),
+        this.getIndexedPolicyManager(ElementType.ENSEMBLE, indexedManagers, indexOptions),
+      ]);
+    }
+
+    await this.appendActivePersonas(result, seen, requiresFreshIndex);
+    await this.appendActiveSkills(result, seen);
+    await this.appendActiveAgents(result, seen, indexOptions);
+    await this.appendActiveEnsembles(result, seen, indexOptions, indexedManagers);
+
+    return result;
+  }
+
+  private async appendActivePersonas(
+    result: PolicyElement[],
+    seen: Set<string>,
+    resolveFromStorage: boolean,
+  ): Promise<void> {
+    try {
+      const personas = resolveFromStorage
+        ? await this.personaManager.resolveActivePersonas()
+        : this.personaManager.getActivePersonas();
+      for (const persona of personas) {
+        seen.add(this.policyElementKey('persona', persona.metadata.name));
         result.push({
           type: 'persona',
-          name: p.metadata.name,
-          metadata: p.metadata as unknown as Record<string, unknown>,
+          name: persona.metadata.name,
+          metadata: persona.metadata as unknown as Record<string, unknown>,
         });
       }
     } catch (error) {
       logger.warn('Failed to gather active personas for policy evaluation', { error });
     }
+  }
 
+  private async appendActiveSkills(result: PolicyElement[], seen: Set<string>): Promise<void> {
     try {
-      // Active skills (async)
-      const skills = await this.skillManager.getActiveSkills();
-      for (const s of skills) {
-        const key = `skill:${s.metadata.name}`;
-        seen.add(key);
+      for (const skill of await this.skillManager.getActiveSkills()) {
+        seen.add(this.policyElementKey('skill', skill.metadata.name));
         result.push({
           type: 'skill',
-          name: s.metadata.name,
-          metadata: s.metadata as unknown as Record<string, unknown>,
+          name: skill.metadata.name,
+          metadata: skill.metadata as unknown as Record<string, unknown>,
         });
       }
     } catch (error) {
       logger.warn('Failed to gather active skills for policy evaluation', { error });
     }
+  }
 
+  private async appendActiveAgents(
+    result: PolicyElement[],
+    seen: Set<string>,
+    indexOptions: PolicyIndexOptions,
+  ): Promise<void> {
     try {
-      // Active agents (async)
-      const agents = await this.agentManager.getActiveAgents();
-      for (const agent of agents) {
-        const key = `agent:${agent.metadata.name}`;
-        seen.add(key);
+      for (const agent of await this.agentManager.getActiveAgents(indexOptions)) {
+        seen.add(this.policyElementKey('agent', agent.metadata.name));
         result.push({
           type: 'agent',
           name: agent.metadata.name,
@@ -437,53 +525,148 @@ export class ElementCRUDHandler {
     } catch (error) {
       logger.warn('Failed to gather active agents for policy evaluation', { error });
     }
+  }
 
+  private async appendActiveEnsembles(
+    result: PolicyElement[],
+    seen: Set<string>,
+    indexOptions: PolicyIndexOptions,
+    indexedManagers: IndexedPolicyManagers,
+  ): Promise<void> {
     try {
-      // Active ensembles (async)
       const ensembles = await this.ensembleManager.getActiveEnsembles();
-      for (const e of ensembles) {
-        const ensembleKey = `ensemble:${e.metadata.name}`;
-        seen.add(ensembleKey);
-        result.push({
-          type: 'ensemble',
-          name: e.metadata.name,
-          metadata: e.metadata as unknown as Record<string, unknown>,
-        });
-
-        // Issue #625 Phase 4: Resolve ensemble member gatekeeper policies
-        const members = (e.metadata as unknown as Record<string, unknown>)?.elements as
-          Array<{ element_name: string; element_type: string }> | undefined;
-        if (Array.isArray(members)) {
-          for (const member of members) {
-            const memberKey = `${member.element_type}:${member.element_name}`;
-            if (seen.has(memberKey)) continue; // Already active individually
-            try {
-              const memberElements = await this.getElements(member.element_type);
-              const found = (memberElements as Array<{ metadata: Record<string, unknown> }>).find(
-                el => (el?.metadata as Record<string, unknown>)?.name === member.element_name
-              );
-              if (found?.metadata && (found.metadata as Record<string, unknown>)?.gatekeeper) {
-                seen.add(memberKey);
-                result.push({
-                  type: member.element_type,
-                  name: member.element_name,
-                  metadata: found.metadata as Record<string, unknown>,
-                });
-              }
-            } catch {
-              // Non-fatal: skip member if element type lookup fails
-            }
-          }
-        }
-      }
+      const candidates = this.appendEnsemblesAndCollectMembers(ensembles, result, seen);
+      const resolvedMembers = await this.resolvePolicyMembers(candidates, indexOptions, indexedManagers);
+      this.appendResolvedPolicyMembers(resolvedMembers, result, seen);
     } catch (error) {
       logger.warn('Failed to gather active ensembles for policy evaluation', { error });
     }
-
-    return result;
   }
 
-  async getPolicyElementsForReport(sessionId?: string): Promise<Array<{
+  private appendEnsemblesAndCollectMembers(
+    ensembles: Awaited<ReturnType<EnsembleManager['getActiveEnsembles']>>,
+    result: PolicyElement[],
+    seen: Set<string>,
+  ): PolicyMemberCandidate[] {
+    const candidates: PolicyMemberCandidate[] = [];
+    const queuedMemberKeys = new Set<string>();
+
+    for (const ensemble of ensembles) {
+      seen.add(this.policyElementKey('ensemble', ensemble.metadata.name));
+      result.push({
+        type: 'ensemble',
+        name: ensemble.metadata.name,
+        metadata: ensemble.metadata as unknown as Record<string, unknown>,
+      });
+
+      const members = (ensemble.metadata as unknown as Record<string, unknown>)?.elements as
+        Array<{ element_name: string; element_type: string }> | undefined;
+      if (!Array.isArray(members)) continue;
+
+      for (const member of members) {
+        const normalizedType = this.normalizeElementType(member.element_type);
+        const normalizedName = this.normalizeLookupValue(member.element_name);
+        if (normalizedType === '' || normalizedName === '') continue;
+
+        const key = this.policyElementKey(normalizedType, normalizedName);
+        if (seen.has(key) || queuedMemberKeys.has(key)) continue;
+        queuedMemberKeys.add(key);
+        candidates.push({ type: normalizedType, name: normalizedName, key });
+      }
+    }
+    return candidates;
+  }
+
+  private async resolvePolicyMembers(
+    candidates: PolicyMemberCandidate[],
+    indexOptions: PolicyIndexOptions,
+    indexedManagers: IndexedPolicyManagers,
+  ): Promise<Array<PolicyElement | undefined>> {
+    const resolved = new Array<PolicyElement | undefined>(candidates.length);
+    const memberLookups = new Map<string, Promise<PolicyMemberElement | undefined>>();
+    let nextCandidateIndex = 0;
+
+    const resolveNext = async (): Promise<void> => {
+      while (nextCandidateIndex < candidates.length) {
+        const candidateIndex = nextCandidateIndex++;
+        const candidate = candidates[candidateIndex];
+        try {
+          const found = await this.findPolicyMember(
+            candidate,
+            indexedManagers,
+            memberLookups,
+            indexOptions,
+          );
+          if (found?.metadata?.['gatekeeper']) {
+            resolved[candidateIndex] = {
+              type: this.toPolicyElementType(candidate.type),
+              name: candidate.name,
+              metadata: found.metadata,
+            };
+          }
+        } catch {
+          // A malformed or missing member must not break evaluation of others.
+        }
+      }
+    };
+
+    const workerCount = Math.min(ACTIVE_POLICY_MEMBER_LOOKUP_CONCURRENCY, candidates.length);
+    await Promise.all(Array.from({ length: workerCount }, () => resolveNext()));
+    return resolved;
+  }
+
+  private appendResolvedPolicyMembers(
+    resolvedMembers: Array<PolicyElement | undefined>,
+    result: PolicyElement[],
+    seen: Set<string>,
+  ): void {
+    for (const resolved of resolvedMembers) {
+      if (!resolved) continue;
+      const key = this.policyElementKey(resolved.type, resolved.name);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      result.push(resolved);
+    }
+  }
+
+  private findPolicyMember(
+    candidate: PolicyMemberCandidate,
+    indexedManagers: IndexedPolicyManagers,
+    memberLookups: Map<string, Promise<PolicyMemberElement | undefined>>,
+    indexOptions: PolicyIndexOptions,
+  ): Promise<PolicyMemberElement | undefined> {
+    const existing = memberLookups.get(candidate.key);
+    if (existing) return existing;
+
+    const lookup = this.getIndexedPolicyManager(candidate.type, indexedManagers, indexOptions)
+      .then(async (manager) => manager
+        ? manager.findByName(candidate.name) as Promise<PolicyMemberElement | undefined>
+        : undefined);
+    memberLookups.set(candidate.key, lookup);
+    return lookup;
+  }
+
+  private getIndexedPolicyManager(
+    type: string,
+    indexedManagers: IndexedPolicyManagers,
+    indexOptions: PolicyIndexOptions,
+  ): Promise<BaseElementManager<any> | undefined> {
+    const normalizedType = this.normalizeElementType(type);
+    const existing = indexedManagers.get(normalizedType);
+    if (existing) return existing;
+
+    const manager = this.getManagerForType(normalizedType);
+    const indexed = manager
+      ? manager.refreshIndex(indexOptions).then(() => manager)
+      : Promise.resolve(undefined);
+    indexedManagers.set(normalizedType, indexed);
+    return indexed;
+  }
+
+  async getPolicyElementsForReport(
+    sessionId?: string,
+    options: { allowCoalescing?: boolean } = {},
+  ): Promise<Array<{
     type: string;
     name: string;
     metadata: Record<string, unknown>;
@@ -497,7 +680,7 @@ export class ElementCRUDHandler {
     }>();
 
     const addElement = (
-      element: { type: string; name: string; metadata: Record<string, unknown> },
+      element: PolicyElement,
       sessionIds: string[] = [],
     ): void => {
       if (!this.hasGatekeeperPolicy(element.metadata)) {
@@ -521,55 +704,55 @@ export class ElementCRUDHandler {
 
     const currentSessionId = this.activationStore?.getSessionId();
     const includeCurrentSession = !sessionId || !currentSessionId || currentSessionId === sessionId;
+    const indexOptions = options.allowCoalescing === false
+      ? { freshAfterInFlight: true }
+      : {};
 
     if (includeCurrentSession) {
-      for (const activeElement of await this.getActiveElementsForPolicy()) {
+      for (const activeElement of await this.getActiveElementsForPolicy(options)) {
         addElement(activeElement, currentSessionId ? [currentSessionId] : []);
       }
     }
 
     if (this.activationStore?.isEnabled()) {
       const persistedStates = await this.activationStore.listPersistedActivationStates(sessionId);
-      const catalogs = new Map<string, Array<{ metadata?: Record<string, unknown>; filename?: string }>>();
+      const indexedManagers: IndexedPolicyManagers = new Map();
+      const persistedLookups = new Map<string, Promise<PolicyElement | null>>();
 
-      const getCatalog = async (type: string) => {
-        const normalizedType = this.normalizeElementType(type);
-        if (!catalogs.has(normalizedType)) {
-          catalogs.set(
-            normalizedType,
-            (await this.getElements(normalizedType)) as Array<{ metadata?: Record<string, unknown>; filename?: string }>,
-          );
-        }
-        return catalogs.get(normalizedType) ?? [];
-      };
-
-      const findPersistedElement = async (
+      const findPersistedElement = (
         type: string,
         activation: PersistedActivation,
-      ): Promise<{ type: string; name: string; metadata: Record<string, unknown> } | null> => {
-        const catalog = await getCatalog(type);
+      ): Promise<PolicyElement | null> => {
+        const normalizedType = this.normalizeElementType(type);
         const normalizedName = this.normalizeLookupValue(activation.name);
         const normalizedFilename = this.normalizeLookupValue(activation.filename);
+        const lookupKey = `${normalizedType}:${normalizedName}:${normalizedFilename}`;
+        const existing = persistedLookups.get(lookupKey);
+        if (existing) return existing;
 
-        const found = catalog.find((element) => {
-          const metadata = element.metadata ?? {};
-          const elementName = this.normalizeLookupValue(metadata['name']);
-          const elementFilename = this.normalizeLookupValue(
-            element.filename ?? metadata['filename'] ?? metadata['sourceFile'],
-          );
+        const lookup = this.getIndexedPolicyManager(normalizedType, indexedManagers, indexOptions)
+          .then(async (manager) => {
+            if (!manager) return null;
 
-          return elementName === normalizedName || (normalizedFilename !== '' && elementFilename === normalizedFilename);
-        });
+            let found = normalizedName !== ''
+              ? await manager.findByName(normalizedName) as PolicyMemberElement | undefined
+              : undefined;
+            if (!found && normalizedFilename !== '') {
+              found = await manager.findByName(normalizedFilename) as PolicyMemberElement | undefined;
+            }
 
-        if (!found?.metadata || !this.hasGatekeeperPolicy(found.metadata)) {
-          return null;
-        }
+            if (!found?.metadata || !this.hasGatekeeperPolicy(found.metadata)) {
+              return null;
+            }
 
-        return {
-          type: this.toPolicyElementType(type),
-          name: (found.metadata['name'] as string) ?? activation.name,
-          metadata: found.metadata,
-        };
+            return {
+              type: this.toPolicyElementType(normalizedType),
+              name: (found.metadata['name'] as string) ?? activation.name,
+              metadata: found.metadata,
+            };
+          });
+        persistedLookups.set(lookupKey, lookup);
+        return lookup;
       };
 
       for (const state of persistedStates) {
@@ -643,6 +826,7 @@ export class ElementCRUDHandler {
     });
 
     this.activationStore?.clearAll();
+    this.invalidateActivePolicySnapshot();
     this.policyExportService?.exportPolicies().catch(() => {});
 
     const failureSummary = failed.length > 0 ? ` with ${failed.length} failure(s)` : '';
@@ -812,6 +996,7 @@ export class ElementCRUDHandler {
       }
 
       const result = await strategy.deactivate(name);
+      this.invalidateActivePolicySnapshot();
 
       // Issue #598, #1946: Persist deactivation state for session restore (per-session)
       const sessionStore = this.getSessionActivationStore();

--- a/src/handlers/mcp-aql/MCPAQLHandler.ts
+++ b/src/handlers/mcp-aql/MCPAQLHandler.ts
@@ -678,8 +678,11 @@ export class MCPAQLHandler {
   private async getActiveElements(sessionId?: string): Promise<ActiveElement[]> {
     try {
       const rawElements = sessionId
-        ? await this.handlers.elementCRUD.getPolicyElementsForReport(sessionId)
-        : await this.handlers.elementCRUD.getActiveElementsForPolicy();
+        ? await this.handlers.elementCRUD.getPolicyElementsForReport(
+          sessionId,
+          { allowCoalescing: false },
+        )
+        : await this.handlers.elementCRUD.getActiveElementsForPolicy({ allowCoalescing: false });
       const activeElements: ActiveElement[] = rawElements.map((el) => ({
         type: el.type,
         name: el.name,

--- a/src/persona/PersonaManager.ts
+++ b/src/persona/PersonaManager.ts
@@ -746,6 +746,20 @@ export class PersonaManager extends BaseElementManager<PersonaElement> {
   }
 
   /**
+   * Resolve active personas through the storage-backed lookup path.
+   * Used after a freshness scan, which may evict changed personas from the
+   * synchronous cache that getActivePersonas() intentionally relies on.
+   */
+  async resolveActivePersonas(): Promise<PersonaElement[]> {
+    const personas: PersonaElement[] = [];
+    for (const filename of this.getActivationSet()) {
+      const persona = await this.findPersonaAsync(filename);
+      if (persona) personas.push(persona);
+    }
+    return personas;
+  }
+
+  /**
    * Get identifier for the first active persona (filename).
    * Issue #281: For backward compatibility, returns first active persona ID
    */

--- a/src/services/PolicyExportService.ts
+++ b/src/services/PolicyExportService.ts
@@ -13,6 +13,7 @@
 import { writeFile, access } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { AsyncResource } from 'node:async_hooks';
 import { getStaticPolicyData } from '../handlers/mcp-aql/policies/ToolClassification.js';
 import { logger } from '../utils/logger.js';
 import { env } from '../config/env.js';
@@ -33,12 +34,22 @@ interface ElementPolicyEntry {
   deny_patterns: string[];
 }
 
-export class PolicyExportService {
-  private deps: PolicyExportDeps;
+type PolicyDocument = Record<string, unknown>;
 
-  constructor(deps: PolicyExportDeps) {
-    this.deps = deps;
-  }
+interface PendingPolicyExport {
+  sequence: number;
+  capture: () => Promise<PolicyDocument | undefined>;
+}
+
+export class PolicyExportService {
+  private exportInFlight?: Promise<void>;
+  private pendingExport?: PendingPolicyExport;
+  private nextExportSequence = 0;
+
+  constructor(
+    private readonly deps: PolicyExportDeps,
+    private readonly policyDir: string = POLICY_DIR,
+  ) {}
 
   /**
    * Export current policy state to the bridge imports folder.
@@ -48,27 +59,66 @@ export class PolicyExportService {
    *
    * Skips silently if the bridge imports directory doesn't exist.
    */
-  async exportPolicies(): Promise<void> {
+  exportPolicies(): Promise<void> {
     if (!env.DOLLHOUSE_POLICY_EXPORT_ENABLED) {
-      return;
+      return Promise.resolve();
     }
 
-    try {
-      // Check if bridge imports directory exists — skip if not
-      await access(POLICY_DIR);
-    } catch {
-      // Bridge not installed or imports dir not created — skip silently
-      return;
-    }
+    // Bind a lazy capture to the caller's AsyncLocalStorage context. Bursts
+    // replace pending captures before they do work, while a newer session can
+    // never run through an older request's context.
+    this.pendingExport = {
+      sequence: ++this.nextExportSequence,
+      capture: AsyncResource.bind(() => this.capturePolicySnapshot()),
+    };
+    this.exportInFlight ??= this.runExportLoop();
+    return this.exportInFlight;
+  }
 
+  private async runExportLoop(): Promise<void> {
     try {
+      while (this.pendingExport) {
+        const exportJob = this.pendingExport;
+        this.pendingExport = undefined;
+        const policy = await exportJob.capture();
+
+        // If a newer request arrived while this snapshot was being gathered,
+        // skip the older write. The loop will publish the newest snapshot.
+        const newerRequest = this.pendingExport as PendingPolicyExport | undefined;
+        if (newerRequest && newerRequest.sequence > exportJob.sequence) {
+          continue;
+        }
+        if (policy) await this.writePolicy(policy);
+      }
+    } finally {
+      this.exportInFlight = undefined;
+
+      // Close the settlement race: a request queued after the loop observed
+      // empty state is included before the promise returned to callers settles.
+      if (this.pendingExport) {
+        const trailing = this.runExportLoop();
+        this.exportInFlight = trailing;
+        await trailing;
+      }
+    }
+  }
+
+  private async capturePolicySnapshot(): Promise<PolicyDocument | undefined> {
+    try {
+      try {
+        await access(this.policyDir);
+      } catch {
+        // Bridge not installed or imports dir not created — skip silently.
+        return undefined;
+      }
+
       const staticRules = getStaticPolicyData();
       const activeElements = await this.deps.getActiveElementsForPolicy();
       const version = this.deps.getServerVersion();
 
       const elementPolicies = this.buildElementPolicies(activeElements);
 
-      const policy = {
+      return {
         schema_version: '1.0',
         server: {
           name: 'DollhouseMCP-V2-Refactor CRUDE',
@@ -88,12 +138,23 @@ export class PolicyExportService {
         element_policies: elementPolicies,
         risk_scores: staticRules.risk_scores,
       };
-
-      const filePath = join(POLICY_DIR, POLICY_FILENAME);
-      await writeFile(filePath, JSON.stringify(policy, null, 2), 'utf-8');
-      logger.info('[PolicyExportService] Policies exported', { filePath, elementCount: elementPolicies.active_element_count });
     } catch (err) {
-      // Non-fatal: log and continue
+      logger.warn('[PolicyExportService] Failed to capture policies', { error: (err as Error).message });
+      return undefined;
+    }
+  }
+
+  private async writePolicy(policy: PolicyDocument): Promise<void> {
+    try {
+      const filePath = join(this.policyDir, POLICY_FILENAME);
+      await writeFile(filePath, JSON.stringify(policy, null, 2), 'utf-8');
+      const elementPolicies = policy['element_policies'] as { active_element_count?: number } | undefined;
+      logger.info('[PolicyExportService] Policies exported', {
+        filePath,
+        elementCount: elementPolicies?.active_element_count ?? 0,
+      });
+    } catch (err) {
+      // Non-fatal: policy export must never break element activation.
       logger.warn('[PolicyExportService] Failed to export policies', { error: (err as Error).message });
     }
   }

--- a/src/storage/AbstractDatabaseStorageLayer.ts
+++ b/src/storage/AbstractDatabaseStorageLayer.ts
@@ -19,7 +19,12 @@ import { elements, elementTags } from '../database/schema/elements.js';
 import type { UserIdResolver } from '../database/UserContext.js';
 import type { DrizzleTx } from '../database/db-utils.js';
 import type { ElementIndexEntry, ManifestDiffResult } from './types.js';
-import type { IWritableStorageLayer, ElementWriteMetadata, WriteContentOptions } from './IStorageLayer.js';
+import type {
+  IWritableStorageLayer,
+  ElementWriteMetadata,
+  StorageScanOptions,
+  WriteContentOptions,
+} from './IStorageLayer.js';
 
 /**
  * Canonical key for case/format-insensitive name resolution: lowercase, with
@@ -71,7 +76,7 @@ export abstract class AbstractDatabaseStorageLayer implements IWritableStorageLa
 
   // ── IStorageLayer ─────────────────────────────────────────────────
 
-  async scan(): Promise<ManifestDiffResult> {
+  async scan(_options?: StorageScanOptions): Promise<ManifestDiffResult> {
     const result: ManifestDiffResult = {
       added: [],
       modified: [],

--- a/src/storage/ElementStorageLayer.ts
+++ b/src/storage/ElementStorageLayer.ts
@@ -8,8 +8,8 @@
 import * as path from 'path';
 import { logger } from '../utils/logger.js';
 import type { IStorageBackend } from './IStorageBackend.js';
-import type { IStorageLayer } from './IStorageLayer.js';
-import type { ElementIndexEntry, ManifestDiffResult } from './types.js';
+import type { IStorageLayer, StorageScanOptions } from './IStorageLayer.js';
+import { mergeManifestDiffResults, type ElementIndexEntry, type ManifestDiffResult } from './types.js';
 import { StorageManifest } from './StorageManifest.js';
 import { MetadataIndex } from './MetadataIndex.js';
 import { FrontmatterParser } from './FrontmatterParser.js';
@@ -94,9 +94,8 @@ export class ElementStorageLayer implements IStorageLayer {
     return this.elementDirResolver ? this.elementDirResolver() : this.staticElementDir;
   }
 
-  /** Get or create the scan state for the current directory. */
-  private getState(): DirScanState {
-    const dir = this.elementDir;
+  /** Get or create the scan state for a pinned directory. */
+  private getState(dir = this.elementDir): DirScanState {
     let state = this.dirStates.get(dir);
     if (!state) {
       state = {
@@ -116,9 +115,27 @@ export class ElementStorageLayer implements IStorageLayer {
    * - Deduplicates concurrent calls (returns same promise)
    * - Updates index and manifest based on diff
    */
-  async scan(): Promise<ManifestDiffResult> {
-    const state = this.getState();
+  async scan(options: StorageScanOptions = {}): Promise<ManifestDiffResult> {
     const currentDir = this.elementDir;
+    const state = this.getState(currentDir);
+
+    const existingScan = state.scanInProgress;
+    if (existingScan) {
+      if (!options.freshAfterInFlight) return existingScan;
+
+      let initialDiff: ManifestDiffResult | undefined;
+      try {
+        initialDiff = await existingScan;
+      } catch {
+        // Give the trailing scan an independent chance to recover.
+      }
+
+      const successor = state.scanInProgress;
+      const trailingDiff = successor && successor !== existingScan
+        ? await successor
+        : await this.startScan(currentDir, state);
+      return initialDiff ? mergeManifestDiffResults(initialDiff, trailingDiff) : trailingDiff;
+    }
 
     const now = Date.now();
     if (now - state.lastScanTimestamp < this.scanCooldownMs) {
@@ -126,17 +143,16 @@ export class ElementStorageLayer implements IStorageLayer {
       return EMPTY_DIFF;
     }
 
-    // Deduplicate concurrent scans FOR THE SAME DIRECTORY.
-    // Each user's dir has its own scanInProgress promise — no cross-user leakage.
-    if (state.scanInProgress) {
-      return state.scanInProgress;
-    }
+    return this.startScan(currentDir, state);
+  }
 
-    state.scanInProgress = this.performScanForDir(currentDir, state);
+  private async startScan(currentDir: string, state: DirScanState): Promise<ManifestDiffResult> {
+    const scanPromise = this.performScanForDir(currentDir, state);
+    state.scanInProgress = scanPromise;
     try {
-      return await state.scanInProgress;
+      return await scanPromise;
     } finally {
-      state.scanInProgress = null;
+      if (state.scanInProgress === scanPromise) state.scanInProgress = null;
     }
   }
 

--- a/src/storage/IStorageLayer.ts
+++ b/src/storage/IStorageLayer.ts
@@ -16,12 +16,21 @@
 
 import type { ElementIndexEntry, ManifestDiffResult } from './types.js';
 
+export interface StorageScanOptions {
+  /**
+   * If this call joins an already-running scan, perform one serialized
+   * trailing scan before returning. This is used by freshness-critical reads
+   * so a change made after the joined scan began cannot be hidden by cooldown.
+   */
+  freshAfterInFlight?: boolean;
+}
+
 export interface IStorageLayer {
   /**
    * Scan the filesystem for changes relative to the last snapshot.
    * Implementations should enforce cooldown and deduplicate concurrent calls.
    */
-  scan(): Promise<ManifestDiffResult>;
+  scan(options?: StorageScanOptions): Promise<ManifestDiffResult>;
 
   /**
    * Trigger scan and return all indexed entries.

--- a/src/storage/MemoryStorageLayer.ts
+++ b/src/storage/MemoryStorageLayer.ts
@@ -14,9 +14,9 @@
 
 import * as path from 'path';
 import { logger } from '../utils/logger.js';
-import type { IStorageLayer } from './IStorageLayer.js';
+import type { IStorageLayer, StorageScanOptions } from './IStorageLayer.js';
 import type { IStorageBackend } from './IStorageBackend.js';
-import type { ElementIndexEntry, ManifestDiffResult } from './types.js';
+import { mergeManifestDiffResults, type ElementIndexEntry, type ManifestDiffResult } from './types.js';
 import { StorageManifest } from './StorageManifest.js';
 import { MetadataIndex } from './MetadataIndex.js';
 import { FileStorageBackend } from './FileStorageBackend.js';
@@ -93,9 +93,8 @@ export class MemoryStorageLayer implements IStorageLayer {
     return this.memoriesDirResolver ? this.memoriesDirResolver() : this.staticMemoriesDir;
   }
 
-  /** Get or create per-dir scan state. */
-  private getState(): MemoryDirScanState {
-    const dir = this.memoriesDir;
+  /** Get or create scan state for a pinned directory. */
+  private getState(dir = this.memoriesDir): MemoryDirScanState {
     let state = this.dirStates.get(dir);
     if (!state) {
       const indexPath = path.join(dir, '_index.json');
@@ -114,17 +113,35 @@ export class MemoryStorageLayer implements IStorageLayer {
 
   // ---- IStorageLayer implementation ----
 
-  async scan(): Promise<ManifestDiffResult> {
+  async scan(options: StorageScanOptions = {}): Promise<ManifestDiffResult> {
     // Pin dir + state at the start — all async work below uses these
     // pinned references, not the resolver. This prevents cross-user
     // contamination when concurrent requests from different users hit
     // the same root-scoped MemoryStorageLayer.
     const dir = this.memoriesDir;
-    const state = this.getState();
+    const state = this.getState(dir);
+
+    const existingScan = state.scanInProgress;
+    if (existingScan) {
+      if (!options.freshAfterInFlight) return existingScan;
+
+      let initialDiff: ManifestDiffResult | undefined;
+      try {
+        initialDiff = await existingScan;
+      } catch {
+        // Give the trailing scan an independent chance to recover.
+      }
+
+      const successor = state.scanInProgress;
+      const trailingDiff = successor && successor !== existingScan
+        ? await successor
+        : await this.startScan(dir, state, false);
+      return initialDiff ? mergeManifestDiffResults(initialDiff, trailingDiff) : trailingDiff;
+    }
 
     if (!state.coldStartDone) {
       state.coldStartDone = true;
-      return this.coldStartForDir(dir, state);
+      return this.startScan(dir, state, true);
     }
 
     const now = Date.now();
@@ -132,15 +149,22 @@ export class MemoryStorageLayer implements IStorageLayer {
       return EMPTY_DIFF;
     }
 
-    if (state.scanInProgress) {
-      return state.scanInProgress;
-    }
+    return this.startScan(dir, state, false);
+  }
 
-    state.scanInProgress = this.performScanForDir(dir, state);
+  private async startScan(
+    dir: string,
+    state: MemoryDirScanState,
+    coldStart: boolean,
+  ): Promise<ManifestDiffResult> {
+    const scanPromise = coldStart
+      ? this.coldStartForDir(dir, state)
+      : this.performScanForDir(dir, state);
+    state.scanInProgress = scanPromise;
     try {
-      return await state.scanInProgress;
+      return await scanPromise;
     } finally {
-      state.scanInProgress = null;
+      if (state.scanInProgress === scanPromise) state.scanInProgress = null;
     }
   }
 

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -8,10 +8,11 @@ export type {
   ElementIndexEntry,
   ManifestDiffResult,
 } from './types.js';
+export { mergeManifestDiffResults } from './types.js';
 
 // Interfaces
 export type { IStorageBackend } from './IStorageBackend.js';
-export type { IStorageLayer } from './IStorageLayer.js';
+export type { IStorageLayer, StorageScanOptions } from './IStorageLayer.js';
 
 // Classes — Phase 1 (ElementStorageLayer for .md elements)
 export { FrontmatterParser } from './FrontmatterParser.js';

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -83,3 +83,65 @@ export interface ManifestDiffResult {
   /** Files whose mtime matches the manifest (no change) */
   unchanged: string[];
 }
+
+type ManifestDiffCategory = keyof ManifestDiffResult;
+
+const DIFF_CATEGORIES: readonly ManifestDiffCategory[] = [
+  'added',
+  'modified',
+  'removed',
+  'unchanged',
+];
+
+/**
+ * Merge two consecutive manifest diffs into one coherent transition.
+ *
+ * A path appears in exactly one output category. Transitions preserve cache
+ * invalidations across a trailing scan: for example, modified -> unchanged
+ * remains modified, while removed -> added becomes modified. A transient
+ * added -> removed path is reported as removed so any object loaded between
+ * the two scans is evicted.
+ */
+export function mergeManifestDiffResults(
+  first: ManifestDiffResult,
+  second: ManifestDiffResult,
+): ManifestDiffResult {
+  const firstCategories = categorizeDiff(first);
+  const secondCategories = categorizeDiff(second);
+  const orderedPaths = new Set<string>();
+
+  for (const category of DIFF_CATEGORIES) {
+    for (const filePath of first[category]) orderedPaths.add(filePath);
+  }
+  for (const category of DIFF_CATEGORIES) {
+    for (const filePath of second[category]) orderedPaths.add(filePath);
+  }
+
+  const merged: ManifestDiffResult = { added: [], modified: [], removed: [], unchanged: [] };
+  for (const filePath of orderedPaths) {
+    const category = mergeDiffCategory(firstCategories.get(filePath), secondCategories.get(filePath));
+    if (category) merged[category].push(filePath);
+  }
+  return merged;
+}
+
+function categorizeDiff(diff: ManifestDiffResult): Map<string, ManifestDiffCategory> {
+  const categories = new Map<string, ManifestDiffCategory>();
+  for (const category of DIFF_CATEGORIES) {
+    for (const filePath of diff[category]) categories.set(filePath, category);
+  }
+  return categories;
+}
+
+function mergeDiffCategory(
+  first: ManifestDiffCategory | undefined,
+  second: ManifestDiffCategory | undefined,
+): ManifestDiffCategory | undefined {
+  if (!first) return second;
+  if (!second) return first;
+
+  if (second === 'removed') return 'removed';
+  if (first === 'added') return 'added';
+  if (first === 'unchanged' && second === 'unchanged') return 'unchanged';
+  return 'modified';
+}

--- a/tests/unit/base/ElementListOperations.test.ts
+++ b/tests/unit/base/ElementListOperations.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { ElementListOperations } from '../../../src/elements/base/ElementListOperations.js';
+
+describe('ElementListOperations.scanAndEvict', () => {
+  it('uses database identifiers directly when evicting writable-storage cache entries', async () => {
+    const cache = { uncacheByPath: jest.fn() };
+    const storageLayer = {
+      invalidate: jest.fn(),
+      scan: jest.fn().mockResolvedValue({
+        added: [],
+        modified: ['modified-uuid'],
+        removed: ['removed-uuid'],
+        unchanged: [],
+      }),
+      writeContent: jest.fn(),
+      deleteContent: jest.fn(),
+      readContent: jest.fn(),
+    };
+    const operations = new ElementListOperations(
+      { elementDir: '/portfolio/skills' } as any,
+      cache as any,
+      {} as any,
+      {} as any,
+      storageLayer as any,
+      undefined,
+      undefined,
+    );
+
+    await operations.scanAndEvict({ freshAfterInFlight: true });
+
+    expect(storageLayer.invalidate).toHaveBeenCalledTimes(1);
+    expect(storageLayer.scan).toHaveBeenCalledWith({ freshAfterInFlight: true });
+    expect(cache.uncacheByPath.mock.calls).toEqual([
+      ['modified-uuid'],
+      ['removed-uuid'],
+    ]);
+  });
+});

--- a/tests/unit/elements/agents/AgentManager.test.ts
+++ b/tests/unit/elements/agents/AgentManager.test.ts
@@ -143,6 +143,23 @@ describe('AgentManager', () => {
     });
   });
 
+  describe('Active agents', () => {
+    it('resolves only active names without listing the full catalog', async () => {
+      const activeAgent = { metadata: { name: 'active-agent' } } as Agent;
+      (agentManager as any).getActivationSet().add('active-agent');
+      const refresh = jest.spyOn(agentManager as any, 'scanAndEvict').mockResolvedValue(undefined);
+      const findByName = jest.spyOn(agentManager, 'findByName').mockResolvedValue(activeAgent);
+      const list = jest.spyOn(agentManager, 'list');
+
+      const result = await agentManager.getActiveAgents({ freshAfterInFlight: true });
+
+      expect(result).toEqual([activeAgent]);
+      expect(refresh).toHaveBeenCalledWith({ freshAfterInFlight: true });
+      expect(findByName).toHaveBeenCalledWith('active-agent');
+      expect(list).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Recovery state synchronization', () => {
     it('allows normal completion to shrink legacy oversized state', async () => {
       const agent = new Agent({ name: 'recovery-agent' }, metadataService);

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -35,6 +35,8 @@ describe('ElementCRUDHandler (DI)', () => {
       delete: jest.fn(),
       find: jest.fn(),
       getActiveSkills: jest.fn().mockResolvedValue([]),
+      refreshIndex: jest.fn().mockResolvedValue(undefined),
+      findByName: jest.fn().mockResolvedValue(undefined),
       deactivateSkill: jest.fn().mockResolvedValue({ success: true, message: 'deactivated' }),
     } as unknown as jest.Mocked<SkillManager>;
 
@@ -51,23 +53,32 @@ describe('ElementCRUDHandler (DI)', () => {
       getActiveAgents: jest.fn().mockResolvedValue([]),
       deactivateAgent: jest.fn().mockResolvedValue({ success: true, message: 'deactivated' }),
       list: jest.fn().mockResolvedValue([]),
+      refreshIndex: jest.fn().mockResolvedValue(undefined),
+      findByName: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<AgentManager>;
 
     memoryManager = {
       save: jest.fn(),
       getActiveMemories: jest.fn().mockResolvedValue([]),
+      refreshIndex: jest.fn().mockResolvedValue(undefined),
+      findByName: jest.fn().mockResolvedValue(undefined),
       deactivateMemory: jest.fn().mockResolvedValue({ success: true, message: 'deactivated' }),
     } as unknown as jest.Mocked<MemoryManager>;
 
     ensembleManager = {
       list: jest.fn(),
       getActiveEnsembles: jest.fn().mockResolvedValue([]),
+      refreshIndex: jest.fn().mockResolvedValue(undefined),
+      findByName: jest.fn().mockResolvedValue(undefined),
       deactivateEnsemble: jest.fn().mockResolvedValue({ success: true, message: 'deactivated' }),
     } as unknown as jest.Mocked<EnsembleManager>;
 
     personaHandler = {
       getActivePersona: jest.fn(),
       getActivePersonas: jest.fn().mockReturnValue([]),
+      resolveActivePersonas: jest.fn().mockResolvedValue([]),
+      refreshIndex: jest.fn().mockResolvedValue(undefined),
+      findByName: jest.fn().mockResolvedValue(undefined),
       deactivatePersona: jest.fn().mockReturnValue({ success: true, message: 'deactivated' }),
       findPersona: jest.fn(),
       list: jest.fn().mockReturnValue([]),
@@ -252,6 +263,205 @@ describe('ElementCRUDHandler (DI)', () => {
       ]));
     });
 
+    it('indexes each ensemble-member type once without full catalog loads', async () => {
+      ensembleManager.getActiveEnsembles.mockResolvedValue([{
+        metadata: {
+          name: 'policy-team',
+          elements: [
+            { element_type: 'skill', element_name: 'policy-skill' },
+            { element_type: 'skills', element_name: 'policy-skill' },
+            { element_type: 'skill', element_name: 'ordinary-skill' },
+            { element_type: 'memory', element_name: 'policy-memory' },
+          ],
+        },
+      } as any]);
+      skillManager.list = jest.fn();
+      skillManager.refreshIndex = jest.fn().mockResolvedValue(undefined);
+      skillManager.findByName = jest.fn(async (name: string) => name === 'policy-skill'
+        ? {
+          metadata: {
+            name,
+            gatekeeper: { externalRestrictions: { denyPatterns: ['Bash:rm*'] } },
+          },
+        } as any
+        : undefined);
+      memoryManager.list = jest.fn();
+      memoryManager.refreshIndex = jest.fn().mockResolvedValue(undefined);
+      memoryManager.findByName = jest.fn().mockResolvedValue({
+        metadata: {
+          name: 'policy-memory',
+          gatekeeper: { externalRestrictions: { confirmPatterns: ['Bash:git push*'] } },
+        },
+      } as any);
+
+      const result = await handler.getActiveElementsForPolicy();
+
+      expect(skillManager.refreshIndex).toHaveBeenCalledTimes(1);
+      expect(memoryManager.refreshIndex).toHaveBeenCalledTimes(1);
+      expect(skillManager.findByName).toHaveBeenCalledTimes(2);
+      expect(memoryManager.findByName).toHaveBeenCalledTimes(1);
+      expect(skillManager.list).not.toHaveBeenCalled();
+      expect(memoryManager.list).not.toHaveBeenCalled();
+      expect(result.filter((element) => element.name === 'policy-skill')).toHaveLength(1);
+      expect(result.filter((element) => element.name === 'policy-memory')).toHaveLength(1);
+      expect(result).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: 'ordinary-skill' }),
+      ]));
+    });
+
+    it('keeps large ensemble policy scans linear in unique member count', async () => {
+      const members = Array.from({ length: 500 }, (_, index) => ({
+        element_type: index % 2 === 0 ? 'skill' : 'skills',
+        element_name: `member-${index % 250}`,
+      }));
+      ensembleManager.getActiveEnsembles.mockResolvedValue([{
+        metadata: { name: 'large-ensemble', elements: members },
+      } as any]);
+      skillManager.list = jest.fn();
+      skillManager.refreshIndex = jest.fn().mockResolvedValue(undefined);
+      skillManager.findByName = jest.fn().mockResolvedValue(undefined);
+
+      await handler.getActiveElementsForPolicy();
+
+      expect(skillManager.refreshIndex).toHaveBeenCalledTimes(1);
+      expect(skillManager.findByName).toHaveBeenCalledTimes(250);
+      expect(skillManager.list).not.toHaveBeenCalled();
+    });
+
+    it('bounds concurrent ensemble-member lookups at eight', async () => {
+      const members = Array.from({ length: 20 }, (_, index) => ({
+        element_type: 'skill',
+        element_name: `member-${index}`,
+      }));
+      ensembleManager.getActiveEnsembles.mockResolvedValue([{
+        metadata: { name: 'large-policy-team', elements: members },
+      } as any]);
+      skillManager.refreshIndex = jest.fn().mockResolvedValue(undefined);
+
+      let inFlight = 0;
+      let maxInFlight = 0;
+      let releaseLookups!: () => void;
+      let markCeilingReached!: () => void;
+      const lookupsBlocked = new Promise<void>((resolve) => {
+        releaseLookups = resolve;
+      });
+      const ceilingReached = new Promise<void>((resolve) => {
+        markCeilingReached = resolve;
+      });
+      skillManager.findByName = jest.fn(async () => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        if (maxInFlight === 8) markCeilingReached();
+        await lookupsBlocked;
+        inFlight -= 1;
+        return undefined;
+      });
+
+      const snapshot = handler.getActiveElementsForPolicy();
+      await ceilingReached;
+      expect(skillManager.findByName).toHaveBeenCalledTimes(8);
+      releaseLookups();
+      await snapshot;
+
+      expect(skillManager.findByName).toHaveBeenCalledTimes(20);
+      expect(maxInFlight).toBe(8);
+    });
+
+    it('coalesces overlapping reporting snapshots in the same session', async () => {
+      let releaseEnsembles!: () => void;
+      const ensemblesBlocked = new Promise<void>((resolve) => {
+        releaseEnsembles = resolve;
+      });
+      ensembleManager.getActiveEnsembles.mockImplementation(async () => {
+        await ensemblesBlocked;
+        return [];
+      });
+
+      const snapshots = [
+        handler.getActiveElementsForPolicy(),
+        handler.getActiveElementsForPolicy(),
+        handler.getActiveElementsForPolicy(),
+      ];
+      releaseEnsembles();
+      await Promise.all(snapshots);
+
+      expect(ensembleManager.getActiveEnsembles).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not share reporting snapshots across session scopes', async () => {
+      let currentSession = 'session-a';
+      const contextTracker = {
+        getSessionContext: jest.fn(() => ({ sessionId: currentSession })),
+      };
+      const scopedHandler = new ElementCRUDHandler(
+        skillManager,
+        templateManager,
+        templateRenderer,
+        agentManager,
+        memoryManager,
+        ensembleManager,
+        personaHandler,
+        portfolioManager,
+        initService,
+        indicatorService,
+        fileOperations,
+        undefined as any,
+        undefined as any,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        contextTracker as any,
+      );
+      let releaseEnsembles!: () => void;
+      const ensemblesBlocked = new Promise<void>((resolve) => {
+        releaseEnsembles = resolve;
+      });
+      ensembleManager.getActiveEnsembles.mockImplementation(async () => {
+        await ensemblesBlocked;
+        return [];
+      });
+
+      const firstSessionSnapshot = scopedHandler.getActiveElementsForPolicy();
+      currentSession = 'session-b';
+      const secondSessionSnapshot = scopedHandler.getActiveElementsForPolicy();
+      releaseEnsembles();
+      await Promise.all([firstSessionSnapshot, secondSessionSnapshot]);
+
+      expect(ensembleManager.getActiveEnsembles).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not coalesce enforcement onto an in-flight reporting snapshot', async () => {
+      let markReportingStarted!: () => void;
+      let releaseReporting!: () => void;
+      const reportingStarted = new Promise<void>((resolve) => {
+        markReportingStarted = resolve;
+      });
+      const reportingBlocked = new Promise<void>((resolve) => {
+        releaseReporting = resolve;
+      });
+      ensembleManager.getActiveEnsembles
+        .mockImplementationOnce(async () => {
+          markReportingStarted();
+          await reportingBlocked;
+          return [];
+        })
+        .mockResolvedValueOnce([]);
+
+      const reportingSnapshot = handler.getActiveElementsForPolicy();
+      await reportingStarted;
+      await handler.getActiveElementsForPolicy({ allowCoalescing: false });
+
+      expect(ensembleManager.getActiveEnsembles).toHaveBeenCalledTimes(2);
+      expect(personaHandler.refreshIndex).toHaveBeenCalledWith({ freshAfterInFlight: true });
+      expect(skillManager.refreshIndex).toHaveBeenCalledWith({ freshAfterInFlight: true });
+      expect(ensembleManager.refreshIndex).toHaveBeenCalledWith({ freshAfterInFlight: true });
+      expect(personaHandler.resolveActivePersonas).toHaveBeenCalledTimes(1);
+      expect(agentManager.getActiveAgents).toHaveBeenLastCalledWith({ freshAfterInFlight: true });
+      releaseReporting();
+      await reportingSnapshot;
+    });
+
     it('merges persisted activation snapshots into reportable policy elements', async () => {
       const activationStore = {
         isEnabled: jest.fn().mockReturnValue(true),
@@ -268,18 +478,18 @@ describe('ElementCRUDHandler (DI)', () => {
       } as unknown as jest.Mocked<ActivationStore>;
 
       skillManager.getActiveSkills = jest.fn().mockResolvedValue([]);
-      skillManager.list = jest.fn().mockResolvedValue([
-        {
-          metadata: {
-            name: 'audit-trace-demo',
-            gatekeeper: {
-              externalRestrictions: {
-                confirmPatterns: ['Bash:git push*'],
-              },
+      skillManager.list = jest.fn();
+      skillManager.refreshIndex = jest.fn().mockResolvedValue(undefined);
+      skillManager.findByName = jest.fn().mockResolvedValue({
+        metadata: {
+          name: 'audit-trace-demo',
+          gatekeeper: {
+            externalRestrictions: {
+              confirmPatterns: ['Bash:git push*'],
             },
           },
-        } as any,
-      ]);
+        },
+      } as any);
 
       const reportHandler = new ElementCRUDHandler(
         skillManager,
@@ -308,6 +518,9 @@ describe('ElementCRUDHandler (DI)', () => {
         }),
       ]);
       expect(activationStore.listPersistedActivationStates).toHaveBeenCalledWith('session-other');
+      expect(skillManager.refreshIndex).toHaveBeenCalledTimes(1);
+      expect(skillManager.findByName).toHaveBeenCalledWith('audit-trace-demo');
+      expect(skillManager.list).not.toHaveBeenCalled();
     });
 
     it('does not leak the current session in-memory policies into another session report', async () => {
@@ -337,28 +550,33 @@ describe('ElementCRUDHandler (DI)', () => {
           },
         } as any,
       ]);
-      skillManager.list = jest.fn().mockResolvedValue([
-        {
-          metadata: {
-            name: 'audit-trace-demo',
-            gatekeeper: {
-              externalRestrictions: {
-                confirmPatterns: ['Bash:git push*'],
+      skillManager.list = jest.fn();
+      skillManager.refreshIndex = jest.fn().mockResolvedValue(undefined);
+      skillManager.findByName = jest.fn(async (name: string) => {
+        const elements = [
+          {
+            metadata: {
+              name: 'audit-trace-demo',
+              gatekeeper: {
+                externalRestrictions: {
+                  confirmPatterns: ['Bash:git push*'],
+                },
               },
             },
           },
-        } as any,
-        {
-          metadata: {
-            name: 'leader-only-skill',
-            gatekeeper: {
-              externalRestrictions: {
-                denyPatterns: ['Bash:rm*'],
+          {
+            metadata: {
+              name: 'leader-only-skill',
+              gatekeeper: {
+                externalRestrictions: {
+                  denyPatterns: ['Bash:rm*'],
+                },
               },
             },
           },
-        } as any,
-      ]);
+        ];
+        return elements.find((element) => element.metadata.name === name) as any;
+      });
 
       const reportHandler = new ElementCRUDHandler(
         skillManager,
@@ -385,6 +603,9 @@ describe('ElementCRUDHandler (DI)', () => {
           sessionIds: ['session-other'],
         }),
       ]);
+      expect(skillManager.refreshIndex).toHaveBeenCalledTimes(1);
+      expect(skillManager.findByName).toHaveBeenCalledTimes(1);
+      expect(skillManager.list).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -523,6 +523,76 @@ describe('ElementCRUDHandler (DI)', () => {
       expect(skillManager.list).not.toHaveBeenCalled();
     });
 
+    it('bounds persisted policy lookups at eight and preserves activation order', async () => {
+      const activations = Array.from({ length: 20 }, (_, index) => ({
+        name: `persisted-skill-${index}`,
+        activatedAt: new Date().toISOString(),
+      }));
+      const activationStore = {
+        isEnabled: jest.fn().mockReturnValue(true),
+        getSessionId: jest.fn().mockReturnValue('leader-session'),
+        listPersistedActivationStates: jest.fn().mockResolvedValue([{
+          sessionId: 'session-other',
+          lastUpdated: new Date().toISOString(),
+          activations: { skill: activations },
+        }]),
+      } as unknown as jest.Mocked<ActivationStore>;
+
+      skillManager.refreshIndex = jest.fn().mockResolvedValue(undefined);
+      let inFlight = 0;
+      let maxInFlight = 0;
+      let releaseLookups!: () => void;
+      let markCeilingReached!: () => void;
+      const lookupsBlocked = new Promise<void>((resolve) => {
+        releaseLookups = resolve;
+      });
+      const ceilingReached = new Promise<void>((resolve) => {
+        markCeilingReached = resolve;
+      });
+      skillManager.findByName = jest.fn(async (name: string) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        if (maxInFlight === 8) markCeilingReached();
+        await lookupsBlocked;
+        inFlight -= 1;
+        return {
+          metadata: {
+            name,
+            gatekeeper: { externalRestrictions: { confirmPatterns: ['Bash:git push*'] } },
+          },
+        } as any;
+      });
+
+      const reportHandler = new ElementCRUDHandler(
+        skillManager,
+        templateManager,
+        templateRenderer,
+        agentManager,
+        memoryManager,
+        ensembleManager,
+        personaHandler,
+        portfolioManager,
+        initService,
+        indicatorService,
+        fileOperations,
+        undefined as any,
+        undefined as any,
+        activationStore,
+      );
+
+      const report = reportHandler.getPolicyElementsForReport('session-other');
+      await ceilingReached;
+      expect(skillManager.findByName).toHaveBeenCalledTimes(8);
+      releaseLookups();
+      const result = await report;
+
+      expect(skillManager.findByName).toHaveBeenCalledTimes(20);
+      expect(maxInFlight).toBe(8);
+      expect(result.map((element) => element.name)).toEqual(
+        activations.map((activation) => activation.name),
+      );
+    });
+
     it('does not leak the current session in-memory policies into another session report', async () => {
       const activationStore = {
         isEnabled: jest.fn().mockReturnValue(true),

--- a/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
+++ b/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
@@ -481,7 +481,10 @@ describe('MCPAQLHandler', () => {
       });
 
       expect(result.success).toBe(true);
-      expect(mockRegistry.elementCRUD.getPolicyElementsForReport).toHaveBeenCalledWith('session-follower-1');
+      expect(mockRegistry.elementCRUD.getPolicyElementsForReport).toHaveBeenCalledWith(
+        'session-follower-1',
+        { allowCoalescing: false },
+      );
     });
   });
 
@@ -1778,6 +1781,8 @@ describe('MCPAQLHandler', () => {
       const result = await enforcingHandler.handleRead(input);
       // list_elements should be denied by the active persona's policy
       expect(result.success).toBe(false);
+      expect(enforcingRegistry.elementCRUD.getActiveElementsForPolicy)
+        .toHaveBeenCalledWith({ allowCoalescing: false });
     });
 
     it('confirm_operation should be auto-approved (no infinite loop)', async () => {

--- a/tests/unit/services/PolicyExportService.test.ts
+++ b/tests/unit/services/PolicyExportService.test.ts
@@ -11,9 +11,10 @@
  * Uses a real temp directory to avoid ESM mocking complexity.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import { PolicyExportService, type PolicyExportDeps } from '../../../src/services/PolicyExportService.js';
 import { getStaticPolicyData } from '../../../src/handlers/mcp-aql/policies/ToolClassification.js';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -34,44 +35,7 @@ function createMockDeps(overrides: Partial<PolicyExportDeps> = {}): PolicyExport
  * instead of the real bridge imports path.
  */
 function createServiceWithDir(dir: string, deps: Partial<PolicyExportDeps> = {}): PolicyExportService {
-  const service = new PolicyExportService(createMockDeps(deps));
-  // Override the private POLICY_DIR via a subclass to test with temp dir
-  // We access the internal method through the public API and override writeFile path
-  // by monkey-patching exportPolicies to use our test dir
-  service.exportPolicies = async () => {
-    // Temporarily replace the module-level constants by overriding the method
-    const staticRules = getStaticPolicyData();
-    const activeElements = await createMockDeps(deps).getActiveElementsForPolicy();
-    const version = createMockDeps(deps).getServerVersion();
-
-    const elementPolicies = (service as any).buildElementPolicies(activeElements);
-
-    const policy = {
-      schema_version: '1.0',
-      server: {
-        name: 'DollhouseMCP-V2-Refactor CRUDE',
-        version,
-      },
-      exported_at: new Date().toISOString(),
-      static_rules: {
-        safe_tools: staticRules.safe_tools,
-        safe_bash_patterns: staticRules.safe_bash_patterns,
-        dangerous_bash_patterns: staticRules.dangerous_bash_patterns,
-        blocked_bash_patterns: staticRules.blocked_bash_patterns,
-        irreversible_patterns: staticRules.irreversible_patterns,
-        sensitive_path_prefixes: staticRules.sensitive_path_prefixes,
-        gatekeeper_essential_operations: staticRules.gatekeeper_essential_operations,
-        safe_mcp_operations: staticRules.safe_mcp_operations,
-      },
-      element_policies: elementPolicies,
-      risk_scores: staticRules.risk_scores,
-    };
-
-    const filePath = path.join(dir, 'dollhousemcp-crude-policies.json');
-    await fs.writeFile(filePath, JSON.stringify(policy, null, 2), 'utf-8');
-  };
-
-  return service;
+  return new PolicyExportService(createMockDeps(deps), dir);
 }
 
 async function readPolicyFile(): Promise<Record<string, any>> {
@@ -91,11 +55,75 @@ describe('PolicyExportService', () => {
 
   describe('exportPolicies', () => {
     it('should skip silently when bridge directory does not exist', async () => {
-      // Use the real service pointing at real (non-existent) path
-      // This verifies the access() check works
-      const service = new PolicyExportService(createMockDeps());
+      const service = new PolicyExportService(createMockDeps(), path.join(testDir, 'missing'));
       // If bridge dir doesn't exist, this should not throw
       await expect(service.exportPolicies()).resolves.toBeUndefined();
+    });
+
+    it('coalesces a burst into one bounded trailing capture', async () => {
+      let releaseFirstCapture!: () => void;
+      let markFirstCaptureStarted!: () => void;
+      const firstCaptureBlocked = new Promise<void>((resolve) => {
+        releaseFirstCapture = resolve;
+      });
+      const firstCaptureStarted = new Promise<void>((resolve) => {
+        markFirstCaptureStarted = resolve;
+      });
+      let captureCount = 0;
+      const getActiveElementsForPolicy = jest.fn(async () => {
+        captureCount += 1;
+        if (captureCount === 1) {
+          markFirstCaptureStarted();
+          await firstCaptureBlocked;
+        }
+        return [];
+      });
+      const service = createServiceWithDir(policyDir, { getActiveElementsForPolicy });
+
+      const first = service.exportPolicies();
+      await firstCaptureStarted;
+      const second = service.exportPolicies();
+      const third = service.exportPolicies();
+      releaseFirstCapture();
+      await Promise.all([first, second, third]);
+
+      expect(getActiveElementsForPolicy).toHaveBeenCalledTimes(2);
+    });
+
+    it('publishes the newest caller snapshot in that caller session context', async () => {
+      const sessions = new AsyncLocalStorage<string>();
+      let releaseOlderCapture!: () => void;
+      let markOlderCaptureStarted!: () => void;
+      const olderCaptureBlocked = new Promise<void>((resolve) => {
+        releaseOlderCapture = resolve;
+      });
+      const olderCaptureStarted = new Promise<void>((resolve) => {
+        markOlderCaptureStarted = resolve;
+      });
+      const capturedSessions: string[] = [];
+      const service = createServiceWithDir(policyDir, {
+        getActiveElementsForPolicy: async () => {
+          const session = sessions.getStore() ?? 'missing';
+          capturedSessions.push(session);
+          if (session === 'older') {
+            markOlderCaptureStarted();
+            await olderCaptureBlocked;
+          }
+          return [{ type: 'persona', name: session, metadata: {} }];
+        },
+      });
+
+      const older = sessions.run('older', () => service.exportPolicies());
+      await olderCaptureStarted;
+      const newer = sessions.run('newer', () => service.exportPolicies());
+      releaseOlderCapture();
+      await Promise.all([older, newer]);
+
+      const policy = await readPolicyFile();
+      expect(capturedSessions).toEqual(['older', 'newer']);
+      expect(policy.element_policies.elements).toEqual([
+        expect.objectContaining({ type: 'persona', name: 'newer' }),
+      ]);
     });
 
     it('should produce valid schema v1.0 structure', async () => {

--- a/tests/unit/storage/ElementStorageLayer.test.ts
+++ b/tests/unit/storage/ElementStorageLayer.test.ts
@@ -133,6 +133,52 @@ describe('ElementStorageLayer', () => {
       // Backend should only be called once
       expect(backend.listFiles).toHaveBeenCalledTimes(1);
     });
+
+    it('runs one trailing scan for freshness-sensitive callers', async () => {
+      await layer.scan();
+      layer.invalidate();
+
+      let markOlderScanStarted!: () => void;
+      let releaseOlderScan!: () => void;
+      const olderScanStarted = new Promise<void>((resolve) => {
+        markOlderScanStarted = resolve;
+      });
+      const olderScanBlocked = new Promise<void>((resolve) => {
+        releaseOlderScan = resolve;
+      });
+      (backend.statMany as jest.Mock<any>)
+        .mockImplementationOnce(async () => {
+          markOlderScanStarted();
+          await olderScanBlocked;
+          return new Map([
+            ['alpha.md', makeMeta('alpha.md', 1000)],
+            ['beta.md', makeMeta('beta.md', 5000)],
+          ]);
+        })
+        .mockResolvedValue(new Map([
+          ['alpha.md', makeMeta('alpha.md', 1000)],
+          ['beta.md', makeMeta('beta.md', 5000)],
+        ]));
+      (backend.readFile as jest.Mock<any>).mockImplementation((absPath: string) => {
+        if (absPath.includes('alpha')) return Promise.resolve(makeContent('Alpha', 'Alpha desc'));
+        if (absPath.includes('beta')) return Promise.resolve(makeContent('Beta Updated', 'New desc'));
+        return Promise.resolve(makeContent('Unknown'));
+      });
+
+      const olderScan = layer.scan();
+      await olderScanStarted;
+      const freshScans = [
+        layer.scan({ freshAfterInFlight: true }),
+        layer.scan({ freshAfterInFlight: true }),
+      ];
+      releaseOlderScan();
+      const [, firstFreshDiff, secondFreshDiff] = await Promise.all([olderScan, ...freshScans]);
+
+      expect(backend.listFiles).toHaveBeenCalledTimes(3);
+      expect(firstFreshDiff.modified).toContain('beta.md');
+      expect(secondFreshDiff.modified).toContain('beta.md');
+      expect(layer.getPathByName('Beta Updated')).toBe('beta.md');
+    });
   });
 
   describe('change detection', () => {

--- a/tests/unit/storage/MemoryStorageLayer.test.ts
+++ b/tests/unit/storage/MemoryStorageLayer.test.ts
@@ -270,6 +270,44 @@ describe('MemoryStorageLayer', () => {
       expect(d1).toBe(d2);
       expect(d2).toBe(d3);
     });
+
+    it('runs one trailing scan for freshness-sensitive callers', async () => {
+      await layer.scan();
+      (backend.directoryExists as jest.Mock<any>).mockClear();
+      layer.invalidate();
+
+      let markOlderScanStarted!: () => void;
+      let releaseOlderScan!: () => void;
+      const olderScanStarted = new Promise<void>((resolve) => {
+        markOlderScanStarted = resolve;
+      });
+      const olderScanBlocked = new Promise<void>((resolve) => {
+        releaseOlderScan = resolve;
+      });
+      (backend.directoryExists as jest.Mock<any>)
+        .mockImplementationOnce(async () => {
+          markOlderScanStarted();
+          await olderScanBlocked;
+          return true;
+        })
+        .mockResolvedValue(true);
+      (backend.statMany as jest.Mock<any>).mockResolvedValue(new Map([
+        ['system/baseline.yaml', makeMeta('system/baseline.yaml', 2000)],
+      ]));
+
+      const olderScan = layer.scan();
+      await olderScanStarted;
+      const freshScans = [
+        layer.scan({ freshAfterInFlight: true }),
+        layer.scan({ freshAfterInFlight: true }),
+      ];
+      releaseOlderScan();
+      const [, firstFreshDiff, secondFreshDiff] = await Promise.all([olderScan, ...freshScans]);
+
+      expect(backend.directoryExists).toHaveBeenCalledTimes(2);
+      expect(firstFreshDiff.modified).toContain('system/baseline.yaml');
+      expect(secondFreshDiff.modified).toContain('system/baseline.yaml');
+    });
   });
 
   // ----------------------------------------------------------------

--- a/tests/unit/storage/types.test.ts
+++ b/tests/unit/storage/types.test.ts
@@ -27,6 +27,7 @@ describe('mergeManifestDiffResults', () => {
     ['modified', 'removed', 'removed'],
     ['removed', 'added', 'modified'],
     ['removed', 'modified', 'modified'],
+    ['removed', 'removed', 'removed'],
     ['unchanged', 'modified', 'modified'],
     ['unchanged', 'removed', 'removed'],
     ['unchanged', 'unchanged', 'unchanged'],

--- a/tests/unit/storage/types.test.ts
+++ b/tests/unit/storage/types.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  mergeManifestDiffResults,
+  type ManifestDiffResult,
+} from '../../../src/storage/types.js';
+
+const emptyDiff = (): ManifestDiffResult => ({
+  added: [],
+  modified: [],
+  removed: [],
+  unchanged: [],
+});
+
+function diff(category: keyof ManifestDiffResult, filePath = 'policy.md'): ManifestDiffResult {
+  const result = emptyDiff();
+  result[category].push(filePath);
+  return result;
+}
+
+describe('mergeManifestDiffResults', () => {
+  it.each([
+    ['added', 'unchanged', 'added'],
+    ['added', 'modified', 'added'],
+    ['added', 'removed', 'removed'],
+    ['modified', 'unchanged', 'modified'],
+    ['modified', 'modified', 'modified'],
+    ['modified', 'removed', 'removed'],
+    ['removed', 'added', 'modified'],
+    ['removed', 'modified', 'modified'],
+    ['unchanged', 'modified', 'modified'],
+    ['unchanged', 'removed', 'removed'],
+    ['unchanged', 'unchanged', 'unchanged'],
+  ] as const)('merges %s -> %s as %s', (first, second, expected) => {
+    const result = mergeManifestDiffResults(diff(first), diff(second));
+
+    expect(result[expected]).toEqual(['policy.md']);
+    expect(Object.values(result).flat()).toEqual(['policy.md']);
+  });
+
+  it('preserves deterministic first-seen order and disjoint categories', () => {
+    const first: ManifestDiffResult = {
+      added: ['new.md'],
+      modified: ['changed.md'],
+      removed: [],
+      unchanged: ['steady.md'],
+    };
+    const second: ManifestDiffResult = {
+      added: ['replacement.md'],
+      modified: ['steady.md'],
+      removed: ['new.md'],
+      unchanged: ['changed.md'],
+    };
+
+    expect(mergeManifestDiffResults(first, second)).toEqual({
+      added: ['replacement.md'],
+      modified: ['changed.md', 'steady.md'],
+      removed: ['new.md'],
+      unchanged: [],
+    });
+  });
+});


### PR DESCRIPTION
Closes #2634.
Part of #2627.

## Summary

This is the first of three beta-native hotfix PRs. It ports the bounded active-policy resolution, freshness coordination, and serialized policy exports onto beta without merging or batch-cherry-picking stable history.

- Replaces ensemble member × full-catalog expansion with deduplicated indexed lookups.
- Normalizes singular/plural member types, refreshes each manager once, caps member reads at 8, and preserves result order.
- Makes reporting snapshots coalescible per session while enforcement reads always request freshness after any in-flight scan.
- Adds per-directory trailing scans and coherent manifest-diff merging so invalidations are not lost.
- Preserves database-backed cache eviction semantics without filesystem path assumptions.
- Serializes policy exports with a bounded trailing drain and preserves each caller's async session context.
- Resolves the contradictory manifest-transition behavior tracked in #2632.

## Beta-specific behavior

- Baseline: `04fbce6315c7693b4d6bddd7ccb5b092ecd6ba68`
- Exact head: `c5e22f6147ac806f915f46dfbf80385cfba08ad8`
- Target: `beta`
- No activation identity/restore work from PR 2.
- No OAuth helper work from PR 3.
- No version bump, dependency update, release, deployment, or hosted integration promotion.

## Validation

Passed locally on macOS:

- Focused policy/storage/MCP-AQL/export tests: 8 suites, 307 tests.
- Gatekeeper integration tests: 4 suites, 30 tests.
- Rapid security gate: 9 suites, 108 passed (46 intentionally excluded by the script's name filter).
- Repository security audit: 0 findings across 447 files.
- TypeScript source typecheck.
- Script typecheck.
- ESLint with zero warnings across `src` and the new standalone tests.
- Build and diff checks.

Passed in the repository's Node 20 Debian CI-simulation Docker image with an 8 GB memory cap:

- Image build, including safety package and application build.
- Focused policy/storage/MCP-AQL/export tests: 8 suites, 305 tests.

Additional regression coverage includes:

- 500 repeated ensemble references collapsing to 250 unique indexed reads.
- Duplicate singular/plural references.
- An 8-read concurrency ceiling.
- Multiple freshness callers sharing exactly one trailing scan.
- Failed initial scans recovering through the trailing scan.
- Same-session reporting coalescing and cross-session isolation.
- Enforcement bypassing an older reporting snapshot.
- Newest-session policy export winning overlapping writes.
- Database identifier eviction without filesystem path joining.

## Known baseline/environment observations

- `npm audit --audit-level=high` reports existing beta dependency advisories; this PR does not change `package-lock.json`.
- The exhaustive local suite has unrelated environment-coupled failures (installed Claude permission hook, current local MCP interface mode, one shared-state console test, and the existing BuildInfo timing microbenchmark). Focused and adjacent implementation suites pass.
- Podman is not installed on this host, so the equivalent repository Docker CI-simulation image was used. The protected Ubuntu/macOS/Windows matrix remains required.

## Merge discipline

Draft only. Do not merge without Mick's explicit approval of this exact head. Do not use an administrator merge.

Todd coordination is satisfied for the beta hotfix sequence.


