### PR TITLE
[BETA HOTFIX 2/3] Adapt durable activation identity to sessions, files, and PostgreSQL

### DIFF
--- a/src/di/Container.ts
+++ b/src/di/Container.ts
@@ -922,6 +922,13 @@ export class DollhouseContainer {
       activateFn: (activation: PersistedActivation) => Promise<{ success: boolean }>,
       skip?: Set<string>,
     ): Promise<void> => {
+      const prune = (activation: PersistedActivation): void => {
+        if (activation.filename || activation.identity) {
+          store.removeStaleActivation(elementType, activation.name, activation.filename, activation.identity);
+        } else {
+          store.removeStaleActivation(elementType, activation.name);
+        }
+      };
       for (const activation of store.getActivations(elementType)) {
         if (skip?.has(activation.name)) {
           logger.debug(`[Container] ${elementType} '${activation.name}' already active (auto-loaded), skipping`);
@@ -933,12 +940,12 @@ export class DollhouseContainer {
             restoredCount++;
           } else {
             logger.debug(`[Container] Pruning missing ${elementType} '${activation.name}'`);
-            store.removeStaleActivation(elementType, activation.name);
+            prune(activation);
             skippedCount++;
           }
         } catch {
           logger.debug(`[Container] Skipping failed ${elementType} '${activation.name}'`);
-          store.removeStaleActivation(elementType, activation.name);
+          prune(activation);
           skippedCount++;
         }
       }
@@ -947,7 +954,29 @@ export class DollhouseContainer {
     // Personas use filename if available (Issue #843)
     await restoreType('persona', (a) => personaManager.activatePersona(a.filename || a.name));
     await restoreType('skill', (a) => skillManager.activateSkill(a.name));
-    await restoreType('agent', (a) => agentManager.activateAgent(a.name));
+    await restoreType('agent', async (activation) => {
+      const persistedIdentity = activation.identity ?? (activation.filename
+        ? { kind: 'file' as const, value: activation.filename }
+        : undefined);
+      const result = persistedIdentity
+        ? await agentManager.activateAgentByStorageIdentity(persistedIdentity, activation.name)
+        : await agentManager.activateAgent(activation.name);
+
+      // Upgrade a successful legacy name-only/filename record immediately.
+      // The next restart can then resolve the agent after a metadata rename.
+      if (result.success && result.agent && result.identity) {
+        if (
+          activation.identity && (
+            activation.identity.kind !== result.identity.kind ||
+            activation.identity.value !== result.identity.value
+          )
+        ) {
+          store.removeStaleActivation('agent', activation.name, activation.filename, activation.identity);
+        }
+        store.recordActivation('agent', result.agent.metadata.name, undefined, result.identity);
+      }
+      return result;
+    });
 
     // Memories: dedup against auto-loaded ones
     const activeMemories = await memoryManager.getActiveMemories();

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -1066,10 +1066,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     const identity = this.getActivationIdentity(agent);
     const key = activeKey ?? identity?.value ?? agent.metadata.name;
     this.getActivationSet().delete(key);
-    this.getActivationSet().delete(agent.metadata.name);
-    this.getActivationSet().delete(identifier);
     this.getActivationNameMap().delete(key);
-    if (identity) this.getActivationNameMap().delete(identity.value);
 
     // Update agent status in memory
     await agent.deactivate();

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -109,6 +109,8 @@ import { ElementNotFoundError, ErrorCategory, ErrorHandler } from '../../utils/E
 import { ValidationErrorCodes } from '../../utils/errorCodes.js';
 import { sanitizeGatekeeperPolicy } from '../../handlers/mcp-aql/policies/ElementPolicies.js';
 import { SECURITY_LIMITS } from '../../security/constants.js';
+import { ElementStatus } from '../../types/elements/IElement.js';
+import type { PersistedActivationIdentity } from '../../state/IActivationStateStore.js';
 
 const AGENT_FILE_EXTENSION = '.md';
 const STATE_DIRECTORY = '.state';
@@ -150,6 +152,13 @@ interface ExecutionGenerationEntry {
   observers: number;
 }
 
+export interface AgentActivationResult {
+  success: boolean;
+  message: string;
+  agent?: Agent;
+  identity?: PersistedActivationIdentity;
+}
+
 export interface ExecutionGenerationObservation {
   token: object;
   release: () => void;
@@ -169,6 +178,7 @@ export class AgentManager extends BaseElementManager<Agent> {
   private metadataService: MetadataService;
   // Fallback for tests/callers that don't inject the registry
   private readonly _localActiveAgentNames: Set<string> = new Set();
+  private readonly _localAgentNamesByIdentity = new Map<string, string>();
 
   // Issue #1948: Instance-injected dependencies (replaces static resolvers)
   private _elementManagerResolver?: (managerName: string) => ResolvedElementManager | null;
@@ -231,6 +241,13 @@ export class AgentManager extends BaseElementManager<Agent> {
   /** Issue #1946: Per-session activation state via base class helper. */
   private getActivationSet(): Set<string> {
     return this.resolveActivationSet('agents', this._localActiveAgentNames);
+  }
+
+  private getActivationNameMap(): Map<string, string> {
+    if (!this.activationRegistry) return this._localAgentNamesByIdentity;
+    const sessionId = this.contextTracker?.getSessionContext()?.sessionId
+      ?? this.activationRegistry.getDefaultSessionId();
+    return this.activationRegistry.getOrCreate(sessionId).agentNamesByIdentity;
   }
 
   protected override getElementLabel(): string {
@@ -901,17 +918,19 @@ export class AgentManager extends BaseElementManager<Agent> {
     return AGENT_FILE_EXTENSION;
   }
 
-  /**
-   * Override list to apply active status based on activeAgentNames set
-   */
+  /** Apply per-session active status using durable storage identity. */
   override async list(options?: { includePublic?: boolean }): Promise<Agent[]> {
     const agents = await super.list(options);
 
-    // Apply active status to agents that are in the active set (by name)
     for (const agent of agents) {
-      if (this.getActivationSet().has(agent.metadata.name)) {
-        // Activate the agent to set status to ACTIVE
-        await agent.activate();
+      const identity = this.getActivationIdentity(agent);
+      if (
+        (identity && this.getActivationSet().has(identity.value)) ||
+        this.getActivationSet().has(agent.metadata.name)
+      ) {
+        if (typeof agent.getStatus !== 'function' || agent.getStatus() !== ElementStatus.ACTIVE) {
+          await agent.activate();
+        }
       }
     }
 
@@ -925,23 +944,48 @@ export class AgentManager extends BaseElementManager<Agent> {
    * Issue #24 (LOW PRIORITY): Consistent error messages using ElementMessages
    * Issue #24 (LOW PRIORITY): Cleanup trigger for memory leak prevention
    */
-  async activateAgent(identifier: string): Promise<{ success: boolean; message: string; agent?: Agent }> {
-    // PERFORMANCE FIX: Use findByName() instead of list()
+  async activateAgent(identifier: string): Promise<AgentActivationResult> {
     const agent = await this.findByName(identifier);
+    return this.activateResolvedAgent(agent, identifier);
+  }
 
+  /** Restore or address an agent through its backend-owned durable key. */
+  async activateAgentByStorageIdentity(
+    identity: PersistedActivationIdentity,
+    legacyName?: string,
+  ): Promise<AgentActivationResult> {
+    await this.scanAndEvict({ freshAfterInFlight: true });
+    const expectedKind = isWritableStorageLayer(this.storageLayer) ? 'database' : 'file';
+    const agent = identity.kind === expectedKind
+      ? await this.findByStorageIdentity(identity.value)
+      : undefined;
+    if (agent) return this.activateResolvedAgent(agent, legacyName ?? agent.metadata.name);
+    if (legacyName) return this.activateAgent(legacyName);
+    return this.activateResolvedAgent(undefined, identity.value);
+  }
+
+  private async activateResolvedAgent(
+    agent: Agent | undefined,
+    activationName: string,
+  ): Promise<AgentActivationResult> {
     if (!agent) {
       return {
         success: false,
         // CONSISTENCY FIX: Use standardized error message format
-        message: ElementMessages.notFound(ElementType.AGENT, identifier)
+        message: ElementMessages.notFound(ElementType.AGENT, activationName)
       };
     }
 
     // MEMORY LEAK FIX: Check if cleanup is needed before adding
     this.checkAndCleanupActiveSet();
 
-    // Add to active set (by name, which is stable across reloads)
-    this.getActivationSet().add(agent.metadata.name);
+    const identity = this.getActivationIdentity(agent);
+    if (identity) {
+      this.getActivationSet().add(identity.value);
+      this.getActivationNameMap().set(identity.value, agent.metadata.name);
+    } else {
+      this.getActivationSet().add(agent.metadata.name);
+    }
 
     // Update agent status in memory
     await agent.activate();
@@ -967,7 +1011,18 @@ export class AgentManager extends BaseElementManager<Agent> {
       success: true,
       // CONSISTENCY FIX: Use standardized success message format
       message: ElementMessages.activated(ElementType.AGENT, agent.metadata.name),
-      agent
+      agent,
+      ...(identity ? { identity } : {}),
+    };
+  }
+
+  /** Return the durable key attached by the cache/storage pipeline. */
+  getActivationIdentity(agent: Agent): PersistedActivationIdentity | undefined {
+    const storagePath = (agent as Agent & { filePath?: unknown }).filePath;
+    if (typeof storagePath !== 'string' || storagePath.trim() === '') return undefined;
+    return {
+      kind: isWritableStorageLayer(this.storageLayer) ? 'database' : 'file',
+      value: storagePath,
     };
   }
 
@@ -977,9 +1032,28 @@ export class AgentManager extends BaseElementManager<Agent> {
    * Issue #24 (LOW PRIORITY): Performance optimization using findByName()
    * Issue #24 (LOW PRIORITY): Consistent error messages using ElementMessages
    */
-  async deactivateAgent(identifier: string): Promise<{ success: boolean; message: string }> {
-    // PERFORMANCE FIX: Use findByName() instead of list()
-    const agent = await this.findByName(identifier);
+  async deactivateAgent(identifier: string): Promise<AgentActivationResult> {
+    await this.scanAndEvict({ freshAfterInFlight: true });
+    const normalizedIdentifier = identifier.toLowerCase();
+    let agent: Agent | undefined;
+    let activeKey: string | undefined;
+
+    for (const key of this.getActivationSet()) {
+      const alias = this.getActivationNameMap().get(key);
+      const candidate = alias === undefined
+        ? await this.findByName(key)
+        : await this.findByStorageIdentity(key);
+      if (
+        key.toLowerCase() === normalizedIdentifier ||
+        alias?.toLowerCase() === normalizedIdentifier ||
+        candidate?.metadata.name.toLowerCase() === normalizedIdentifier
+      ) {
+        agent = candidate;
+        activeKey = key;
+        if (agent) break;
+      }
+    }
+    agent ??= await this.findByName(identifier);
 
     if (!agent) {
       return {
@@ -989,8 +1063,13 @@ export class AgentManager extends BaseElementManager<Agent> {
       };
     }
 
-    // Remove from active set
+    const identity = this.getActivationIdentity(agent);
+    const key = activeKey ?? identity?.value ?? agent.metadata.name;
+    this.getActivationSet().delete(key);
     this.getActivationSet().delete(agent.metadata.name);
+    this.getActivationSet().delete(identifier);
+    this.getActivationNameMap().delete(key);
+    if (identity) this.getActivationNameMap().delete(identity.value);
 
     // Update agent status in memory
     await agent.deactivate();
@@ -1013,7 +1092,9 @@ export class AgentManager extends BaseElementManager<Agent> {
     return {
       success: true,
       // CONSISTENCY FIX: Use standardized success message format
-      message: ElementMessages.deactivated(ElementType.AGENT, agent.metadata.name)
+      message: ElementMessages.deactivated(ElementType.AGENT, agent.metadata.name),
+      agent,
+      ...(identity ? { identity } : {}),
     };
   }
 
@@ -1023,9 +1104,15 @@ export class AgentManager extends BaseElementManager<Agent> {
   async getActiveAgents(options: StorageScanOptions = {}): Promise<Agent[]> {
     await this.scanAndEvict(options);
     const agents: Agent[] = [];
-    for (const name of this.getActivationSet()) {
-      const agent = await this.findByName(name);
-      if (agent) agents.push(agent);
+    for (const key of this.getActivationSet()) {
+      const agent = this.getActivationNameMap().has(key)
+        ? await this.findByStorageIdentity(key)
+        : await this.findByName(key);
+      if (!agent) continue;
+      if (typeof agent.getStatus === 'function' && agent.getStatus() !== ElementStatus.ACTIVE) {
+        await agent.activate();
+      }
+      agents.push(agent);
     }
     return agents;
   }
@@ -2044,14 +2131,16 @@ export class AgentManager extends BaseElementManager<Agent> {
   private async cleanupStaleActiveAgents(): Promise<void> {
     try {
       const startSize = this.getActivationSet().size;
-      const agents = await this.list();
-      const existingAgentNames = new Set(agents.map(a => a.metadata.name));
-
       const staleNames: string[] = [];
-      for (const activeName of this.getActivationSet()) {
-        if (!existingAgentNames.has(activeName)) {
-          this.getActivationSet().delete(activeName);
-          staleNames.push(activeName);
+      for (const activeKey of this.getActivationSet()) {
+        const alias = this.getActivationNameMap().get(activeKey);
+        const agent = alias === undefined
+          ? await this.findByName(activeKey)
+          : await this.findByStorageIdentity(activeKey);
+        if (!agent) {
+          this.getActivationSet().delete(activeKey);
+          this.getActivationNameMap().delete(activeKey);
+          staleNames.push(alias ?? activeKey);
         }
       }
 

--- a/src/elements/base/BaseElementManager.ts
+++ b/src/elements/base/BaseElementManager.ts
@@ -506,6 +506,28 @@ export abstract class BaseElementManager<T extends IElement> implements IElement
     return this._resolver.findByName(identifier);
   }
 
+  /**
+   * Resolve an element by its backend-owned durable key. File-backed managers
+   * accept the indexed relative path; database-backed managers accept a row
+   * UUID. Unlike findByName(), this never interprets the key as display text.
+   */
+  async findByStorageIdentity(identity: string): Promise<T | undefined> {
+    if (typeof identity !== 'string' || identity.trim() === '') return undefined;
+    const normalizedIdentity = identity.trim();
+    if (
+      isWritableStorageLayer(this.storageLayer) &&
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(normalizedIdentity)
+    ) {
+      return undefined;
+    }
+    try {
+      return await this.load(normalizedIdentity);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+      throw error;
+    }
+  }
+
   // ============================================
   // INVALID ELEMENT TRACKING (Issue #708)
   // ============================================

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -392,9 +392,11 @@ export class ElementCRUDHandler {
       // Issue #598, #1946: Persist activation state for session restore (per-session)
       const sessionStore = this.getSessionActivationStore();
       if (sessionStore) {
-        const filename = normalizedType === ElementType.PERSONA
-          ? this.personaManager.findPersona(name)?.filename
-          : undefined;
+        const filename = result.activationRecord?.filename ?? (
+          normalizedType === ElementType.PERSONA
+            ? this.personaManager.findPersona(name)?.filename
+            : undefined
+        );
         sessionStore.recordActivation(
           normalizedType,
           result.activationRecord?.name ?? name,
@@ -1053,7 +1055,7 @@ export class ElementCRUDHandler {
         sessionStore.recordDeactivation(
           normalizedType,
           result.activationRecord?.name ?? name,
-          undefined,
+          result.activationRecord?.filename,
           result.activationRecord?.identity,
         );
       }

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -70,14 +70,22 @@ type PolicyElement = {
   type: string;
   name: string;
   metadata: Record<string, unknown>;
+  storageIdentity?: string;
 };
 
 type PolicyMemberElement = {
   metadata?: Record<string, unknown>;
+  filePath?: string;
+  filename?: string;
 };
 
 type PolicyIndexOptions = { freshAfterInFlight?: boolean };
 type IndexedPolicyManagers = Map<string, Promise<BaseElementManager<any> | undefined>>;
+type DeadlockReliefElement = {
+  type: string;
+  name: string;
+  activationIdentifier?: string;
+};
 type PolicyMemberCandidate = { type: string; name: string; key: string };
 
 const ACTIVE_POLICY_LOOKUP_CONCURRENCY = 8;
@@ -235,8 +243,12 @@ export class ElementCRUDHandler {
     }
   }
 
-  private policyElementKey(type: string, name: string): string {
-    return `${this.toPolicyElementType(this.normalizeElementType(type))}:${this.normalizeLookupValue(name)}`;
+  private policyElementKey(type: string, name: string, storageIdentity?: string): string {
+    const normalizedType = this.toPolicyElementType(this.normalizeElementType(type));
+    const identity = this.normalizeLookupValue(storageIdentity);
+    return identity
+      ? `${normalizedType}:identity:${identity}`
+      : `${normalizedType}:name:${this.normalizeLookupValue(name)}`;
   }
 
   private getPolicySnapshotScope(): string {
@@ -383,13 +395,18 @@ export class ElementCRUDHandler {
         const filename = normalizedType === ElementType.PERSONA
           ? this.personaManager.findPersona(name)?.filename
           : undefined;
-        sessionStore.recordActivation(normalizedType, name, filename);
+        sessionStore.recordActivation(
+          normalizedType,
+          result.activationRecord?.name ?? name,
+          filename,
+          result.activationRecord?.identity,
+        );
       }
 
       // Issue #762: Export policies to bridge after activation
       this.policyExportService?.exportPolicies().catch(() => {});
 
-      return result;
+      return { content: result.content };
     } catch (error) {
       logger.error(`Failed to activate element:`, { type, name, error });
       return {
@@ -500,11 +517,13 @@ export class ElementCRUDHandler {
         ? await this.personaManager.resolveActivePersonas()
         : this.personaManager.getActivePersonas();
       for (const persona of personas) {
-        seen.add(this.policyElementKey('persona', persona.metadata.name));
+        const storageIdentity = this.normalizeLookupValue(persona.filename) || undefined;
+        seen.add(this.policyElementKey('persona', persona.metadata.name, storageIdentity));
         result.push({
           type: 'persona',
           name: persona.metadata.name,
           metadata: persona.metadata as unknown as Record<string, unknown>,
+          ...(storageIdentity ? { storageIdentity } : {}),
         });
       }
     } catch (error) {
@@ -534,11 +553,13 @@ export class ElementCRUDHandler {
   ): Promise<void> {
     try {
       for (const agent of await this.agentManager.getActiveAgents(indexOptions)) {
-        seen.add(this.policyElementKey('agent', agent.metadata.name));
+        const storageIdentity = this.agentManager.getActivationIdentity(agent)?.value;
+        seen.add(this.policyElementKey('agent', agent.metadata.name, storageIdentity));
         result.push({
           type: 'agent',
           name: agent.metadata.name,
           metadata: agent.metadata as unknown as Record<string, unknown>,
+          ...(storageIdentity ? { storageIdentity } : {}),
         });
       }
     } catch (error) {
@@ -696,7 +717,7 @@ export class ElementCRUDHandler {
         return;
       }
 
-      const key = `${element.type}:${element.name}`;
+      const key = this.policyElementKey(element.type, element.name, element.storageIdentity);
       const existing = merged.get(key);
       if (existing) {
         sessionIds.forEach(id => existing.sessionIds.add(id));
@@ -735,7 +756,8 @@ export class ElementCRUDHandler {
         const normalizedType = this.normalizeElementType(type);
         const normalizedName = this.normalizeLookupValue(activation.name);
         const normalizedFilename = this.normalizeLookupValue(activation.filename);
-        const lookupKey = `${normalizedType}:${normalizedName}:${normalizedFilename}`;
+        const normalizedIdentity = this.normalizeLookupValue(activation.identity?.value);
+        const lookupKey = `${normalizedType}:${activation.identity?.kind ?? ''}:${normalizedIdentity}:${normalizedName}:${normalizedFilename}`;
         const existing = persistedLookups.get(lookupKey);
         if (existing) return existing;
 
@@ -743,9 +765,12 @@ export class ElementCRUDHandler {
           .then(async (manager) => {
             if (!manager) return null;
 
-            let found = normalizedName !== ''
-              ? await manager.findByName(normalizedName) as PolicyMemberElement | undefined
+            let found = normalizedIdentity !== ''
+              ? await manager.findByStorageIdentity(normalizedIdentity) as PolicyMemberElement | undefined
               : undefined;
+            if (!found && normalizedName !== '') {
+              found = await manager.findByName(normalizedName) as PolicyMemberElement | undefined;
+            }
             if (!found && normalizedFilename !== '') {
               found = await manager.findByName(normalizedFilename) as PolicyMemberElement | undefined;
             }
@@ -754,10 +779,17 @@ export class ElementCRUDHandler {
               return null;
             }
 
+            const foundStorageIdentity = normalizedType === ElementType.AGENT
+              ? found.filePath
+              : normalizedType === ElementType.PERSONA
+                ? found.filename ?? found.filePath ?? normalizedFilename
+                : undefined;
+
             return {
               type: this.toPolicyElementType(normalizedType),
               name: (found.metadata['name'] as string) ?? activation.name,
               metadata: found.metadata,
+              ...(foundStorageIdentity ? { storageIdentity: foundStorageIdentity } : {}),
             };
           });
         persistedLookups.set(lookupKey, lookup);
@@ -791,14 +823,15 @@ export class ElementCRUDHandler {
     };
     snapshotFile?: string;
   }> {
-    const activeElements = await this.collectActiveElementsForDeadlockRelief();
+    const activeElementTargets = await this.collectActiveElementsForDeadlockRelief();
+    const activeElements = activeElementTargets.map(({ type, name }) => ({ type, name }));
     const activePolicyElements = await this.getActiveElementsForPolicy();
     const sandboxingElement = findConfirmDenyingElement(activePolicyElements);
     const advisoryElements = findConfirmAdvisoryElements(activePolicyElements);
     const deactivated: Array<{ type: string; name: string }> = [];
     const failed: Array<{ type: string; name: string; error: string }> = [];
 
-    for (const element of activeElements) {
+    for (const element of activeElementTargets) {
       const strategy = this.strategies.get(element.type);
       if (!strategy) {
         failed.push({
@@ -810,8 +843,8 @@ export class ElementCRUDHandler {
       }
 
       try {
-        await strategy.deactivate(element.name);
-        deactivated.push(element);
+        await strategy.deactivate(element.activationIdentifier ?? element.name);
+        deactivated.push({ type: element.type, name: element.name });
       } catch (error) {
         failed.push({
           type: element.type,
@@ -875,8 +908,8 @@ export class ElementCRUDHandler {
     };
   }
 
-  private async collectActiveElementsForDeadlockRelief(): Promise<Array<{ type: string; name: string }>> {
-    const activeElements: Array<{ type: string; name: string }> = [];
+  private async collectActiveElementsForDeadlockRelief(): Promise<DeadlockReliefElement[]> {
+    const activeElements: DeadlockReliefElement[] = [];
 
     const activePersonas = this.personaManager.getActivePersonas();
     activeElements.push(...activePersonas.map((persona) => ({
@@ -891,10 +924,14 @@ export class ElementCRUDHandler {
     })));
 
     const activeAgents = await this.agentManager.getActiveAgents();
-    activeElements.push(...activeAgents.map((agent) => ({
-      type: ElementType.AGENT,
-      name: agent.metadata.name,
-    })));
+    activeElements.push(...activeAgents.map((agent) => {
+      const activationIdentifier = this.agentManager.getActivationIdentity(agent)?.value;
+      return {
+        type: ElementType.AGENT,
+        name: agent.metadata.name,
+        ...(activationIdentifier ? { activationIdentifier } : {}),
+      };
+    }));
 
     const activeMemories = await this.memoryManager.getActiveMemories();
     activeElements.push(...activeMemories.map((memory) => ({
@@ -910,7 +947,7 @@ export class ElementCRUDHandler {
 
     const seen = new Set<string>();
     return activeElements.filter((element) => {
-      const key = `${element.type}:${element.name}`;
+      const key = `${element.type}:${element.activationIdentifier ?? element.name}`;
       if (seen.has(key)) {
         return false;
       }
@@ -1013,13 +1050,18 @@ export class ElementCRUDHandler {
       // Issue #598, #1946: Persist deactivation state for session restore (per-session)
       const sessionStore = this.getSessionActivationStore();
       if (sessionStore) {
-        sessionStore.recordDeactivation(normalizedType, name);
+        sessionStore.recordDeactivation(
+          normalizedType,
+          result.activationRecord?.name ?? name,
+          undefined,
+          result.activationRecord?.identity,
+        );
       }
 
       // Issue #762: Export policies to bridge after deactivation
       this.policyExportService?.exportPolicies().catch(() => {});
 
-      return result;
+      return { content: result.content };
     } catch (error) {
       // Re-throw ElementNotFoundError to propagate to MCP-AQL layer
       // This ensures operations return success=false instead of success=true with error text

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -781,11 +781,12 @@ export class ElementCRUDHandler {
               return null;
             }
 
-            const foundStorageIdentity = normalizedType === ElementType.AGENT
-              ? found.filePath
-              : normalizedType === ElementType.PERSONA
-                ? found.filename ?? found.filePath ?? normalizedFilename
-                : undefined;
+            let foundStorageIdentity: string | undefined;
+            if (normalizedType === ElementType.AGENT) {
+              foundStorageIdentity = found.filePath;
+            } else if (normalizedType === ElementType.PERSONA) {
+              foundStorageIdentity = found.filename ?? found.filePath ?? normalizedFilename;
+            }
 
             return {
               type: this.toPolicyElementType(normalizedType),

--- a/src/handlers/strategies/AgentActivationStrategy.ts
+++ b/src/handlers/strategies/AgentActivationStrategy.ts
@@ -211,7 +211,11 @@ export class AgentActivationStrategy extends BaseActivationStrategy implements E
       content: [{
         type: "text",
         text: parts.join('\n')
-      }]
+      }],
+      activationRecord: {
+        name: agent.metadata.name,
+        ...(result.identity ? { identity: result.identity } : {}),
+      },
     };
   }
 
@@ -228,7 +232,13 @@ export class AgentActivationStrategy extends BaseActivationStrategy implements E
       this.throwNotFoundError(name, 'Agent');
     }
 
-    return this.createSuccessResponse(result.message);
+    return {
+      ...this.createSuccessResponse(result.message),
+      activationRecord: {
+        name: result.agent?.metadata.name ?? name,
+        ...(result.identity ? { identity: result.identity } : {}),
+      },
+    };
   }
 
   /**

--- a/src/handlers/strategies/ElementActivationStrategy.ts
+++ b/src/handlers/strategies/ElementActivationStrategy.ts
@@ -19,6 +19,7 @@ export interface MCPResponse {
   /** Internal persistence metadata; not rendered into the MCP response body. */
   activationRecord?: {
     name: string;
+    filename?: string;
     identity?: PersistedActivationIdentity;
   };
 }

--- a/src/handlers/strategies/ElementActivationStrategy.ts
+++ b/src/handlers/strategies/ElementActivationStrategy.ts
@@ -6,6 +6,8 @@
  * implements this interface to provide custom activation logic.
  */
 
+import type { PersistedActivationIdentity } from '../../state/IActivationStateStore.js';
+
 /**
  * Standard MCP response format
  */
@@ -14,6 +16,11 @@ export interface MCPResponse {
     type: string;
     text: string;
   }>;
+  /** Internal persistence metadata; not rendered into the MCP response body. */
+  activationRecord?: {
+    name: string;
+    identity?: PersistedActivationIdentity;
+  };
 }
 
 /**

--- a/src/handlers/strategies/PersonaActivationStrategy.ts
+++ b/src/handlers/strategies/PersonaActivationStrategy.ts
@@ -66,7 +66,11 @@ export class PersonaActivationStrategy extends BaseActivationStrategy implements
       content: [{
         type: "text",
         text
-      }]
+      }],
+      activationRecord: {
+        name: persona.metadata.name,
+        filename: persona.filename,
+      },
     };
   }
 
@@ -107,7 +111,11 @@ export class PersonaActivationStrategy extends BaseActivationStrategy implements
       content: [{
         type: "text",
         text: `${indicator}✅ ${result.message}`
-      }]
+      }],
+      activationRecord: {
+        name: persona.metadata.name,
+        filename: persona.filename,
+      },
     };
   }
 

--- a/src/services/sessionIdentity.ts
+++ b/src/services/sessionIdentity.ts
@@ -2,8 +2,8 @@ import { createHash } from 'node:crypto';
 import os from 'node:os';
 import { UnicodeValidator } from '../security/validators/unicodeValidator.js';
 
-/** Session ID validation: must start with a letter, then alphanumeric/hyphens/underscores, 1-64 chars */
-export const SESSION_ID_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]{0,63}$/;
+/** Filename- and query-safe session identifiers, including digit-first UUIDs. */
+export const SESSION_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
 const DERIVED_SESSION_PREFIX = 'local';
 const DERIVED_SESSION_HASH_LENGTH = 10;
 

--- a/src/state/DatabaseActivationStateStore.ts
+++ b/src/state/DatabaseActivationStateStore.ts
@@ -10,9 +10,15 @@
 
 import { logger } from '../utils/logger.js';
 import { SecurityMonitor } from '../security/securityMonitor.js';
-import { UnicodeValidator } from '../security/validators/unicodeValidator.js';
-import { normalizeMCPAQLElementType } from '../handlers/mcp-aql/types.js';
 import type { DatabaseInstance } from '../database/connection.js';
+import {
+  normalizeActivationIdentifier,
+  normalizeActivationInput,
+  normalizeActivationType,
+  normalizePersistedActivationMap,
+  removeActivationRecords,
+  upsertActivationRecord,
+} from './activation-record-utils.js';
 import {
   validateDbStoreParams,
   validateDbSessionId,
@@ -35,20 +41,6 @@ import type {
 const STORE_NAME = 'DatabaseActivationStateStore';
 
 // ── Helpers ─────────────────────────────────────────────────────────
-
-function normalizeType(elementType: string): string | undefined {
-  return normalizeMCPAQLElementType(elementType);
-}
-
-function normalizeIdentifier(value: string): string {
-  return UnicodeValidator.normalize(value).normalizedContent.trim();
-}
-
-function normalizeIdentity(value: PersistedActivationIdentity | undefined): PersistedActivationIdentity | undefined {
-  if (!value || (value.kind !== 'file' && value.kind !== 'database')) return undefined;
-  const normalizedValue = normalizeIdentifier(value.value);
-  return normalizedValue ? { kind: value.kind, value: normalizedValue } : undefined;
-}
 
 // ── Implementation ──────────────────────────────────────────────────
 
@@ -89,26 +81,7 @@ export class DatabaseActivationStateStore implements IActivationStateStore {
       const raw = row.activations as Record<string, PersistedActivation[]> | null;
       if (!raw || typeof raw !== 'object') return;
 
-      for (const [rawType, entries] of Object.entries(raw)) {
-        const type = normalizeType(rawType);
-        if (!type || !Array.isArray(entries)) continue;
-
-        this.activations[type] = entries.flatMap((a) => {
-          if (!a || typeof a.name !== 'string') return [];
-          const normalizedName = normalizeIdentifier(a.name);
-          if (!normalizedName) return [];
-          const normalizedFilename = typeof a.filename === 'string'
-            ? normalizeIdentifier(a.filename)
-            : undefined;
-          const normalizedIdentity = normalizeIdentity(a.identity);
-          return [{
-            ...a,
-            name: normalizedName,
-            ...(normalizedFilename ? { filename: normalizedFilename } : {}),
-            ...(normalizedIdentity ? { identity: normalizedIdentity } : {}),
-          }];
-        });
-      }
+      this.activations = normalizePersistedActivationMap(raw);
 
       const totalCount = this.getTotalActivationCount();
       if (totalCount > 0) {
@@ -138,70 +111,33 @@ export class DatabaseActivationStateStore implements IActivationStateStore {
     filename?: string,
     identity?: PersistedActivationIdentity,
   ): void {
-    const type = normalizeType(elementType);
+    const type = normalizeActivationType(elementType);
     if (!type) return;
-    const normalizedName = normalizeIdentifier(name);
-    if (!normalizedName) return;
-    const normalizedFilename = typeof filename === 'string'
-      ? normalizeIdentifier(filename)
-      : undefined;
-    const normalizedIdentity = normalizeIdentity(identity);
+    const input = normalizeActivationInput(name, filename, identity);
+    if (!input) return;
 
     if (!this.activations[type]) {
       this.activations[type] = [];
     }
 
-    const existing = this.activations[type];
-    let activeRecord = normalizedIdentity
-      ? existing.find(a => a.identity?.kind === normalizedIdentity.kind && a.identity.value === normalizedIdentity.value)
-      : undefined;
-    activeRecord ??= normalizedIdentity?.kind === 'file'
-      ? existing.find(a => !a.identity && a.filename === normalizedIdentity.value)
-      : undefined;
-    activeRecord ??= normalizedFilename
-      ? existing.find(a => a.filename === normalizedFilename)
-      : undefined;
-    activeRecord ??= existing.find(a =>
-      a.name === normalizedName && (!normalizedIdentity || !a.identity)
+    const mutation = upsertActivationRecord(
+      this.activations[type],
+      type,
+      input,
+      new Date().toISOString(),
     );
-    if (activeRecord) {
-      let changed = false;
-      if (activeRecord.name !== normalizedName) {
-        activeRecord.name = normalizedName;
-        changed = true;
-      }
-      if (normalizedFilename && activeRecord.filename !== normalizedFilename) {
-        activeRecord.filename = normalizedFilename;
-        changed = true;
-      }
-      if (normalizedIdentity && (
-        activeRecord.identity?.kind !== normalizedIdentity.kind ||
-        activeRecord.identity?.value !== normalizedIdentity.value
-      )) {
-        activeRecord.identity = normalizedIdentity;
-        changed = true;
-      }
-      if (type === 'agent' && normalizedIdentity && activeRecord.filename) {
-        delete activeRecord.filename;
-        changed = true;
-      }
-      if (changed) this.persistAsync();
+    if (mutation === 'unchanged') return;
+    if (mutation === 'updated') {
+      this.persistAsync();
       return;
     }
-
-    existing.push({
-      name: normalizedName,
-      ...(normalizedFilename ? { filename: normalizedFilename } : {}),
-      ...(normalizedIdentity ? { identity: normalizedIdentity } : {}),
-      activatedAt: new Date().toISOString(),
-    });
 
     SecurityMonitor.logSecurityEvent({
       type: 'ELEMENT_ACTIVATED',
       severity: 'LOW',
       source: `${STORE_NAME}.recordActivation`,
-      details: `Activation recorded: ${type}/${normalizedName}`,
-      additionalData: { sessionId: this.sessionId, elementType: type, name: normalizedName },
+      details: `Activation recorded: ${type}/${input.name}`,
+      additionalData: { sessionId: this.sessionId, elementType: type, name: input.name },
     });
 
     this.persistAsync();
@@ -213,39 +149,24 @@ export class DatabaseActivationStateStore implements IActivationStateStore {
     filename?: string,
     identity?: PersistedActivationIdentity,
   ): void {
-    const type = normalizeType(elementType);
+    const type = normalizeActivationType(elementType);
     if (!type) return;
-    const normalizedName = normalizeIdentifier(name);
-    if (!normalizedName) return;
-    const normalizedFilename = typeof filename === 'string'
-      ? normalizeIdentifier(filename)
-      : undefined;
-    const normalizedIdentity = normalizeIdentity(identity);
+    const input = normalizeActivationInput(name, filename, identity);
+    if (!input) return;
 
     const activations = this.activations[type];
     if (!activations) return;
 
-    const initialLength = activations.length;
-    this.activations[type] = activations.filter(a => {
-      if (normalizedIdentity) {
-        const identityMatches = a.identity?.kind === normalizedIdentity.kind &&
-          a.identity.value === normalizedIdentity.value;
-        const legacyNameMatches = !a.identity && a.name === normalizedName;
-        return !identityMatches && !legacyNameMatches;
-      }
-      if (normalizedFilename) {
-        return a.filename !== normalizedFilename && !(!a.filename && a.name === normalizedName);
-      }
-      return a.name !== normalizedName && a.filename !== normalizedName;
-    });
+    const removal = removeActivationRecords(activations, input);
+    this.activations[type] = removal.records;
 
-    if (this.activations[type].length !== initialLength) {
+    if (removal.removed) {
       SecurityMonitor.logSecurityEvent({
         type: 'ELEMENT_DEACTIVATED',
         severity: 'LOW',
         source: `${STORE_NAME}.recordDeactivation`,
-        details: `Deactivation recorded: ${type}/${normalizedName}`,
-        additionalData: { sessionId: this.sessionId, elementType: type, name: normalizedName },
+        details: `Deactivation recorded: ${type}/${input.name}`,
+        additionalData: { sessionId: this.sessionId, elementType: type, name: input.name },
       });
 
       this.persistAsync();
@@ -262,7 +183,7 @@ export class DatabaseActivationStateStore implements IActivationStateStore {
   }
 
   getActivations(elementType: string): PersistedActivation[] {
-    const type = normalizeType(elementType);
+    const type = normalizeActivationType(elementType);
     if (!type) return [];
     return this.activations[type] ? [...this.activations[type]] : [];
   }
@@ -288,7 +209,7 @@ export class DatabaseActivationStateStore implements IActivationStateStore {
   async listPersistedActivationStates(sessionId?: string): Promise<PersistedActivationStateSnapshot[]> {
     if (sessionId !== undefined) validateDbSessionId(sessionId);
     try {
-      const normalizedSessionId = sessionId ? normalizeIdentifier(sessionId) : undefined;
+      const normalizedSessionId = sessionId ? normalizeActivationIdentifier(sessionId) : undefined;
       const rows = await queryUserSessions(this.db, this.userId, normalizedSessionId);
 
       return rows
@@ -320,32 +241,7 @@ export class DatabaseActivationStateStore implements IActivationStateStore {
   private normalizeActivationsForSnapshot(
     raw: Record<string, PersistedActivation[]>,
   ): Record<string, PersistedActivation[]> {
-    const normalized: Record<string, PersistedActivation[]> = {};
-    for (const [rawType, entries] of Object.entries(raw)) {
-      const type = normalizeType(rawType);
-      if (!type || !Array.isArray(entries)) continue;
-
-      const normalizedEntries = entries.flatMap((entry) => {
-        if (!entry || typeof entry.name !== 'string') return [];
-        const normalizedName = normalizeIdentifier(entry.name);
-        if (!normalizedName) return [];
-        const normalizedFilename = typeof entry.filename === 'string'
-          ? normalizeIdentifier(entry.filename)
-          : undefined;
-        const normalizedIdentity = normalizeIdentity(entry.identity);
-        return [{
-          ...entry,
-          name: normalizedName,
-          ...(normalizedFilename ? { filename: normalizedFilename } : {}),
-          ...(normalizedIdentity ? { identity: normalizedIdentity } : {}),
-        }];
-      });
-
-      if (normalizedEntries.length > 0) {
-        normalized[type] = normalizedEntries;
-      }
-    }
-    return normalized;
+    return normalizePersistedActivationMap(raw);
   }
 
   private persistAsync(): void {

--- a/src/state/DatabaseActivationStateStore.ts
+++ b/src/state/DatabaseActivationStateStore.ts
@@ -15,6 +15,7 @@ import { normalizeMCPAQLElementType } from '../handlers/mcp-aql/types.js';
 import type { DatabaseInstance } from '../database/connection.js';
 import {
   validateDbStoreParams,
+  validateDbSessionId,
   handleDbInitializeError,
   loadSessionRow,
   ensureSessionRow,
@@ -25,6 +26,7 @@ import { PersistQueue } from './PersistQueue.js';
 import type {
   IActivationStateStore,
   PersistedActivation,
+  PersistedActivationIdentity,
   PersistedActivationStateSnapshot,
 } from './IActivationStateStore.js';
 
@@ -40,6 +42,12 @@ function normalizeType(elementType: string): string | undefined {
 
 function normalizeIdentifier(value: string): string {
   return UnicodeValidator.normalize(value).normalizedContent.trim();
+}
+
+function normalizeIdentity(value: PersistedActivationIdentity | undefined): PersistedActivationIdentity | undefined {
+  if (!value || (value.kind !== 'file' && value.kind !== 'database')) return undefined;
+  const normalizedValue = normalizeIdentifier(value.value);
+  return normalizedValue ? { kind: value.kind, value: normalizedValue } : undefined;
 }
 
 // ── Implementation ──────────────────────────────────────────────────
@@ -92,10 +100,12 @@ export class DatabaseActivationStateStore implements IActivationStateStore {
           const normalizedFilename = typeof a.filename === 'string'
             ? normalizeIdentifier(a.filename)
             : undefined;
+          const normalizedIdentity = normalizeIdentity(a.identity);
           return [{
             ...a,
             name: normalizedName,
             ...(normalizedFilename ? { filename: normalizedFilename } : {}),
+            ...(normalizedIdentity ? { identity: normalizedIdentity } : {}),
           }];
         });
       }
@@ -122,7 +132,12 @@ export class DatabaseActivationStateStore implements IActivationStateStore {
     }
   }
 
-  recordActivation(elementType: string, name: string, filename?: string): void {
+  recordActivation(
+    elementType: string,
+    name: string,
+    filename?: string,
+    identity?: PersistedActivationIdentity,
+  ): void {
     const type = normalizeType(elementType);
     if (!type) return;
     const normalizedName = normalizeIdentifier(name);
@@ -130,17 +145,54 @@ export class DatabaseActivationStateStore implements IActivationStateStore {
     const normalizedFilename = typeof filename === 'string'
       ? normalizeIdentifier(filename)
       : undefined;
+    const normalizedIdentity = normalizeIdentity(identity);
 
     if (!this.activations[type]) {
       this.activations[type] = [];
     }
 
     const existing = this.activations[type];
-    if (existing.some(a => a.name === normalizedName)) return;
+    let activeRecord = normalizedIdentity
+      ? existing.find(a => a.identity?.kind === normalizedIdentity.kind && a.identity.value === normalizedIdentity.value)
+      : undefined;
+    activeRecord ??= normalizedIdentity?.kind === 'file'
+      ? existing.find(a => !a.identity && a.filename === normalizedIdentity.value)
+      : undefined;
+    activeRecord ??= normalizedFilename
+      ? existing.find(a => a.filename === normalizedFilename)
+      : undefined;
+    activeRecord ??= existing.find(a =>
+      a.name === normalizedName && (!normalizedIdentity || !a.identity)
+    );
+    if (activeRecord) {
+      let changed = false;
+      if (activeRecord.name !== normalizedName) {
+        activeRecord.name = normalizedName;
+        changed = true;
+      }
+      if (normalizedFilename && activeRecord.filename !== normalizedFilename) {
+        activeRecord.filename = normalizedFilename;
+        changed = true;
+      }
+      if (normalizedIdentity && (
+        activeRecord.identity?.kind !== normalizedIdentity.kind ||
+        activeRecord.identity?.value !== normalizedIdentity.value
+      )) {
+        activeRecord.identity = normalizedIdentity;
+        changed = true;
+      }
+      if (type === 'agent' && normalizedIdentity && activeRecord.filename) {
+        delete activeRecord.filename;
+        changed = true;
+      }
+      if (changed) this.persistAsync();
+      return;
+    }
 
     existing.push({
       name: normalizedName,
       ...(normalizedFilename ? { filename: normalizedFilename } : {}),
+      ...(normalizedIdentity ? { identity: normalizedIdentity } : {}),
       activatedAt: new Date().toISOString(),
     });
 
@@ -155,17 +207,37 @@ export class DatabaseActivationStateStore implements IActivationStateStore {
     this.persistAsync();
   }
 
-  recordDeactivation(elementType: string, name: string): void {
+  recordDeactivation(
+    elementType: string,
+    name: string,
+    filename?: string,
+    identity?: PersistedActivationIdentity,
+  ): void {
     const type = normalizeType(elementType);
     if (!type) return;
     const normalizedName = normalizeIdentifier(name);
     if (!normalizedName) return;
+    const normalizedFilename = typeof filename === 'string'
+      ? normalizeIdentifier(filename)
+      : undefined;
+    const normalizedIdentity = normalizeIdentity(identity);
 
     const activations = this.activations[type];
     if (!activations) return;
 
     const initialLength = activations.length;
-    this.activations[type] = activations.filter(a => a.name !== normalizedName);
+    this.activations[type] = activations.filter(a => {
+      if (normalizedIdentity) {
+        const identityMatches = a.identity?.kind === normalizedIdentity.kind &&
+          a.identity.value === normalizedIdentity.value;
+        const legacyNameMatches = !a.identity && a.name === normalizedName;
+        return !identityMatches && !legacyNameMatches;
+      }
+      if (normalizedFilename) {
+        return a.filename !== normalizedFilename && !(!a.filename && a.name === normalizedName);
+      }
+      return a.name !== normalizedName && a.filename !== normalizedName;
+    });
 
     if (this.activations[type].length !== initialLength) {
       SecurityMonitor.logSecurityEvent({
@@ -180,8 +252,13 @@ export class DatabaseActivationStateStore implements IActivationStateStore {
     }
   }
 
-  removeStaleActivation(elementType: string, name: string): void {
-    this.recordDeactivation(elementType, name);
+  removeStaleActivation(
+    elementType: string,
+    name: string,
+    filename?: string,
+    identity?: PersistedActivationIdentity,
+  ): void {
+    this.recordDeactivation(elementType, name, filename, identity);
   }
 
   getActivations(elementType: string): PersistedActivation[] {
@@ -209,6 +286,7 @@ export class DatabaseActivationStateStore implements IActivationStateStore {
   }
 
   async listPersistedActivationStates(sessionId?: string): Promise<PersistedActivationStateSnapshot[]> {
+    if (sessionId !== undefined) validateDbSessionId(sessionId);
     try {
       const normalizedSessionId = sessionId ? normalizeIdentifier(sessionId) : undefined;
       const rows = await queryUserSessions(this.db, this.userId, normalizedSessionId);
@@ -254,10 +332,12 @@ export class DatabaseActivationStateStore implements IActivationStateStore {
         const normalizedFilename = typeof entry.filename === 'string'
           ? normalizeIdentifier(entry.filename)
           : undefined;
+        const normalizedIdentity = normalizeIdentity(entry.identity);
         return [{
           ...entry,
           name: normalizedName,
           ...(normalizedFilename ? { filename: normalizedFilename } : {}),
+          ...(normalizedIdentity ? { identity: normalizedIdentity } : {}),
         }];
       });
 

--- a/src/state/FileActivationStateStore.ts
+++ b/src/state/FileActivationStateStore.ts
@@ -23,14 +23,15 @@ import { normalizeMCPAQLElementType } from '../handlers/mcp-aql/types.js';
 import type {
   IActivationStateStore,
   PersistedActivation,
+  PersistedActivationIdentity,
   PersistedActivationState,
   PersistedActivationStateSnapshot,
 } from './IActivationStateStore.js';
 
 // ── Constants ───────────────────────────────────────────────────────
 
-/** Session ID validation: must start with a letter, then alphanumeric/hyphens/underscores, 1-64 chars */
-const SESSION_ID_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]{0,63}$/;
+/** Session ID validation: filename-safe alphanumeric/hyphen/underscore, 1-64 chars. */
+const SESSION_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
 
 /** Store name for logging and security events. */
 const STORE_NAME = 'FileActivationStateStore';
@@ -67,7 +68,7 @@ function resolveSessionId(): string {
 
   if (!SESSION_ID_PATTERN.test(envValue)) {
     logger.warn(
-      `Invalid DOLLHOUSE_SESSION_ID '${envValue}' — must start with a letter, then alphanumeric/hyphens/underscores, 1-64 chars. Falling back to 'default'.`
+      `Invalid DOLLHOUSE_SESSION_ID '${envValue}' — must contain only letters, numbers, hyphens, or underscores, 1-64 chars. Falling back to 'default'.`
     );
     return 'default';
   }
@@ -81,16 +82,21 @@ function resolveSessionId(): string {
 export function validateExternalSessionId(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) {
-    logger.warn('[FileActivationStateStore] Empty sessionId provided — falling back to resolveSessionId()');
-    return resolveSessionId();
+    throw new Error('[FileActivationStateStore] Invalid external sessionId: value must not be empty');
   }
   if (!SESSION_ID_PATTERN.test(trimmed)) {
-    logger.warn(
-      `[FileActivationStateStore] Invalid external sessionId '${trimmed}' — falling back to 'default'`
+    throw new Error(
+      `[FileActivationStateStore] Invalid external sessionId '${trimmed.slice(0, 64)}' — ` +
+      'must contain only letters, numbers, hyphens, or underscores (1-64 characters)'
     );
-    return 'default';
   }
   return trimmed;
+}
+
+function normalizeIdentity(value: PersistedActivationIdentity | undefined): PersistedActivationIdentity | undefined {
+  if (!value || (value.kind !== 'file' && value.kind !== 'database')) return undefined;
+  const normalizedValue = normalizeActivationIdentifier(value.value);
+  return normalizedValue ? { kind: value.kind, value: normalizedValue } : undefined;
 }
 
 /**
@@ -157,11 +163,13 @@ export class FileActivationStateStore implements IActivationStateStore {
               const normalizedFilename = typeof a.filename === 'string'
                 ? normalizeActivationIdentifier(a.filename)
                 : undefined;
+              const normalizedIdentity = normalizeIdentity(a.identity);
 
               return [{
                 ...a,
                 name: normalizedName,
                 ...(normalizedFilename ? { filename: normalizedFilename } : {}),
+                ...(normalizedIdentity ? { identity: normalizedIdentity } : {}),
               }];
             });
           }
@@ -190,7 +198,12 @@ export class FileActivationStateStore implements IActivationStateStore {
     }
   }
 
-  recordActivation(elementType: string, name: string, filename?: string): void {
+  recordActivation(
+    elementType: string,
+    name: string,
+    filename?: string,
+    identity?: PersistedActivationIdentity,
+  ): void {
     if (!this.enabled) return;
 
     const type = normalizeType(elementType);
@@ -200,19 +213,56 @@ export class FileActivationStateStore implements IActivationStateStore {
     const normalizedFilename = typeof filename === 'string'
       ? normalizeActivationIdentifier(filename)
       : undefined;
+    const normalizedIdentity = normalizeIdentity(identity);
 
     if (!this.state.activations[type]) {
       this.state.activations[type] = [];
     }
 
-    // Deduplicate — don't add if already present
+    // Deduplicate by durable identity first. A name-only match upgrades a
+    // legacy record so the next restart no longer depends on display metadata.
     const existing = this.state.activations[type];
-    const alreadyActive = existing.some(a => a.name === normalizedName);
-    if (alreadyActive) return;
+    let activeRecord = normalizedIdentity
+      ? existing.find(a => a.identity?.kind === normalizedIdentity.kind && a.identity.value === normalizedIdentity.value)
+      : undefined;
+    activeRecord ??= normalizedIdentity?.kind === 'file'
+      ? existing.find(a => !a.identity && a.filename === normalizedIdentity.value)
+      : undefined;
+    activeRecord ??= normalizedFilename
+      ? existing.find(a => a.filename === normalizedFilename)
+      : undefined;
+    activeRecord ??= existing.find(a =>
+      a.name === normalizedName && (!normalizedIdentity || !a.identity)
+    );
+    if (activeRecord) {
+      let changed = false;
+      if (activeRecord.name !== normalizedName) {
+        activeRecord.name = normalizedName;
+        changed = true;
+      }
+      if (normalizedFilename && activeRecord.filename !== normalizedFilename) {
+        activeRecord.filename = normalizedFilename;
+        changed = true;
+      }
+      if (normalizedIdentity && (
+        activeRecord.identity?.kind !== normalizedIdentity.kind ||
+        activeRecord.identity?.value !== normalizedIdentity.value
+      )) {
+        activeRecord.identity = normalizedIdentity;
+        changed = true;
+      }
+      if (type === 'agent' && normalizedIdentity && activeRecord.filename) {
+        delete activeRecord.filename;
+        changed = true;
+      }
+      if (changed) this.persistAsync();
+      return;
+    }
 
     existing.push({
       name: normalizedName,
       ...(normalizedFilename ? { filename: normalizedFilename } : {}),
+      ...(normalizedIdentity ? { identity: normalizedIdentity } : {}),
       activatedAt: new Date().toISOString(),
     });
 
@@ -227,19 +277,39 @@ export class FileActivationStateStore implements IActivationStateStore {
     this.persistAsync();
   }
 
-  recordDeactivation(elementType: string, name: string): void {
+  recordDeactivation(
+    elementType: string,
+    name: string,
+    filename?: string,
+    identity?: PersistedActivationIdentity,
+  ): void {
     if (!this.enabled) return;
 
     const type = normalizeType(elementType);
     if (!type) return;
     const normalizedName = normalizeActivationIdentifier(name);
     if (!normalizedName) return;
+    const normalizedFilename = typeof filename === 'string'
+      ? normalizeActivationIdentifier(filename)
+      : undefined;
+    const normalizedIdentity = normalizeIdentity(identity);
 
     const activations = this.state.activations[type];
     if (!activations) return;
 
     const initialLength = activations.length;
-    this.state.activations[type] = activations.filter(a => a.name !== normalizedName);
+    this.state.activations[type] = activations.filter(a => {
+      if (normalizedIdentity) {
+        const identityMatches = a.identity?.kind === normalizedIdentity.kind &&
+          a.identity.value === normalizedIdentity.value;
+        const legacyNameMatches = !a.identity && a.name === normalizedName;
+        return !identityMatches && !legacyNameMatches;
+      }
+      if (normalizedFilename) {
+        return a.filename !== normalizedFilename && !(!a.filename && a.name === normalizedName);
+      }
+      return a.name !== normalizedName && a.filename !== normalizedName;
+    });
 
     if (this.state.activations[type].length !== initialLength) {
       SecurityMonitor.logSecurityEvent({
@@ -254,8 +324,13 @@ export class FileActivationStateStore implements IActivationStateStore {
     }
   }
 
-  removeStaleActivation(elementType: string, name: string): void {
-    this.recordDeactivation(elementType, name);
+  removeStaleActivation(
+    elementType: string,
+    name: string,
+    filename?: string,
+    identity?: PersistedActivationIdentity,
+  ): void {
+    this.recordDeactivation(elementType, name, filename, identity);
   }
 
   getActivations(elementType: string): PersistedActivation[] {
@@ -286,8 +361,8 @@ export class FileActivationStateStore implements IActivationStateStore {
       return [];
     }
 
-    const normalizedSessionId = typeof sessionId === 'string' && sessionId.trim()
-      ? normalizeActivationIdentifier(sessionId)
+    const normalizedSessionId = typeof sessionId === 'string'
+      ? validateExternalSessionId(sessionId)
       : undefined;
 
     try {
@@ -357,10 +432,12 @@ export class FileActivationStateStore implements IActivationStateStore {
         const normalizedFilename = typeof entry.filename === 'string'
           ? normalizeActivationIdentifier(entry.filename)
           : undefined;
+        const normalizedIdentity = normalizeIdentity(entry.identity);
         return [{
           ...entry,
           name: normalizedName,
           ...(normalizedFilename ? { filename: normalizedFilename } : {}),
+          ...(normalizedIdentity ? { identity: normalizedIdentity } : {}),
         }];
       });
 

--- a/src/state/FileActivationStateStore.ts
+++ b/src/state/FileActivationStateStore.ts
@@ -18,8 +18,14 @@ import { logger } from '../utils/logger.js';
 import { SecurityMonitor } from '../security/securityMonitor.js';
 import { fireAndForgetPersist, handleInitializeError } from './persistence-utils.js';
 import type { FileOperationsService } from '../services/FileOperationsService.js';
-import { UnicodeValidator } from '../security/validators/unicodeValidator.js';
-import { normalizeMCPAQLElementType } from '../handlers/mcp-aql/types.js';
+import {
+  ACTIVATION_SESSION_ID_PATTERN,
+  normalizeActivationInput,
+  normalizeActivationType,
+  normalizePersistedActivationMap,
+  removeActivationRecords,
+  upsertActivationRecord,
+} from './activation-record-utils.js';
 import type {
   IActivationStateStore,
   PersistedActivation,
@@ -31,8 +37,6 @@ import type {
 // ── Constants ───────────────────────────────────────────────────────
 
 /** Session ID validation: filename-safe alphanumeric/hyphen/underscore, 1-64 chars. */
-const SESSION_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
-
 /** Store name for logging and security events. */
 const STORE_NAME = 'FileActivationStateStore';
 
@@ -45,15 +49,10 @@ const STORE_NAME = 'FileActivationStateStore';
  * Returns undefined for unrecognized types.
  */
 export function normalizeType(elementType: string): string | undefined {
-  return normalizeMCPAQLElementType(elementType);
+  return normalizeActivationType(elementType);
 }
 
-/**
- * Normalize an activation identifier (name or filename) for safe storage.
- */
-export function normalizeActivationIdentifier(value: string): string {
-  return UnicodeValidator.normalize(value).normalizedContent.trim();
-}
+export { normalizeActivationIdentifier } from './activation-record-utils.js';
 
 /**
  * Validates and returns the session ID from environment or default.
@@ -66,7 +65,7 @@ function resolveSessionId(): string {
     return id;
   }
 
-  if (!SESSION_ID_PATTERN.test(envValue)) {
+  if (!ACTIVATION_SESSION_ID_PATTERN.test(envValue)) {
     logger.warn(
       `Invalid DOLLHOUSE_SESSION_ID '${envValue}' — must contain only letters, numbers, hyphens, or underscores, 1-64 chars. Falling back to 'default'.`
     );
@@ -84,19 +83,13 @@ export function validateExternalSessionId(value: string): string {
   if (!trimmed) {
     throw new Error('[FileActivationStateStore] Invalid external sessionId: value must not be empty');
   }
-  if (!SESSION_ID_PATTERN.test(trimmed)) {
+  if (!ACTIVATION_SESSION_ID_PATTERN.test(trimmed)) {
     throw new Error(
       `[FileActivationStateStore] Invalid external sessionId '${trimmed.slice(0, 64)}' — ` +
       'must contain only letters, numbers, hyphens, or underscores (1-64 characters)'
     );
   }
   return trimmed;
-}
-
-function normalizeIdentity(value: PersistedActivationIdentity | undefined): PersistedActivationIdentity | undefined {
-  if (!value || (value.kind !== 'file' && value.kind !== 'database')) return undefined;
-  const normalizedValue = normalizeActivationIdentifier(value.value);
-  return normalizedValue ? { kind: value.kind, value: normalizedValue } : undefined;
 }
 
 /**
@@ -151,29 +144,7 @@ export class FileActivationStateStore implements IActivationStateStore {
       const data = JSON.parse(content) as PersistedActivationState;
 
       if (data.version === 1 && data.activations && typeof data.activations === 'object') {
-        for (const [rawType, activations] of Object.entries(data.activations)) {
-          const type = normalizeType(rawType);
-          if (type && Array.isArray(activations)) {
-            this.state.activations[type] = activations.flatMap((a) => {
-              if (!a || typeof a.name !== 'string') return [];
-
-              const normalizedName = normalizeActivationIdentifier(a.name);
-              if (!normalizedName) return [];
-
-              const normalizedFilename = typeof a.filename === 'string'
-                ? normalizeActivationIdentifier(a.filename)
-                : undefined;
-              const normalizedIdentity = normalizeIdentity(a.identity);
-
-              return [{
-                ...a,
-                name: normalizedName,
-                ...(normalizedFilename ? { filename: normalizedFilename } : {}),
-                ...(normalizedIdentity ? { identity: normalizedIdentity } : {}),
-              }];
-            });
-          }
-        }
+        this.state.activations = normalizePersistedActivationMap(data.activations);
 
         const totalCount = this.getTotalActivationCount();
         if (totalCount > 0) {
@@ -208,70 +179,31 @@ export class FileActivationStateStore implements IActivationStateStore {
 
     const type = normalizeType(elementType);
     if (!type) return;
-    const normalizedName = normalizeActivationIdentifier(name);
-    if (!normalizedName) return;
-    const normalizedFilename = typeof filename === 'string'
-      ? normalizeActivationIdentifier(filename)
-      : undefined;
-    const normalizedIdentity = normalizeIdentity(identity);
+    const input = normalizeActivationInput(name, filename, identity);
+    if (!input) return;
 
     if (!this.state.activations[type]) {
       this.state.activations[type] = [];
     }
 
-    // Deduplicate by durable identity first. A name-only match upgrades a
-    // legacy record so the next restart no longer depends on display metadata.
-    const existing = this.state.activations[type];
-    let activeRecord = normalizedIdentity
-      ? existing.find(a => a.identity?.kind === normalizedIdentity.kind && a.identity.value === normalizedIdentity.value)
-      : undefined;
-    activeRecord ??= normalizedIdentity?.kind === 'file'
-      ? existing.find(a => !a.identity && a.filename === normalizedIdentity.value)
-      : undefined;
-    activeRecord ??= normalizedFilename
-      ? existing.find(a => a.filename === normalizedFilename)
-      : undefined;
-    activeRecord ??= existing.find(a =>
-      a.name === normalizedName && (!normalizedIdentity || !a.identity)
+    const mutation = upsertActivationRecord(
+      this.state.activations[type],
+      type,
+      input,
+      new Date().toISOString(),
     );
-    if (activeRecord) {
-      let changed = false;
-      if (activeRecord.name !== normalizedName) {
-        activeRecord.name = normalizedName;
-        changed = true;
-      }
-      if (normalizedFilename && activeRecord.filename !== normalizedFilename) {
-        activeRecord.filename = normalizedFilename;
-        changed = true;
-      }
-      if (normalizedIdentity && (
-        activeRecord.identity?.kind !== normalizedIdentity.kind ||
-        activeRecord.identity?.value !== normalizedIdentity.value
-      )) {
-        activeRecord.identity = normalizedIdentity;
-        changed = true;
-      }
-      if (type === 'agent' && normalizedIdentity && activeRecord.filename) {
-        delete activeRecord.filename;
-        changed = true;
-      }
-      if (changed) this.persistAsync();
+    if (mutation === 'unchanged') return;
+    if (mutation === 'updated') {
+      this.persistAsync();
       return;
     }
-
-    existing.push({
-      name: normalizedName,
-      ...(normalizedFilename ? { filename: normalizedFilename } : {}),
-      ...(normalizedIdentity ? { identity: normalizedIdentity } : {}),
-      activatedAt: new Date().toISOString(),
-    });
 
     SecurityMonitor.logSecurityEvent({
       type: 'ELEMENT_ACTIVATED',
       severity: 'LOW',
       source: 'FileActivationStateStore.recordActivation',
-      details: `Activation recorded: ${type}/${normalizedName}`,
-      additionalData: { sessionId: this.sessionId, elementType: type, name: normalizedName },
+      details: `Activation recorded: ${type}/${input.name}`,
+      additionalData: { sessionId: this.sessionId, elementType: type, name: input.name },
     });
 
     this.persistAsync();
@@ -287,37 +219,22 @@ export class FileActivationStateStore implements IActivationStateStore {
 
     const type = normalizeType(elementType);
     if (!type) return;
-    const normalizedName = normalizeActivationIdentifier(name);
-    if (!normalizedName) return;
-    const normalizedFilename = typeof filename === 'string'
-      ? normalizeActivationIdentifier(filename)
-      : undefined;
-    const normalizedIdentity = normalizeIdentity(identity);
+    const input = normalizeActivationInput(name, filename, identity);
+    if (!input) return;
 
     const activations = this.state.activations[type];
     if (!activations) return;
 
-    const initialLength = activations.length;
-    this.state.activations[type] = activations.filter(a => {
-      if (normalizedIdentity) {
-        const identityMatches = a.identity?.kind === normalizedIdentity.kind &&
-          a.identity.value === normalizedIdentity.value;
-        const legacyNameMatches = !a.identity && a.name === normalizedName;
-        return !identityMatches && !legacyNameMatches;
-      }
-      if (normalizedFilename) {
-        return a.filename !== normalizedFilename && !(!a.filename && a.name === normalizedName);
-      }
-      return a.name !== normalizedName && a.filename !== normalizedName;
-    });
+    const removal = removeActivationRecords(activations, input);
+    this.state.activations[type] = removal.records;
 
-    if (this.state.activations[type].length !== initialLength) {
+    if (removal.removed) {
       SecurityMonitor.logSecurityEvent({
         type: 'ELEMENT_DEACTIVATED',
         severity: 'LOW',
         source: 'FileActivationStateStore.recordDeactivation',
-        details: `Deactivation recorded: ${type}/${normalizedName}`,
-        additionalData: { sessionId: this.sessionId, elementType: type, name: normalizedName },
+        details: `Deactivation recorded: ${type}/${input.name}`,
+        additionalData: { sessionId: this.sessionId, elementType: type, name: input.name },
       });
 
       this.persistAsync();
@@ -420,32 +337,7 @@ export class FileActivationStateStore implements IActivationStateStore {
   private normalizePersistedActivationsForSnapshot(
     activations: PersistedActivationState['activations']
   ): Record<string, PersistedActivation[]> {
-    const normalized: Record<string, PersistedActivation[]> = {};
-    for (const [rawType, entries] of Object.entries(activations)) {
-      const type = normalizeType(rawType);
-      if (!type || !Array.isArray(entries)) continue;
-
-      const normalizedEntries = entries.flatMap((entry) => {
-        if (!entry || typeof entry.name !== 'string') return [];
-        const normalizedName = normalizeActivationIdentifier(entry.name);
-        if (!normalizedName) return [];
-        const normalizedFilename = typeof entry.filename === 'string'
-          ? normalizeActivationIdentifier(entry.filename)
-          : undefined;
-        const normalizedIdentity = normalizeIdentity(entry.identity);
-        return [{
-          ...entry,
-          name: normalizedName,
-          ...(normalizedFilename ? { filename: normalizedFilename } : {}),
-          ...(normalizedIdentity ? { identity: normalizedIdentity } : {}),
-        }];
-      });
-
-      if (normalizedEntries.length > 0) {
-        normalized[type] = normalizedEntries;
-      }
-    }
-    return normalized;
+    return normalizePersistedActivationMap(activations);
   }
 
   // ── Private persistence methods ───────────────────────────────────

--- a/src/state/IActivationStateStore.ts
+++ b/src/state/IActivationStateStore.ts
@@ -14,11 +14,23 @@
 /**
  * A persisted activation record for a single element.
  */
+export interface PersistedActivationIdentity {
+  /** The storage backend that owns the durable key. */
+  kind: 'file' | 'database';
+  /** File path/filename in file mode, or element row UUID in database mode. */
+  value: string;
+}
+
 export interface PersistedActivation {
   /** Element name (human-readable, used for all types) */
   name: string;
-  /** For personas only: the filename key used by PersonaManager */
+  /**
+   * Legacy persona filename key. Retained for read compatibility with v1
+   * activation records; new agent records use `identity` instead.
+   */
   filename?: string;
+  /** Backend-neutral durable identity used when display names can change. */
+  identity?: PersistedActivationIdentity;
   /** ISO-8601 timestamp of when activation was persisted */
   activatedAt: string;
 }
@@ -61,23 +73,39 @@ export interface IActivationStateStore {
    * Record an element activation. Fires async persist.
    * @param elementType - Singular element type (e.g., 'persona', 'skill')
    * @param name - Normalized element name
-   * @param filename - Optional filename key (personas only)
+   * @param filename - Optional legacy filename key (personas only)
+   * @param identity - Optional backend-neutral durable storage identity
    */
-  recordActivation(elementType: string, name: string, filename?: string): void;
+  recordActivation(
+    elementType: string,
+    name: string,
+    filename?: string,
+    identity?: PersistedActivationIdentity,
+  ): void;
 
   /**
    * Record an element deactivation. Fires async persist.
    * @param elementType - Singular element type
    * @param name - Normalized element name
    */
-  recordDeactivation(elementType: string, name: string): void;
+  recordDeactivation(
+    elementType: string,
+    name: string,
+    filename?: string,
+    identity?: PersistedActivationIdentity,
+  ): void;
 
   /**
    * Remove a stale activation (element no longer exists on disk).
    * @param elementType - Singular element type
    * @param name - Normalized element name
    */
-  removeStaleActivation(elementType: string, name: string): void;
+  removeStaleActivation(
+    elementType: string,
+    name: string,
+    filename?: string,
+    identity?: PersistedActivationIdentity,
+  ): void;
 
   /**
    * Get all persisted activations for a given element type.

--- a/src/state/SessionActivationState.ts
+++ b/src/state/SessionActivationState.ts
@@ -33,6 +33,7 @@ export interface SessionUserIdentity {
  * Each Set tracks which elements of that type are active in this session.
  * Key conventions match the existing manager patterns:
  * - personas: keyed by **filename** (e.g., 'creative-dev.md')
+ * - agents: keyed by backend durable storage identity (filename/path or row UUID)
  * - all others: keyed by **metadata.name**
  */
 export interface SessionActivationState {
@@ -40,6 +41,8 @@ export interface SessionActivationState {
   readonly personas: Set<string>;
   readonly skills: Set<string>;
   readonly agents: Set<string>;
+  /** Display-name alias captured when each durable agent identity was activated. */
+  readonly agentNamesByIdentity: Map<string, string>;
   readonly memories: Set<string>;
   readonly ensembles: Set<string>;
 
@@ -67,6 +70,7 @@ export function createSessionActivationState(sessionId: string): SessionActivati
     personas: new Set(),
     skills: new Set(),
     agents: new Set(),
+    agentNamesByIdentity: new Map(),
     memories: new Set(),
     ensembles: new Set(),
     userIdentity: undefined,

--- a/src/state/activation-record-utils.ts
+++ b/src/state/activation-record-utils.ts
@@ -1,12 +1,13 @@
 import { normalizeMCPAQLElementType } from '../handlers/mcp-aql/types.js';
 import { UnicodeValidator } from '../security/validators/unicodeValidator.js';
+import { SESSION_ID_PATTERN } from '../services/sessionIdentity.js';
 import type {
   PersistedActivation,
   PersistedActivationIdentity,
 } from './IActivationStateStore.js';
 
-/** Filename- and query-safe session identifiers, including digit-first UUIDs. */
-export const ACTIVATION_SESSION_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
+/** Shared alias retained for activation-store call sites. */
+export const ACTIVATION_SESSION_ID_PATTERN = SESSION_ID_PATTERN;
 
 export interface NormalizedActivationInput {
   name: string;

--- a/src/state/activation-record-utils.ts
+++ b/src/state/activation-record-utils.ts
@@ -1,13 +1,12 @@
 import { normalizeMCPAQLElementType } from '../handlers/mcp-aql/types.js';
 import { UnicodeValidator } from '../security/validators/unicodeValidator.js';
-import { SESSION_ID_PATTERN } from '../services/sessionIdentity.js';
 import type {
   PersistedActivation,
   PersistedActivationIdentity,
 } from './IActivationStateStore.js';
 
 /** Shared alias retained for activation-store call sites. */
-export const ACTIVATION_SESSION_ID_PATTERN = SESSION_ID_PATTERN;
+export { SESSION_ID_PATTERN as ACTIVATION_SESSION_ID_PATTERN } from '../services/sessionIdentity.js';
 
 export interface NormalizedActivationInput {
   name: string;

--- a/src/state/activation-record-utils.ts
+++ b/src/state/activation-record-utils.ts
@@ -1,0 +1,166 @@
+import { normalizeMCPAQLElementType } from '../handlers/mcp-aql/types.js';
+import { UnicodeValidator } from '../security/validators/unicodeValidator.js';
+import type {
+  PersistedActivation,
+  PersistedActivationIdentity,
+} from './IActivationStateStore.js';
+
+/** Filename- and query-safe session identifiers, including digit-first UUIDs. */
+export const ACTIVATION_SESSION_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
+
+export interface NormalizedActivationInput {
+  name: string;
+  filename?: string;
+  identity?: PersistedActivationIdentity;
+}
+
+export type ActivationUpsertResult = 'inserted' | 'updated' | 'unchanged';
+
+export function normalizeActivationType(elementType: string): string | undefined {
+  return normalizeMCPAQLElementType(elementType);
+}
+
+export function normalizeActivationIdentifier(value: string): string {
+  return UnicodeValidator.normalize(value).normalizedContent.trim();
+}
+
+export function normalizeActivationIdentity(
+  identity: PersistedActivationIdentity | undefined,
+): PersistedActivationIdentity | undefined {
+  if (
+    !identity ||
+    (identity.kind !== 'file' && identity.kind !== 'database') ||
+    typeof identity.value !== 'string'
+  ) return undefined;
+  const value = normalizeActivationIdentifier(identity.value);
+  return value ? { kind: identity.kind, value } : undefined;
+}
+
+export function normalizeActivationInput(
+  name: string,
+  filename?: string,
+  identity?: PersistedActivationIdentity,
+): NormalizedActivationInput | undefined {
+  const normalizedName = normalizeActivationIdentifier(name);
+  if (!normalizedName) return undefined;
+  const normalizedFilename = typeof filename === 'string'
+    ? normalizeActivationIdentifier(filename)
+    : undefined;
+  const normalizedIdentity = normalizeActivationIdentity(identity);
+  return {
+    name: normalizedName,
+    ...(normalizedFilename ? { filename: normalizedFilename } : {}),
+    ...(normalizedIdentity ? { identity: normalizedIdentity } : {}),
+  };
+}
+
+export function normalizePersistedActivation(
+  value: unknown,
+): PersistedActivation | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const activation = value as Partial<PersistedActivation>;
+  if (typeof activation.name !== 'string') return undefined;
+  const input = normalizeActivationInput(
+    activation.name,
+    activation.filename,
+    activation.identity,
+  );
+  if (!input) return undefined;
+
+  const { filename: _filename, identity: _identity, ...rest } = activation;
+  return {
+    ...rest,
+    ...input,
+    activatedAt: typeof activation.activatedAt === 'string'
+      ? activation.activatedAt
+      : new Date(0).toISOString(),
+  };
+}
+
+export function normalizePersistedActivationMap(
+  activations: Record<string, PersistedActivation[]>,
+): Record<string, PersistedActivation[]> {
+  const normalized: Record<string, PersistedActivation[]> = {};
+  for (const [rawType, entries] of Object.entries(activations)) {
+    const type = normalizeActivationType(rawType);
+    if (!type || !Array.isArray(entries)) continue;
+    const normalizedEntries = entries.flatMap((entry) => {
+      const normalizedEntry = normalizePersistedActivation(entry);
+      return normalizedEntry ? [normalizedEntry] : [];
+    });
+    if (normalizedEntries.length > 0) normalized[type] = normalizedEntries;
+  }
+  return normalized;
+}
+
+/** Mutate one type-specific activation list while preserving legacy upgrade rules. */
+export function upsertActivationRecord(
+  records: PersistedActivation[],
+  elementType: string,
+  input: NormalizedActivationInput,
+  activatedAt: string,
+): ActivationUpsertResult {
+  const { name, filename, identity } = input;
+  let activeRecord = identity
+    ? records.find(record =>
+      record.identity?.kind === identity.kind && record.identity.value === identity.value
+    )
+    : undefined;
+  activeRecord ??= identity?.kind === 'file'
+    ? records.find(record => !record.identity && record.filename === identity.value)
+    : undefined;
+  activeRecord ??= filename
+    ? records.find(record => record.filename === filename)
+    : undefined;
+  activeRecord ??= records.find(record =>
+    record.name === name && (!identity || !record.identity)
+  );
+
+  if (!activeRecord) {
+    records.push({ ...input, activatedAt });
+    return 'inserted';
+  }
+
+  let changed = false;
+  if (activeRecord.name !== name) {
+    activeRecord.name = name;
+    changed = true;
+  }
+  if (filename && activeRecord.filename !== filename) {
+    activeRecord.filename = filename;
+    changed = true;
+  }
+  if (identity && (
+    activeRecord.identity?.kind !== identity.kind ||
+    activeRecord.identity.value !== identity.value
+  )) {
+    activeRecord.identity = identity;
+    changed = true;
+  }
+  if (elementType === 'agent' && identity && activeRecord.filename) {
+    delete activeRecord.filename;
+    changed = true;
+  }
+  return changed ? 'updated' : 'unchanged';
+}
+
+export function removeActivationRecords(
+  records: PersistedActivation[],
+  input: NormalizedActivationInput,
+): { records: PersistedActivation[]; removed: boolean } {
+  const remaining = records.filter((record) => {
+    if (input.identity) {
+      const identityMatches = record.identity?.kind === input.identity.kind &&
+        record.identity.value === input.identity.value;
+      const legacyNameMatches = !record.identity && record.name === input.name;
+      return !identityMatches && !legacyNameMatches;
+    }
+    if (input.filename) {
+      const filenameMatches = record.filename === input.filename;
+      const legacyNameMatches = !record.filename && record.name === input.name;
+      return !filenameMatches && !legacyNameMatches;
+    }
+    return record.name !== input.name;
+  });
+  return { records: remaining, removed: remaining.length !== records.length };
+}

--- a/src/state/db-persistence-utils.ts
+++ b/src/state/db-persistence-utils.ts
@@ -28,11 +28,8 @@ const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0
 /**
  * Session ID: alphanumeric prefix + alphanumeric/hyphens/underscores, 1-64 chars.
  *
- * More permissive than FileActivationStateStore's equivalent pattern (which
- * requires a leading letter for filename safety). DB storage has no filename
- * concern, and HTTP sessions use `randomUUID()` — roughly 62% of v4 UUIDs
- * start with a digit (`0-9`). A letter-prefix rule would deterministically
- * reject those and manifest as an "Internal server error" at session init.
+ * HTTP sessions use `randomUUID()`, so digit-first identifiers must remain
+ * valid. FileActivationStateStore uses the same filename-safe character set.
  */
 const SESSION_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
 
@@ -52,8 +49,16 @@ export function validateUserId(userId: string): void {
  */
 export function validateDbStoreParams(userId: string, sessionId: string): void {
   validateUserId(userId);
+  validateDbSessionId(sessionId);
+}
+
+/** Validate a session identifier at database query/reporting boundaries. */
+export function validateDbSessionId(sessionId: string): void {
   if (!SESSION_ID_PATTERN.test(sessionId)) {
-    throw new Error(`[db-persistence-utils] Invalid sessionId — must match [a-zA-Z][a-zA-Z0-9_-]{0,63}, got '${sessionId.slice(0, 40)}'`);
+    throw new Error(
+      `[db-persistence-utils] Invalid sessionId — must contain only letters, numbers, hyphens, or underscores ` +
+      `(1-64 characters), got '${sessionId.slice(0, 40)}'`,
+    );
   }
 }
 

--- a/src/state/db-persistence-utils.ts
+++ b/src/state/db-persistence-utils.ts
@@ -19,6 +19,7 @@ import { SecurityMonitor } from '../security/securityMonitor.js';
 import type { DatabaseInstance } from '../database/connection.js';
 import { withUserContext, withUserRead } from '../database/rls.js';
 import { sessions } from '../database/schema/sessions.js';
+import { ACTIVATION_SESSION_ID_PATTERN } from './activation-record-utils.js';
 
 // ── Validation ──────────────────────────────────────────────────────
 
@@ -31,8 +32,6 @@ const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0
  * HTTP sessions use `randomUUID()`, so digit-first identifiers must remain
  * valid. FileActivationStateStore uses the same filename-safe character set.
  */
-const SESSION_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
-
 /**
  * Validate that a value is a UUID v4.
  * Used by storage layers and stores that receive userId from the DI container.
@@ -54,7 +53,7 @@ export function validateDbStoreParams(userId: string, sessionId: string): void {
 
 /** Validate a session identifier at database query/reporting boundaries. */
 export function validateDbSessionId(sessionId: string): void {
-  if (!SESSION_ID_PATTERN.test(sessionId)) {
+  if (!ACTIVATION_SESSION_ID_PATTERN.test(sessionId)) {
     throw new Error(
       `[db-persistence-utils] Invalid sessionId — must contain only letters, numbers, hyphens, or underscores ` +
       `(1-64 characters), got '${sessionId.slice(0, 40)}'`,

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -11,7 +11,12 @@
 
 // Interfaces
 export type { IActivationStateStore } from './IActivationStateStore.js';
-export type { PersistedActivation, PersistedActivationState, PersistedActivationStateSnapshot } from './IActivationStateStore.js';
+export type {
+  PersistedActivation,
+  PersistedActivationIdentity,
+  PersistedActivationState,
+  PersistedActivationStateSnapshot,
+} from './IActivationStateStore.js';
 export type { IConfirmationStore } from './IConfirmationStore.js';
 export type { IChallengeStore } from './IChallengeStore.js';
 

--- a/src/web-console/modules/activations/PostgresSessionActivationStateAdapter.ts
+++ b/src/web-console/modules/activations/PostgresSessionActivationStateAdapter.ts
@@ -2,6 +2,7 @@ import { and, asc, eq } from 'drizzle-orm';
 
 import { withSystemContext } from '../../../database/admin.js';
 import type { DatabaseInstance } from '../../../database/connection.js';
+import { validateDbSessionId } from '../../../state/db-persistence-utils.js';
 import {
   sessionActivationEvents,
   sessionActivationRecords,
@@ -21,6 +22,7 @@ export class PostgresSessionActivationStateAdapter implements ISessionActivation
   ) {}
 
   async list(sessionId: string): Promise<readonly SessionActivationRecord[]> {
+    validateDbSessionId(sessionId);
     const rows = await withSystemContext(this.db, tx =>
       tx.select().from(sessionActivationRecords)
         .where(eq(sessionActivationRecords.sessionId, sessionId))
@@ -34,6 +36,7 @@ export class PostgresSessionActivationStateAdapter implements ISessionActivation
     type: ConsoleActivatableElementType,
     name: string,
   ): Promise<SessionActivationChangeResult> {
+    validateDbSessionId(sessionId);
     const activatedAt = this.now();
     const rows = await withSystemContext(this.db, tx =>
       tx.insert(sessionActivationRecords).values({
@@ -63,6 +66,7 @@ export class PostgresSessionActivationStateAdapter implements ISessionActivation
   }
 
   async deactivate(sessionId: string, type: ConsoleActivatableElementType, name: string): Promise<boolean> {
+    validateDbSessionId(sessionId);
     const rows = await withSystemContext(this.db, tx =>
       tx.delete(sessionActivationRecords)
         .where(recordIdentity(sessionId, type, name))

--- a/src/web-console/modules/activations/SessionActivationStateAdapter.ts
+++ b/src/web-console/modules/activations/SessionActivationStateAdapter.ts
@@ -41,8 +41,14 @@ export class RegistrySessionActivationStateAdapter implements ISessionActivation
     const state = this.registry.getOrCreate(sessionId);
     const storeRecord = state.activationStore?.getActivations(type).find(record => record.name === name);
     const fallbackRecord = this.fallbackRecords.get(recordKey(sessionId, type, name));
-    const changed = !activationSet(state, type).has(name) && !storeRecord && !fallbackRecord;
-    activationSet(state, type).add(name);
+    const activationKey = type === 'agents' && storeRecord?.identity
+      ? storeRecord.identity.value
+      : name;
+    const changed = !activationSet(state, type).has(activationKey) && !storeRecord && !fallbackRecord;
+    activationSet(state, type).add(activationKey);
+    if (type === 'agents' && storeRecord?.identity) {
+      state.agentNamesByIdentity.set(activationKey, name);
+    }
     if (state.activationStore?.isEnabled()) {
       state.activationStore.recordActivation(type, name);
     } else if (!fallbackRecord) {
@@ -67,10 +73,21 @@ export class RegistrySessionActivationStateAdapter implements ISessionActivation
     const state = this.registry.get(sessionId);
     if (!state) return Promise.resolve(false);
     const stateSet = activationSet(state, type);
-    const changed = stateSet.delete(name) ||
-      Boolean(state.activationStore?.getActivations(type).some(record => record.name === name)) ||
+    const storeRecord = state.activationStore?.getActivations(type).find(record =>
+      record.name === name || record.identity?.value === name
+    );
+    const agentKey = type === 'agents'
+      ? Array.from(state.agentNamesByIdentity.entries()).find(([identity, alias]) =>
+        identity === name || alias === name
+      )?.[0]
+      : undefined;
+    const changed = stateSet.delete(agentKey ?? name) ||
+      Boolean(storeRecord) ||
       this.fallbackRecords.delete(recordKey(sessionId, type, name));
-    if (changed && state.activationStore?.isEnabled()) state.activationStore.recordDeactivation(type, name);
+    if (agentKey) state.agentNamesByIdentity.delete(agentKey);
+    if (changed && state.activationStore?.isEnabled()) {
+      state.activationStore.recordDeactivation(type, name, storeRecord?.filename, storeRecord?.identity);
+    }
     return Promise.resolve(changed);
   }
 
@@ -126,7 +143,10 @@ function recordsFromStateSets(state: SessionActivationState): SessionActivationR
   const now = new Date();
   const records: SessionActivationRecord[] = [];
   for (const type of ACTIVATION_TYPES) {
-    for (const name of activationSet(state, type)) {
+    for (const activationKey of activationSet(state, type)) {
+      const name = type === 'agents'
+        ? state.agentNamesByIdentity.get(activationKey) ?? activationKey
+        : activationKey;
       records.push({ type, name, activatedAt: now });
     }
   }

--- a/src/web-console/modules/activations/SessionActivationStateAdapter.ts
+++ b/src/web-console/modules/activations/SessionActivationStateAdapter.ts
@@ -39,18 +39,34 @@ export class RegistrySessionActivationStateAdapter implements ISessionActivation
     name: string,
   ): Promise<SessionActivationChangeResult> {
     const state = this.registry.getOrCreate(sessionId);
-    const storeRecord = state.activationStore?.getActivations(type).find(record => record.name === name);
+    const agentEntry = type === 'agents'
+      ? Array.from(state.agentNamesByIdentity.entries()).find(([identity, alias]) =>
+        identity === name || alias === name
+      )
+      : undefined;
+    const storeRecord = state.activationStore?.getActivations(type).find(record =>
+      record.name === name || (
+        type === 'agents' &&
+        (record.identity?.value === name || record.identity?.value === agentEntry?.[0])
+      )
+    );
     const fallbackRecord = this.fallbackRecords.get(recordKey(sessionId, type, name));
-    const activationKey = type === 'agents' && storeRecord?.identity
-      ? storeRecord.identity.value
+    const activationKey = type === 'agents'
+      ? storeRecord?.identity?.value ?? agentEntry?.[0] ?? name
       : name;
+    const displayName = agentEntry?.[1] ?? storeRecord?.name ?? name;
     const changed = !activationSet(state, type).has(activationKey) && !storeRecord && !fallbackRecord;
     activationSet(state, type).add(activationKey);
     if (type === 'agents' && storeRecord?.identity) {
-      state.agentNamesByIdentity.set(activationKey, name);
+      state.agentNamesByIdentity.set(activationKey, displayName);
     }
     if (state.activationStore?.isEnabled()) {
-      state.activationStore.recordActivation(type, name);
+      state.activationStore.recordActivation(
+        type,
+        displayName,
+        storeRecord?.filename,
+        storeRecord?.identity,
+      );
     } else if (!fallbackRecord) {
       this.fallbackRecords.set(recordKey(sessionId, type, name), {
         type,
@@ -58,10 +74,12 @@ export class RegistrySessionActivationStateAdapter implements ISessionActivation
         activatedAt: new Date(),
       });
     }
-    const persistedRecord = state.activationStore?.getActivations(type).find(record => record.name === name);
+    const persistedRecord = state.activationStore?.getActivations(type).find(record =>
+      record.name === displayName || record.identity?.value === activationKey
+    );
     const record = {
       type,
-      name,
+      name: displayName,
       activatedAt: persistedRecord
         ? parseActivationDate(persistedRecord.activatedAt)
         : this.fallbackRecords.get(recordKey(sessionId, type, name))?.activatedAt ?? new Date(),

--- a/tests/integration/database/DatabaseActivationStateStore.test.ts
+++ b/tests/integration/database/DatabaseActivationStateStore.test.ts
@@ -72,6 +72,30 @@ describe('DatabaseActivationStateStore', () => {
     expect(store.getActivations('skill')).toHaveLength(1);
   });
 
+  it('should persist distinct row identities and upgrade legacy agent records', async () => {
+    if (!dbAvailable) return;
+    const userId = await ensureTestUser();
+    const store = new DatabaseActivationStateStore(getTestDb(), userId, TEST_SESSION_ID);
+    await store.initialize();
+
+    const firstIdentity = { kind: 'database' as const, value: '11111111-1111-4111-8111-111111111111' };
+    const secondIdentity = { kind: 'database' as const, value: '22222222-2222-4222-8222-222222222222' };
+    store.recordActivation('agent', 'Legacy Agent');
+    store.recordActivation('agent', 'Legacy Agent', undefined, firstIdentity);
+    store.recordActivation('agent', 'Renamed Agent', undefined, firstIdentity);
+    store.recordActivation('agent', 'Renamed Agent', undefined, secondIdentity);
+
+    expect(store.getActivations('agent')).toEqual([
+      expect.objectContaining({ name: 'Renamed Agent', identity: firstIdentity }),
+      expect.objectContaining({ name: 'Renamed Agent', identity: secondIdentity }),
+    ]);
+
+    await store.awaitPendingWrites();
+    const restored = new DatabaseActivationStateStore(getTestDb(), userId, TEST_SESSION_ID);
+    await restored.initialize();
+    expect(restored.getActivations('agent')).toHaveLength(2);
+  });
+
   it('should record deactivation', async () => {
     if (!dbAvailable) return;
     const userId = await ensureTestUser();

--- a/tests/unit/Container.startup-behavior.test.ts
+++ b/tests/unit/Container.startup-behavior.test.ts
@@ -266,6 +266,31 @@ describe('Container Startup - Behavior (Non-Flaky)', () => {
       expect(removeStaleSpy).toHaveBeenCalledWith('agent', 'missing-agent');
     });
 
+    it('should upgrade a successfully restored legacy agent record with durable identity', async () => {
+      const agentManager = container.resolve<any>('AgentManager');
+      const activationStore = container.resolve<IActivationStateStore>('ActivationStore');
+      const identity = { kind: 'file' as const, value: 'stable-agent.md' };
+
+      jest.spyOn(activationStore, 'isEnabled').mockReturnValue(true);
+      jest.spyOn(activationStore, 'initialize').mockResolvedValue(undefined);
+      jest.spyOn(activationStore, 'getActivations').mockImplementation((type: string) => {
+        if (type === 'agent') return [{ name: 'Legacy Agent', activatedAt: new Date().toISOString() }];
+        return [];
+      });
+      const recordSpy = jest.spyOn(activationStore, 'recordActivation').mockImplementation(() => {});
+      jest.spyOn(agentManager, 'activateAgent').mockResolvedValue({
+        success: true,
+        message: 'Activated',
+        agent: { metadata: { name: 'Current Agent' } },
+        identity,
+      });
+
+      await container.preparePortfolio();
+      await container.completeDeferredSetup();
+
+      expect(recordSpy).toHaveBeenCalledWith('agent', 'Current Agent', undefined, identity);
+    });
+
     it('should prune stale persona activations when activatePersona returns failure', async () => {
       const personaManager = container.resolve<any>('PersonaManager');
       const activationStore = container.resolve<IActivationStateStore>('ActivationStore');

--- a/tests/unit/elements/agents/AgentManager.test.ts
+++ b/tests/unit/elements/agents/AgentManager.test.ts
@@ -36,6 +36,7 @@ import {
   AgentStateSizeLimitError,
 } from '../../../../src/storage/FileAgentStateStore.js';
 import { EVICT_TERMINAL_GOAL } from '../../../../src/elements/agents/constants.js';
+import { SessionActivationRegistry } from '../../../../src/state/SessionActivationState.js';
 
 const metadataService: MetadataService = createTestMetadataService();
 
@@ -157,6 +158,60 @@ describe('AgentManager', () => {
       expect(refresh).toHaveBeenCalledWith({ freshAfterInFlight: true });
       expect(findByName).toHaveBeenCalledWith('active-agent');
       expect(list).not.toHaveBeenCalled();
+    });
+
+    it('keeps an active agent addressable after its display name changes', async () => {
+      const agent = new Agent({ name: 'Original Name' }, metadataService);
+      Object.defineProperty(agent, 'filePath', { value: 'stable-agent.md', configurable: true });
+      jest.spyOn(agentManager, 'findByName').mockResolvedValue(agent);
+      const findByStorageIdentity = jest.spyOn(agentManager, 'findByStorageIdentity').mockResolvedValue(agent);
+      jest.spyOn(agentManager as any, 'scanAndEvict').mockResolvedValue(undefined);
+
+      const activated = await agentManager.activateAgent('Original Name');
+      agent.metadata.name = 'Renamed Agent';
+      const active = await agentManager.getActiveAgents({ freshAfterInFlight: true });
+
+      expect(activated.identity).toEqual({ kind: 'file', value: 'stable-agent.md' });
+      expect(findByStorageIdentity).toHaveBeenCalledWith('stable-agent.md');
+      expect(active).toEqual([agent]);
+      expect(active[0].metadata.name).toBe('Renamed Agent');
+    });
+
+    it('preserves same-name agents with distinct storage identities', async () => {
+      const first = new Agent({ name: 'Shared Name' }, metadataService);
+      const second = new Agent({ name: 'Shared Name' }, metadataService);
+      Object.defineProperty(first, 'filePath', { value: 'first.md', configurable: true });
+      Object.defineProperty(second, 'filePath', { value: 'second.md', configurable: true });
+      jest.spyOn(agentManager as any, 'scanAndEvict').mockResolvedValue(undefined);
+      jest.spyOn(agentManager, 'findByStorageIdentity').mockImplementation(async (identity) =>
+        identity === 'first.md' ? first : identity === 'second.md' ? second : undefined
+      );
+
+      await agentManager.activateAgentByStorageIdentity({ kind: 'file', value: 'first.md' }, 'Shared Name');
+      await agentManager.activateAgentByStorageIdentity({ kind: 'file', value: 'second.md' }, 'Shared Name');
+
+      expect(await agentManager.getActiveAgents()).toEqual([first, second]);
+    });
+
+    it('keeps durable agent identities isolated between sessions', async () => {
+      const registry = new SessionActivationRegistry('session-a');
+      let sessionId = 'session-a';
+      (agentManager as any).activationRegistry = registry;
+      (agentManager as any).contextTracker = {
+        getSessionContext: () => ({ sessionId }),
+      };
+      const agent = new Agent({ name: 'Session Agent' }, metadataService);
+      Object.defineProperty(agent, 'filePath', { value: 'session-agent.md', configurable: true });
+      jest.spyOn(agentManager, 'findByName').mockResolvedValue(agent);
+      jest.spyOn(agentManager, 'findByStorageIdentity').mockResolvedValue(agent);
+      jest.spyOn(agentManager as any, 'scanAndEvict').mockResolvedValue(undefined);
+
+      await agentManager.activateAgent('Session Agent');
+      expect(registry.getOrCreate('session-a').agents).toEqual(new Set(['session-agent.md']));
+
+      sessionId = 'session-b';
+      expect(await agentManager.getActiveAgents()).toEqual([]);
+      expect(registry.getOrCreate('session-b').agents.size).toBe(0);
     });
   });
 

--- a/tests/unit/elements/agents/AgentManager.test.ts
+++ b/tests/unit/elements/agents/AgentManager.test.ts
@@ -193,6 +193,24 @@ describe('AgentManager', () => {
       expect(await agentManager.getActiveAgents()).toEqual([first, second]);
     });
 
+    it('deactivates only the resolved identity when another identity matches its display name', async () => {
+      const first = new Agent({ name: 'second.md' }, metadataService);
+      const second = new Agent({ name: 'Other Agent' }, metadataService);
+      Object.defineProperty(first, 'filePath', { value: 'first.md', configurable: true });
+      Object.defineProperty(second, 'filePath', { value: 'second.md', configurable: true });
+      jest.spyOn(agentManager as any, 'scanAndEvict').mockResolvedValue(undefined);
+      jest.spyOn(agentManager, 'findByStorageIdentity').mockImplementation(async (identity) =>
+        identity === 'first.md' ? first : identity === 'second.md' ? second : undefined
+      );
+
+      await agentManager.activateAgentByStorageIdentity({ kind: 'file', value: 'first.md' });
+      await agentManager.activateAgentByStorageIdentity({ kind: 'file', value: 'second.md' });
+      await agentManager.deactivateAgent('first.md');
+
+      expect((agentManager as any).getActivationSet()).toEqual(new Set(['second.md']));
+      expect(await agentManager.getActiveAgents()).toEqual([second]);
+    });
+
     it('keeps durable agent identities isolated between sessions', async () => {
       const registry = new SessionActivationRegistry('session-a');
       let sessionId = 'session-a';

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -55,6 +55,7 @@ describe('ElementCRUDHandler (DI)', () => {
       list: jest.fn().mockResolvedValue([]),
       refreshIndex: jest.fn().mockResolvedValue(undefined),
       findByName: jest.fn().mockResolvedValue(undefined),
+      getActivationIdentity: jest.fn().mockReturnValue(undefined),
     } as unknown as jest.Mocked<AgentManager>;
 
     memoryManager = {
@@ -523,6 +524,170 @@ describe('ElementCRUDHandler (DI)', () => {
       expect(skillManager.list).not.toHaveBeenCalled();
     });
 
+    it('deduplicates live and persisted agent policy by durable identity after rename', async () => {
+      const identity = { kind: 'file' as const, value: 'stable-agent.md' };
+      const policyAgent = {
+        filePath: identity.value,
+        metadata: {
+          name: 'Renamed Agent',
+          gatekeeper: { externalRestrictions: { denyPatterns: ['Bash:rm*'] } },
+        },
+      } as any;
+      const activationStore = {
+        isEnabled: jest.fn().mockReturnValue(true),
+        getSessionId: jest.fn().mockReturnValue('leader-session'),
+        listPersistedActivationStates: jest.fn().mockResolvedValue([{
+          sessionId: 'session-other',
+          lastUpdated: new Date().toISOString(),
+          activations: {
+            agent: [{ name: 'Original Agent', identity, activatedAt: new Date().toISOString() }],
+          },
+        }]),
+      } as unknown as jest.Mocked<ActivationStore>;
+      agentManager.getActiveAgents.mockResolvedValue([policyAgent]);
+      agentManager.getActivationIdentity.mockReturnValue(identity);
+      agentManager.refreshIndex.mockResolvedValue(undefined);
+      agentManager.findByStorageIdentity = jest.fn().mockResolvedValue(policyAgent);
+
+      const reportHandler = new ElementCRUDHandler(
+        skillManager,
+        templateManager,
+        templateRenderer,
+        agentManager,
+        memoryManager,
+        ensembleManager,
+        personaHandler,
+        portfolioManager,
+        initService,
+        indicatorService,
+        fileOperations,
+        undefined as any,
+        undefined as any,
+        activationStore,
+      );
+
+      const result = await reportHandler.getPolicyElementsForReport();
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          type: 'agent',
+          name: 'Renamed Agent',
+          sessionIds: ['leader-session', 'session-other'],
+        }),
+      ]);
+      expect(agentManager.findByStorageIdentity).toHaveBeenCalledWith(identity.value);
+      expect(agentManager.findByName).not.toHaveBeenCalledWith('Original Agent');
+    });
+
+    it('reports a live-only persona by stable filename identity', async () => {
+      personaHandler.getActivePersonas.mockReturnValue([{
+        filename: 'policy-persona.md',
+        metadata: {
+          name: 'Policy Persona',
+          gatekeeper: { externalRestrictions: { denyPatterns: ['Bash:rm*'] } },
+        },
+      } as any]);
+
+      const result = await handler.getPolicyElementsForReport();
+
+      expect(result).toEqual([
+        expect.objectContaining({ type: 'persona', name: 'Policy Persona' }),
+      ]);
+    });
+
+    it('reports a persisted-only persona through its stable filename', async () => {
+      const persistedPersona = {
+        filename: 'policy-persona.md',
+        filePath: 'policy-persona.md',
+        metadata: {
+          name: 'Renamed Policy Persona',
+          gatekeeper: { externalRestrictions: { denyPatterns: ['Bash:rm*'] } },
+        },
+      } as any;
+      const activationStore = {
+        isEnabled: jest.fn().mockReturnValue(true),
+        getSessionId: jest.fn().mockReturnValue('leader-session'),
+        listPersistedActivationStates: jest.fn().mockResolvedValue([{
+          sessionId: 'session-other',
+          lastUpdated: new Date().toISOString(),
+          activations: {
+            persona: [{
+              name: 'Original Policy Persona',
+              filename: 'policy-persona.md',
+              activatedAt: new Date().toISOString(),
+            }],
+          },
+        }]),
+      } as unknown as jest.Mocked<ActivationStore>;
+      personaHandler.findByName.mockImplementation(async (identifier: string) =>
+        identifier === 'policy-persona.md' ? persistedPersona : undefined
+      );
+
+      const reportHandler = new ElementCRUDHandler(
+        skillManager, templateManager, templateRenderer, agentManager, memoryManager,
+        ensembleManager, personaHandler, portfolioManager, initService, indicatorService,
+        fileOperations, undefined as any, undefined as any, activationStore,
+      );
+
+      const result = await reportHandler.getPolicyElementsForReport('session-other');
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          type: 'persona',
+          name: 'Renamed Policy Persona',
+          sessionIds: ['session-other'],
+        }),
+      ]);
+      expect(personaHandler.findByName).toHaveBeenCalledWith('Original Policy Persona');
+      expect(personaHandler.findByName).toHaveBeenCalledWith('policy-persona.md');
+    });
+
+    it('deduplicates combined live and persisted persona policy by stable filename', async () => {
+      const policyPersona = {
+        filename: 'policy-persona.md',
+        filePath: 'policy-persona.md',
+        metadata: {
+          name: 'Renamed Policy Persona',
+          gatekeeper: { externalRestrictions: { denyPatterns: ['Bash:rm*'] } },
+        },
+      } as any;
+      const activationStore = {
+        isEnabled: jest.fn().mockReturnValue(true),
+        getSessionId: jest.fn().mockReturnValue('leader-session'),
+        listPersistedActivationStates: jest.fn().mockResolvedValue([{
+          sessionId: 'session-other',
+          lastUpdated: new Date().toISOString(),
+          activations: {
+            persona: [{
+              name: 'Original Policy Persona',
+              filename: 'policy-persona.md',
+              activatedAt: new Date().toISOString(),
+            }],
+          },
+        }]),
+      } as unknown as jest.Mocked<ActivationStore>;
+      personaHandler.getActivePersonas.mockReturnValue([policyPersona]);
+      personaHandler.findByName.mockImplementation(async (identifier: string) =>
+        identifier === 'policy-persona.md' ? policyPersona : undefined
+      );
+
+      const reportHandler = new ElementCRUDHandler(
+        skillManager, templateManager, templateRenderer, agentManager, memoryManager,
+        ensembleManager, personaHandler, portfolioManager, initService, indicatorService,
+        fileOperations, undefined as any, undefined as any, activationStore,
+      );
+
+      const result = await reportHandler.getPolicyElementsForReport();
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          type: 'persona',
+          name: 'Renamed Policy Persona',
+          sessionIds: ['leader-session', 'session-other'],
+        }),
+      ]);
+    });
+
     it('bounds persisted policy lookups at eight and preserves activation order', async () => {
       const activations = Array.from({ length: 20 }, (_, index) => ({
         name: `persisted-skill-${index}`,
@@ -752,6 +917,25 @@ describe('ElementCRUDHandler (DI)', () => {
       expect(activationStore.clearAll).toHaveBeenCalled();
       expect(fileOperations.createDirectory).toHaveBeenCalled();
       expect(fileOperations.writeFile).toHaveBeenCalled();
+    });
+
+    it('deactivates colliding agent names by durable identity during deadlock relief', async () => {
+      const firstAgent = { filePath: 'first.md', metadata: { name: 'Shared Agent' } } as any;
+      const secondAgent = { filePath: 'second.md', metadata: { name: 'Shared Agent' } } as any;
+      agentManager.getActiveAgents.mockResolvedValue([firstAgent, secondAgent]);
+      agentManager.getActivationIdentity.mockImplementation((agent) => ({
+        kind: 'file',
+        value: agent.filePath,
+      }));
+
+      const result = await handler.releaseDeadlock();
+
+      expect(agentManager.deactivateAgent).toHaveBeenCalledWith('first.md');
+      expect(agentManager.deactivateAgent).toHaveBeenCalledWith('second.md');
+      expect(result.deactivated).toEqual([
+        { type: ElementType.AGENT, name: 'Shared Agent' },
+        { type: ElementType.AGENT, name: 'Shared Agent' },
+      ]);
     });
   });
 });

--- a/tests/unit/handlers/strategies/PersonaActivationStrategy.test.ts
+++ b/tests/unit/handlers/strategies/PersonaActivationStrategy.test.ts
@@ -31,6 +31,7 @@ describe('PersonaActivationStrategy', () => {
   describe('activate', () => {
     it('should activate persona successfully', async () => {
       const mockPersona = {
+        filename: 'test-persona.md',
         metadata: {
           name: 'test-persona',
           description: 'A test persona'
@@ -51,6 +52,10 @@ describe('PersonaActivationStrategy', () => {
       expect(result.content[0].text).toContain('test-persona');
       expect(result.content[0].text).toContain('A test persona');
       expect(result.content[0].text).toContain('Persona instructions here');
+      expect(result.activationRecord).toEqual({
+        name: 'test-persona',
+        filename: 'test-persona.md',
+      });
       expect(mockPersonaManager.activatePersona).toHaveBeenCalledWith('test-persona');
     });
 
@@ -148,6 +153,7 @@ describe('PersonaActivationStrategy', () => {
 
   describe('deactivate', () => {
     const mockPersona = {
+      filename: 'test-persona.md',
       metadata: { name: 'test-persona', description: 'Test' },
       content: 'Content',
       unique_id: 'test-id'
@@ -165,6 +171,10 @@ describe('PersonaActivationStrategy', () => {
       expect(result.content[0].text).toContain('>>');
       expect(result.content[0].text).toContain('✅');
       expect(result.content[0].text).toContain('Persona deactivated');
+      expect(result.activationRecord).toEqual({
+        name: 'test-persona',
+        filename: 'test-persona.md',
+      });
       expect(mockPersonaManager.deactivatePersona).toHaveBeenCalled();
     });
 

--- a/tests/unit/services/sessionIdentity.test.ts
+++ b/tests/unit/services/sessionIdentity.test.ts
@@ -17,6 +17,22 @@ describe('sessionIdentity', () => {
     });
   });
 
+  it('accepts digit-first UUID session identities', () => {
+    const sessionId = '7d444840-9dc0-4f1a-8f5c-07f4f97b6abc';
+    const identity = resolveSessionIdentity({
+      envValue: sessionId,
+      cwd: '/Users/example/project',
+      homeDir: '/Users/example',
+      pid: 1234,
+    });
+
+    expect(identity).toEqual({
+      sessionId,
+      runtimeSessionId: sessionId,
+      source: 'env',
+    });
+  });
+
   it('derives a restart-stable session identity from workspace context', () => {
     const identityA = resolveSessionIdentity({
       cwd: '/Users/mick/project-a',

--- a/tests/unit/state/FileActivationStateStore.test.ts
+++ b/tests/unit/state/FileActivationStateStore.test.ts
@@ -91,9 +91,9 @@ describe('FileActivationStateStore', () => {
       expect(store.getSessionId()).toBe('test-session');
     });
 
-    it('should reject invalid sessionId and fall back to default', () => {
-      const s = new FileActivationStateStore(mockFileOps, TEST_STATE_DIR, '../evil-path');
-      expect(s.getSessionId()).toBe('default');
+    it('should reject an invalid externally supplied sessionId', () => {
+      expect(() => new FileActivationStateStore(mockFileOps, TEST_STATE_DIR, '../evil-path'))
+        .toThrow('Invalid external sessionId');
     });
 
     it('should generate unique session ID when env var not set and no param', () => {
@@ -125,10 +125,10 @@ describe('FileActivationStateStore', () => {
       expect(s.getSessionId()).toBe('claude-code_v2');
     });
 
-    it('should reject session IDs starting with a number', () => {
+    it('should accept session IDs starting with a number for UUID compatibility', () => {
       process.env.DOLLHOUSE_SESSION_ID = '123-session';
       const s = new FileActivationStateStore(mockFileOps, TEST_STATE_DIR);
-      expect(s.getSessionId()).toBe('default');
+      expect(s.getSessionId()).toBe('123-session');
     });
 
     it('should prefer explicit sessionId over env var', () => {
@@ -137,9 +137,9 @@ describe('FileActivationStateStore', () => {
       expect(s.getSessionId()).toBe('from-param');
     });
 
-    it('should fall back to resolveSessionId when sessionId param is empty', () => {
-      const s = new FileActivationStateStore(mockFileOps, TEST_STATE_DIR, '');
-      expect(s.getSessionId()).toMatch(/^session-[a-z0-9]+-[a-f0-9]+$/);
+    it('should reject an empty externally supplied sessionId', () => {
+      expect(() => new FileActivationStateStore(mockFileOps, TEST_STATE_DIR, ''))
+        .toThrow('value must not be empty');
     });
 
     it('should trim whitespace from provided sessionId', () => {
@@ -147,9 +147,15 @@ describe('FileActivationStateStore', () => {
       expect(s.getSessionId()).toBe('valid-session');
     });
 
-    it('should reject param sessionId starting with number', () => {
+    it('should accept an externally supplied UUID-like sessionId starting with a number', () => {
       const s = new FileActivationStateStore(mockFileOps, TEST_STATE_DIR, '123-bad');
-      expect(s.getSessionId()).toBe('default');
+      expect(s.getSessionId()).toBe('123-bad');
+    });
+
+    it('should reject traversal in a reporting session filter before path construction', async () => {
+      await expect(store.listPersistedActivationStates('../another-session'))
+        .rejects.toThrow('Invalid external sessionId');
+      expect(mockFileOps.readFile).not.toHaveBeenCalled();
     });
   });
 
@@ -350,6 +356,54 @@ describe('FileActivationStateStore', () => {
       expect(store.getActivations('skill')).toHaveLength(1);
     });
 
+    it('should upgrade a legacy name-only agent record with durable identity', () => {
+      store.recordActivation('agent', 'Research Agent');
+      store.recordActivation('agent', 'Research Agent', undefined, {
+        kind: 'file',
+        value: 'research-agent.md',
+      });
+
+      expect(store.getActivations('agent')).toEqual([
+        expect.objectContaining({
+          name: 'Research Agent',
+          identity: { kind: 'file', value: 'research-agent.md' },
+        }),
+      ]);
+    });
+
+    it('should update the display name without duplicating a durable identity', () => {
+      const identity = { kind: 'file' as const, value: 'research-agent.md' };
+      store.recordActivation('agent', 'Research Agent', undefined, identity);
+      store.recordActivation('agent', 'Renamed Research Agent', undefined, identity);
+
+      expect(store.getActivations('agent')).toEqual([
+        expect.objectContaining({ name: 'Renamed Research Agent', identity }),
+      ]);
+    });
+
+    it('should migrate a legacy agent filename record after an external rename', () => {
+      store.recordActivation('agent', 'Old Name', 'stable-agent.md');
+      store.recordActivation('agent', 'New Name', undefined, {
+        kind: 'file',
+        value: 'stable-agent.md',
+      });
+
+      expect(store.getActivations('agent')).toEqual([
+        expect.objectContaining({
+          name: 'New Name',
+          identity: { kind: 'file', value: 'stable-agent.md' },
+        }),
+      ]);
+      expect(store.getActivations('agent')[0]).not.toHaveProperty('filename');
+    });
+
+    it('should preserve colliding display names with distinct durable identities', () => {
+      store.recordActivation('agent', 'Shared Name', undefined, { kind: 'file', value: 'first.md' });
+      store.recordActivation('agent', 'Shared Name', undefined, { kind: 'file', value: 'second.md' });
+
+      expect(store.getActivations('agent')).toHaveLength(2);
+    });
+
     it('should deduplicate canonical-equivalent Unicode names', () => {
       store.recordActivation('skill', 'Cafe\u0301 Skill');
       store.recordActivation('skill', 'Café Skill');
@@ -463,6 +517,28 @@ describe('FileActivationStateStore', () => {
 
       store.recordDeactivation('skill', 'Café Skill');
       expect(store.getActivations('skill')).toHaveLength(0);
+    });
+
+    it('should deactivate a renamed agent by durable identity', () => {
+      const identity = { kind: 'file' as const, value: 'research-agent.md' };
+      store.recordActivation('agent', 'Old Name', undefined, identity);
+
+      store.recordDeactivation('agent', 'New Name', undefined, identity);
+
+      expect(store.getActivations('agent')).toHaveLength(0);
+    });
+
+    it('should deactivate only the matching identity when display names collide', () => {
+      const firstIdentity = { kind: 'file' as const, value: 'first.md' };
+      const secondIdentity = { kind: 'file' as const, value: 'second.md' };
+      store.recordActivation('agent', 'Shared Name', undefined, firstIdentity);
+      store.recordActivation('agent', 'Shared Name', undefined, secondIdentity);
+
+      store.recordDeactivation('agent', 'Shared Name', undefined, firstIdentity);
+
+      expect(store.getActivations('agent')).toEqual([
+        expect.objectContaining({ identity: secondIdentity }),
+      ]);
     });
 
     it('should log ELEMENT_DEACTIVATED security event', async () => {

--- a/tests/unit/state/FileActivationStateStore.test.ts
+++ b/tests/unit/state/FileActivationStateStore.test.ts
@@ -541,6 +541,17 @@ describe('FileActivationStateStore', () => {
       ]);
     });
 
+    it('should not treat another record filename as a name-only deactivation match', () => {
+      store.recordActivation('persona', 'First Persona', 'Shared Name');
+      store.recordActivation('persona', 'Shared Name', 'second-persona.md');
+
+      store.recordDeactivation('persona', 'Shared Name');
+
+      expect(store.getActivations('persona')).toEqual([
+        expect.objectContaining({ name: 'First Persona', filename: 'Shared Name' }),
+      ]);
+    });
+
     it('should log ELEMENT_DEACTIVATED security event', async () => {
       // Re-import SecurityMonitor mock to verify it's wired up
       const { SecurityMonitor } = await import('../../../src/security/securityMonitor.js');

--- a/tests/unit/state/FileActivationStateStore.test.ts
+++ b/tests/unit/state/FileActivationStateStore.test.ts
@@ -101,34 +101,21 @@ describe('FileActivationStateStore', () => {
       expect(s.getSessionId()).toMatch(/^session-[a-z0-9]+-[a-f0-9]+$/);
     });
 
-    it('should use DOLLHOUSE_SESSION_ID when set and no param', () => {
-      process.env.DOLLHOUSE_SESSION_ID = 'my-session';
+    it.each([
+      ['a valid value', 'my-session', 'my-session'],
+      ['an invalid traversal value', '../evil-path', 'default'],
+      ['hyphens and underscores', 'claude-code_v2', 'claude-code_v2'],
+      ['a digit-first value', '123-session', '123-session'],
+    ])('should resolve DOLLHOUSE_SESSION_ID with %s', (_case, envValue, expected) => {
+      process.env.DOLLHOUSE_SESSION_ID = envValue;
       const s = new FileActivationStateStore(mockFileOps, TEST_STATE_DIR);
-      expect(s.getSessionId()).toBe('my-session');
-    });
-
-    it('should fall back to default for invalid env session ID', () => {
-      process.env.DOLLHOUSE_SESSION_ID = '../evil-path';
-      const s = new FileActivationStateStore(mockFileOps, TEST_STATE_DIR);
-      expect(s.getSessionId()).toBe('default');
+      expect(s.getSessionId()).toBe(expected);
     });
 
     it('should generate unique session ID for empty env session ID', () => {
       process.env.DOLLHOUSE_SESSION_ID = '  ';
       const s = new FileActivationStateStore(mockFileOps, TEST_STATE_DIR);
       expect(s.getSessionId()).toMatch(/^session-[a-z0-9]+-[a-f0-9]+$/);
-    });
-
-    it('should accept alphanumeric with hyphens and underscores', () => {
-      process.env.DOLLHOUSE_SESSION_ID = 'claude-code_v2';
-      const s = new FileActivationStateStore(mockFileOps, TEST_STATE_DIR);
-      expect(s.getSessionId()).toBe('claude-code_v2');
-    });
-
-    it('should accept session IDs starting with a number for UUID compatibility', () => {
-      process.env.DOLLHOUSE_SESSION_ID = '123-session';
-      const s = new FileActivationStateStore(mockFileOps, TEST_STATE_DIR);
-      expect(s.getSessionId()).toBe('123-session');
     });
 
     it('should prefer explicit sessionId over env var', () => {

--- a/tests/unit/state/SessionActivationRegistry.test.ts
+++ b/tests/unit/state/SessionActivationRegistry.test.ts
@@ -28,6 +28,7 @@ describe('createSessionActivationState', () => {
     expect(state.personas.size).toBe(0);
     expect(state.skills.size).toBe(0);
     expect(state.agents.size).toBe(0);
+    expect(state.agentNamesByIdentity.size).toBe(0);
     expect(state.memories.size).toBe(0);
     expect(state.ensembles.size).toBe(0);
     expect(state.userIdentity).toBeUndefined();
@@ -128,6 +129,7 @@ describe('SessionActivationRegistry', () => {
       sessionA.personas.add('persona-a.md');
       sessionA.skills.add('skill-a');
       sessionA.agents.add('agent-a');
+      sessionA.agentNamesByIdentity.set('agent-a.md', 'Agent A');
       sessionA.memories.add('memory-a');
       sessionA.ensembles.add('ensemble-a');
 
@@ -144,6 +146,7 @@ describe('SessionActivationRegistry', () => {
       expect(sessionB.personas.has('persona-b.md')).toBe(true);
       expect(sessionB.personas.has('persona-a.md')).toBe(false);
       expect(sessionB.agents.size).toBe(0);
+      expect(sessionB.agentNamesByIdentity.size).toBe(0);
       expect(sessionB.memories.size).toBe(0);
     });
 

--- a/tests/unit/web-console/modules/ActivationModule.test.ts
+++ b/tests/unit/web-console/modules/ActivationModule.test.ts
@@ -427,6 +427,32 @@ describe('RegistrySessionActivationStateAdapter', () => {
     expect(state.agentNamesByIdentity.size).toBe(0);
     expect(store.getActivations(AGENT_TYPE)).toEqual([]);
   });
+
+  it('re-activates a renamed agent through its durable identity without duplicating persistence', async () => {
+    const registry = new SessionActivationRegistry('default-session');
+    const state = registry.getOrCreate(SESSION_ID);
+    const store = new FixtureActivationStateStore(SESSION_ID);
+    const identity = { kind: 'file' as const, value: 'stable-agent.md' };
+    store.recordActivation(AGENT_TYPE, 'Original Agent', undefined, identity);
+    state.activationStore = store;
+    state.agents.add(identity.value);
+    state.agentNamesByIdentity.set(identity.value, 'Renamed Agent');
+    const adapter = new RegistrySessionActivationStateAdapter(registry);
+
+    await expect(adapter.activate(SESSION_ID, AGENT_TYPE, 'Renamed Agent')).resolves.toEqual({
+      changed: false,
+      record: {
+        type: AGENT_TYPE,
+        name: 'Renamed Agent',
+        activatedAt: NOW,
+      },
+    });
+    expect(store.getActivations(AGENT_TYPE)).toEqual([{
+      name: 'Renamed Agent',
+      identity,
+      activatedAt: NOW.toISOString(),
+    }]);
+  });
 });
 
 class FixtureActivationStateStore implements IActivationStateStore {
@@ -445,6 +471,15 @@ class FixtureActivationStateStore implements IActivationStateStore {
     identity?: PersistedActivationIdentity,
   ): void {
     const existing = this.activations.get(elementType) ?? [];
+    const identityMatch = identity
+      ? existing.find(activation =>
+        activation.identity?.kind === identity.kind && activation.identity.value === identity.value
+      )
+      : undefined;
+    if (identityMatch) {
+      identityMatch.name = name;
+      return;
+    }
     if (existing.some(activation => activation.name === name)) return;
     this.activations.set(elementType, [
       ...existing,

--- a/tests/unit/web-console/modules/ActivationModule.test.ts
+++ b/tests/unit/web-console/modules/ActivationModule.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from '@jest/globals';
 import type {
   IActivationStateStore,
   PersistedActivation,
+  PersistedActivationIdentity,
   PersistedActivationStateSnapshot,
 } from '../../../../src/state/IActivationStateStore.js';
 import { SessionActivationRegistry } from '../../../../src/state/SessionActivationState.js';
@@ -406,6 +407,26 @@ describe('RegistrySessionActivationStateAdapter', () => {
     await expect(adapter.deactivate(SESSION_ID, SKILL_TYPE, SKILL_CANONICAL_NAME)).resolves.toBe(false);
     expect(store.getActivations(SKILL_TYPE)).toEqual([]);
   });
+
+  it('reports and deactivates agent identities through their display-name alias', async () => {
+    const registry = new SessionActivationRegistry('default-session');
+    const state = registry.getOrCreate(SESSION_ID);
+    const store = new FixtureActivationStateStore(SESSION_ID);
+    const identity = { kind: 'file' as const, value: 'stable-agent.md' };
+    store.recordActivation(AGENT_TYPE, 'Renamed Agent', undefined, identity);
+    state.activationStore = store;
+    state.agents.add(identity.value);
+    state.agentNamesByIdentity.set(identity.value, 'Renamed Agent');
+    const adapter = new RegistrySessionActivationStateAdapter(registry);
+
+    await expect(adapter.list(SESSION_ID)).resolves.toEqual([
+      expect.objectContaining({ type: AGENT_TYPE, name: 'Renamed Agent' }),
+    ]);
+    await expect(adapter.deactivate(SESSION_ID, AGENT_TYPE, 'Renamed Agent')).resolves.toBe(true);
+    expect(state.agents.size).toBe(0);
+    expect(state.agentNamesByIdentity.size).toBe(0);
+    expect(store.getActivations(AGENT_TYPE)).toEqual([]);
+  });
 });
 
 class FixtureActivationStateStore implements IActivationStateStore {
@@ -417,7 +438,12 @@ class FixtureActivationStateStore implements IActivationStateStore {
     return Promise.resolve();
   }
 
-  recordActivation(elementType: string, name: string, filename?: string): void {
+  recordActivation(
+    elementType: string,
+    name: string,
+    filename?: string,
+    identity?: PersistedActivationIdentity,
+  ): void {
     const existing = this.activations.get(elementType) ?? [];
     if (existing.some(activation => activation.name === name)) return;
     this.activations.set(elementType, [
@@ -425,15 +451,25 @@ class FixtureActivationStateStore implements IActivationStateStore {
       {
         name,
         ...(filename ? { filename } : {}),
+        ...(identity ? { identity } : {}),
         activatedAt: NOW.toISOString(),
       },
     ]);
   }
 
-  recordDeactivation(elementType: string, name: string): void {
+  recordDeactivation(
+    elementType: string,
+    name: string,
+    _filename?: string,
+    identity?: PersistedActivationIdentity,
+  ): void {
     this.activations.set(
       elementType,
-      (this.activations.get(elementType) ?? []).filter(activation => activation.name !== name),
+      (this.activations.get(elementType) ?? []).filter(activation =>
+        identity
+          ? activation.identity?.kind !== identity.kind || activation.identity.value !== identity.value
+          : activation.name !== name
+      ),
     );
   }
 


### PR DESCRIPTION
## Summary

Implements the second beta hotfix PR from #2627 using a backend-neutral durable activation identity.

- Keys file-backed agents by stable path and PostgreSQL-backed agents by row UUID.
- Preserves per-session isolation and display-name aliases across HTTP child sessions.
- Restores and upgrades legacy name-only or filename records, including metadata renames and backend changes.
- Deduplicates live and persisted agent/persona policy reporting by durable identity.
- Deactivates and prunes exact identities when names collide, including deadlock relief.
- Rejects caller-controlled invalid session IDs before filesystem or database reporting boundaries.
- Uses one canonical session-ID validator across stdio, file, and PostgreSQL paths, including digit-first UUIDs.
- Preserves beta runtime recovery and persistence behavior; no dependency, version, release, or hosted integration changes.

## Review corrections

- Extracted shared activation-record normalization, upsert, migration, and removal logic used by both stores.
- Reduced Sonar new-code duplication from 9.4% to 0.0%.
- Fixed agent display-name/identity collision deletion.
- Fixed exact persona filename deactivation.
- Fixed renamed-agent session reactivation without duplicate persisted records.
- Unified session-ID validation after exact-head Claude review identified a stdio/HTTP divergence.
- Cleared all new Sonar maintainability findings, including the final direct-re-export convention.

## Baseline

- Base branch: beta
- Exact base SHA: d58ebbab173e2bef8ab0b3ac29220d025ad9b6d0
- Exact head SHA: 1583623a7db1319eb3b10d3db49c5182f0ecd2be
- Sequence: 2 of 3

## Validation

- Exact-head GitHub checks: all 22 pass.
- Core and extended Node matrix: pass on Ubuntu, macOS, and Windows for Node 20/22 as configured.
- Docker: linux/amd64, linux/arm64, and Compose pass.
- CodeQL, security audits, QA, build-artifact validation, dependency review, and documentation validation: pass.
- Sonar Quality Gate: pass; 0.0% new-code duplication, 0 duplicated blocks, 0 duplicated lines, 0 new violations.
- Exact-head Claude review: Approve; all original findings and follow-ups are resolved.
- Local exact-head TypeScript, focused regression tests, changed-file ESLint, and diff check: pass.
- Broader local regression set: 226 focused tests pass; PostgreSQL 17 integration 8/8; rapid security 108 pass; repository security audit 0 findings.
- Full controlled unit suite before the final narrow cleanup: 12,755 passed, 12 skipped; only the pre-existing BuildInfo timing assertion missed its 600 ms threshold by 2 ms.

## Scope controls

- No OAuth helper changes; those belong to PR 3.
- No policy catalog/storage/export work from PR 1.
- No dependency or version changes.
- Do not merge without Mick approving this exact head.

Closes #2635
Related: #2627, #2629, #2630, #2631