### PR TITLE
chore: bump beta version to 2.1.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.1.0-beta.2] - 2026-09-04
+
+- Deployment candidate following the main-to-beta reconciliation in PR #2653.
+- Includes the current hosted HTTP, PostgreSQL, OAuth, console, and agent-runtime updates.
+- Known AgentManager identity follow-ups remain tracked separately.
+
 ## [2.1.0-beta.1] - 2026-07-04
 
 First versioned build of the 2.1 beta line. Not published to npm; deployed to the hosted beta environment.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "dollhousemcp",
   "display_name": "DollhouseMCP",
-  "version": "2.1.0-beta.1",
+  "version": "2.1.0-beta.2",
   "description": "Open-source AI customization through modular Dollhouse elements — personas, skills, templates, agents, memories, and ensembles.",
   "long_description": "DollhouseMCP is an MCP server that lets you customize your AI with modular Dollhouse elements. Create personas that shape behavior and permissions, skills that add capabilities, templates for consistent outputs, agents for autonomous multi-step goals, memories for persistent context, and ensembles that bundle elements together. Includes MCP-AQL query language with 5 semantic CRUDE endpoints, Gatekeeper permission system, community collection, and a built-in portfolio browser.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.1.0-beta.1",
+  "version": "2.1.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.1.0-beta.1",
+      "version": "2.1.0-beta.2",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.1.0-beta.1",
+  "version": "2.1.0-beta.2",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.1.0-beta.1",
+  "version": "2.1.0-beta.2",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.1.0-beta.1",
+      "version": "2.1.0-beta.2",
       "transport": {
         "type": "stdio"
       }

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -3,7 +3,7 @@
  * Generated at build time by scripts/generate-version.js
  */
 
-export const PACKAGE_VERSION = '2.1.0-beta.1';
-export const BUILD_TIMESTAMP = '2026-07-04T19:05:36.130Z';
+export const PACKAGE_VERSION = '2.1.0-beta.2';
+export const BUILD_TIMESTAMP = '2026-09-04T18:40:57.469Z';
 export const BUILD_TYPE: 'npm' | 'git' = 'git';
 export const PACKAGE_NAME = '@dollhousemcp/mcp-server';

--- a/tests/unit/scripts/publish-beta-release-state.test.ts
+++ b/tests/unit/scripts/publish-beta-release-state.test.ts
@@ -179,7 +179,7 @@ describe('Publish Beta Release state validation', () => {
       tagTarget: expectedSha,
       release: matchingRelease(),
       npmExists: true,
-      npmBetaVersion: '2.1.0-beta.2',
+      npmBetaVersion: '2.1.0-beta.3',
       npmLatestVersion: '2.0.40',
     });
 


### PR DESCRIPTION
## Summary

- bump the beta package identity from `2.1.0-beta.1` to `2.1.0-beta.2`
- update package, lockfile, manifest, server metadata, and generated version consistently
- add beta.2 changelog context for the PR #2653 reconciliation deployment candidate
- keep the beta release-state test version-relative by using beta.3 as its simulated newer channel

## Validation

- `node scripts/update-version.mjs 2.1.0-beta.2 --dry-run`
- `npm run build`
- focused release/version suite: 4 suites, 36 tests passed
- `git diff --check`

## Deployment note

A deployment of the still-versioned beta.1 branch was stopped during Docker image construction after backups and source staging, before any running container was replaced. The existing hosted service remains healthy and serves beta.1. After this PR is reviewed and merged, the deployment should be rerun with backups enabled and the remote `DEPLOYED_REVISION` verified against the resulting beta commit.

Known AgentManager and database identity follow-ups from PR #2653 remain intentionally separate.