### PR TITLE
ci: publish safety workspace before server releases

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -96,7 +96,12 @@ jobs:
       - name: Dry run safety package
         if: github.event.inputs.dry_run == 'true'
         working-directory: packages/safety
-        run: npm publish --dry-run
+        shell: bash
+        run: |
+          # npm 11 rejects --dry-run for a version that already exists. Use a
+          # run-local version so the complete publish lifecycle remains testable.
+          npm pkg set "version=0.0.0-dry-run.${GITHUB_RUN_ID}"
+          npm publish --dry-run
 
   publish-npm:
     name: Publish to npm Registry
@@ -186,6 +191,9 @@ jobs:
         run: |
           echo "🧪 DRY RUN MODE - Skipping publication"
           echo "Package would be published: @dollhousemcp/mcp-server@${{ steps.package_version.outputs.version }}"
+          # npm 11 rejects --dry-run for a version that already exists. Use a
+          # run-local version so the complete publish lifecycle remains testable.
+          npm pkg set "version=0.0.0-dry-run.${GITHUB_RUN_ID}"
           npm publish --dry-run
 
       - name: Notify success

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -32,10 +32,6 @@ concurrency:
   group: release-publish-${{ github.workflow }}
   cancel-in-progress: false
 
-permissions:
-  id-token: write   # Required for OIDC/Trusted Publishing
-  contents: read    # Required for checkout
-
 env:
   NODE_OPTIONS: '--max-old-space-size=4096'
   CI: true
@@ -44,6 +40,9 @@ jobs:
   publish-safety:
     name: Publish safety package
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout code
@@ -103,6 +102,9 @@ jobs:
     name: Publish to npm Registry
     needs: publish-safety
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,14 +3,19 @@ name: Publish to npm
 # This workflow publishes the package to npm registry when a release is published.
 # Uses npm Trusted Publishing (OIDC) for secure, token-free authentication.
 #
-# Trusted Publishing Setup Required:
-# 1. Go to https://www.npmjs.com/package/@dollhousemcp/mcp-server/access
-# 2. Add Trusted Publisher:
+# Trusted Publishing Setup Required for both @dollhousemcp/mcp-server and
+# @dollhousemcp/safety:
+# 1. Open each package's settings on npmjs.com.
+# 2. Add the same Trusted Publisher to each package:
 #    - Provider: GitHub Actions
 #    - Organization: DollhouseMCP
 #    - Repository: mcp-server
 #    - Workflow: publish-npm.yml
 #    - Environment: (leave blank)
+#    - Allowed action: npm publish
+#
+# The safety package job completes before the server package job. Existing
+# safety versions are skipped so server-only releases remain idempotent.
 
 on:
   release:
@@ -36,8 +41,67 @@ env:
   CI: true
 
 jobs:
+  publish-safety:
+    name: Publish safety package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js for npm
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: packages/safety/package-lock.json
+        env:
+          NODE_AUTH_TOKEN: ''
+
+      - name: Install safety package dependencies
+        working-directory: packages/safety
+        run: npm ci --ignore-scripts --workspaces=false
+
+      - name: Build safety package
+        working-directory: packages/safety
+        run: npm run build
+
+      - name: Check safety package version
+        id: safety_version
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./packages/safety/package.json').version")
+          REQUIRED_RANGE=$(node -p "require('./package.json').dependencies['@dollhousemcp/safety']")
+          EXPECTED_RANGE="^$VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          if [ "$REQUIRED_RANGE" != "$EXPECTED_RANGE" ]; then
+            echo "needs_publish=false" >> "$GITHUB_OUTPUT"
+            echo "Safety workspace version $VERSION is not the server dependency floor ($REQUIRED_RANGE); skipping."
+          elif npm view "@dollhousemcp/safety@$VERSION" version >/dev/null 2>&1; then
+            echo "needs_publish=false" >> "$GITHUB_OUTPUT"
+            echo "@dollhousemcp/safety@$VERSION is already published; skipping."
+          else
+            echo "needs_publish=true" >> "$GITHUB_OUTPUT"
+            echo "@dollhousemcp/safety@$VERSION is not published yet."
+          fi
+
+      - name: Publish safety package (with provenance)
+        if: github.event.inputs.dry_run != 'true' && steps.safety_version.outputs.needs_publish == 'true'
+        working-directory: packages/safety
+        env:
+          NPM_CONFIG_PROVENANCE: 'true'
+        run: npm publish --provenance --access public --loglevel verbose
+
+      - name: Dry run safety package
+        if: github.event.inputs.dry_run == 'true'
+        working-directory: packages/safety
+        run: npm publish --dry-run
+
   publish-npm:
     name: Publish to npm Registry
+    needs: publish-safety
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -76,15 +76,30 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
           if [ "$REQUIRED_RANGE" != "$EXPECTED_RANGE" ]; then
-            echo "needs_publish=false" >> "$GITHUB_OUTPUT"
-            echo "Safety workspace version $VERSION is not the server dependency floor ($REQUIRED_RANGE); skipping."
-          elif npm view "@dollhousemcp/safety@$VERSION" version >/dev/null 2>&1; then
-            echo "needs_publish=false" >> "$GITHUB_OUTPUT"
-            echo "@dollhousemcp/safety@$VERSION is already published; skipping."
-          else
-            echo "needs_publish=true" >> "$GITHUB_OUTPUT"
-            echo "@dollhousemcp/safety@$VERSION is not published yet."
+            echo "::error::Safety workspace version $VERSION does not match the server dependency floor ($REQUIRED_RANGE). Expected $EXPECTED_RANGE."
+            exit 1
           fi
+
+          for ATTEMPT in 1 2 3; do
+            if LOOKUP_OUTPUT=$(npm view "@dollhousemcp/safety@$VERSION" version 2>&1); then
+              echo "needs_publish=false" >> "$GITHUB_OUTPUT"
+              echo "@dollhousemcp/safety@$VERSION is already published; skipping."
+              exit 0
+            fi
+
+            if printf '%s\n' "$LOOKUP_OUTPUT" | grep -Eq '(^|[[:space:]])E404([[:space:]]|$)|404 Not Found|No match found for version'; then
+              echo "needs_publish=true" >> "$GITHUB_OUTPUT"
+              echo "@dollhousemcp/safety@$VERSION is not published yet."
+              exit 0
+            fi
+
+            if [ "$ATTEMPT" -lt 3 ]; then
+              sleep $((ATTEMPT * 2))
+            fi
+          done
+
+          echo "::error::Unable to verify @dollhousemcp/safety@$VERSION in the npm registry after 3 attempts."
+          exit 1
 
       - name: Publish safety package (with provenance)
         if: github.event.inputs.dry_run != 'true' && steps.safety_version.outputs.needs_publish == 'true'
@@ -94,6 +109,8 @@ jobs:
         run: npm publish --provenance --access public --loglevel verbose
 
       - name: Dry run safety package
+        # Intentionally runs even when the version is already published so the
+        # complete package lifecycle is exercised on demand.
         if: github.event.inputs.dry_run == 'true'
         working-directory: packages/safety
         shell: bash
@@ -149,7 +166,7 @@ jobs:
         shell: bash
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Publishing version: $VERSION"
 
       - name: Debug OIDC Environment

--- a/tests/unit/github-workflow-validation.test.ts
+++ b/tests/unit/github-workflow-validation.test.ts
@@ -232,15 +232,27 @@ describe('GitHub Workflow Validation', () => {
       expect(workflow.jobs['publish-npm'].permissions).toEqual(expectedPermissions);
     });
 
-    it('should publish safety only when its version is absent from npm', () => {
+    it('should fail closed when the safety dependency floor is mismatched', () => {
+      const safetyJob = workflow.jobs['publish-safety'];
+      const versionStep = safetyJob.steps.find(step => step.name === 'Check safety package version');
+
+      expect(versionStep?.run).toContain("dependencies['@dollhousemcp/safety']");
+      expect(versionStep?.run).toContain('EXPECTED_RANGE="^$VERSION"');
+      expect(versionStep?.run).toContain('does not match the server dependency floor');
+      expect(versionStep?.run).toMatch(/if \[ "\$REQUIRED_RANGE" != "\$EXPECTED_RANGE" \]; then[\s\S]*exit 1/);
+    });
+
+    it('should publish safety only after a verified registry absence', () => {
       const safetyJob = workflow.jobs['publish-safety'];
       const versionStep = safetyJob.steps.find(step => step.name === 'Check safety package version');
       const publishStep = safetyJob.steps.find(step => step.name === 'Publish safety package (with provenance)');
 
       expect(versionStep?.run).toContain('@dollhousemcp/safety@$VERSION');
-      expect(versionStep?.run).toContain("dependencies['@dollhousemcp/safety']");
-      expect(versionStep?.run).toContain('REQUIRED_RANGE');
-      expect(versionStep?.run).toContain('EXPECTED_RANGE="^$VERSION"');
+      expect(versionStep?.run).toContain('for ATTEMPT in 1 2 3');
+      expect(versionStep?.run).toContain('E404');
+      expect(versionStep?.run).toContain('No match found for version');
+      expect(versionStep?.run).toContain('sleep $((ATTEMPT * 2))');
+      expect(versionStep?.run).toContain('after 3 attempts');
       expect(versionStep?.run).toContain('needs_publish=false');
       expect(versionStep?.run).toContain('needs_publish=true');
       expect(publishStep?.run).toBe('npm publish --provenance --access public --loglevel verbose');

--- a/tests/unit/github-workflow-validation.test.ts
+++ b/tests/unit/github-workflow-validation.test.ts
@@ -26,6 +26,7 @@ interface WorkflowJob {
   steps: WorkflowStep[];
   env?: Record<string, any>;
   permissions?: Record<string, string> | string;
+  needs?: string | string[];
 }
 
 interface Workflow {
@@ -204,6 +205,45 @@ describe('GitHub Workflow Validation', () => {
       expect(downloadStep?.run).toContain('--certificate-oidc-issuer "$EXPECTED_ISSUER"');
       expect(downloadStep?.run).toContain('EXPECTED_ISSUER');
       expect(downloadStep?.run).toContain('https://token.actions.githubusercontent.com');
+    });
+  });
+
+  describe('Publish to npm Workflow', () => {
+    let workflow: Workflow;
+
+    beforeAll(() => {
+      const workflowPath = path.join(workflowDir, 'publish-npm.yml');
+      workflow = yaml.load(fs.readFileSync(workflowPath, 'utf8')) as Workflow;
+    });
+
+    it('should publish the safety package before the server package', () => {
+      const safetyJob = workflow.jobs['publish-safety'];
+      const serverJob = workflow.jobs['publish-npm'];
+
+      expect(safetyJob).toBeDefined();
+      expect(serverJob.needs).toBe('publish-safety');
+    });
+
+    it('should publish safety only when its version is absent from npm', () => {
+      const safetyJob = workflow.jobs['publish-safety'];
+      const versionStep = safetyJob.steps.find(step => step.name === 'Check safety package version');
+      const publishStep = safetyJob.steps.find(step => step.name === 'Publish safety package (with provenance)');
+
+      expect(versionStep?.run).toContain('@dollhousemcp/safety@$VERSION');
+      expect(versionStep?.run).toContain("dependencies['@dollhousemcp/safety']");
+      expect(versionStep?.run).toContain('REQUIRED_RANGE');
+      expect(versionStep?.run).toContain('EXPECTED_RANGE="^$VERSION"');
+      expect(versionStep?.run).toContain('needs_publish=false');
+      expect(versionStep?.run).toContain('needs_publish=true');
+      expect(publishStep?.run).toBe('npm publish --provenance --access public --loglevel verbose');
+      expect(publishStep?.env?.NPM_CONFIG_PROVENANCE).toBe('true');
+    });
+
+    it('should retain a safety-package dry run path', () => {
+      const safetyJob = workflow.jobs['publish-safety'];
+      const dryRunStep = safetyJob.steps.find(step => step.name === 'Dry run safety package');
+
+      expect(dryRunStep?.run).toBe('npm publish --dry-run');
     });
   });
 });

--- a/tests/unit/github-workflow-validation.test.ts
+++ b/tests/unit/github-workflow-validation.test.ts
@@ -251,7 +251,23 @@ describe('GitHub Workflow Validation', () => {
       const safetyJob = workflow.jobs['publish-safety'];
       const dryRunStep = safetyJob.steps.find(step => step.name === 'Dry run safety package');
 
-      expect(dryRunStep?.run).toBe('npm publish --dry-run');
+      expect(dryRunStep?.shell).toBe('bash');
+      expect(dryRunStep?.run).toContain('version=0.0.0-dry-run.${GITHUB_RUN_ID}');
+      expect(dryRunStep?.run).toContain('npm publish --dry-run');
+    });
+
+    it('should avoid published-version conflicts in both dry-run paths', () => {
+      const safetyDryRun = workflow.jobs['publish-safety'].steps.find(
+        step => step.name === 'Dry run safety package'
+      );
+      const serverDryRun = workflow.jobs['publish-npm'].steps.find(
+        step => step.name === 'Dry run (skip publish)'
+      );
+
+      for (const step of [safetyDryRun, serverDryRun]) {
+        expect(step?.run).toContain('npm pkg set "version=0.0.0-dry-run.${GITHUB_RUN_ID}"');
+        expect(step?.run).toContain('npm publish --dry-run');
+      }
     });
   });
 });

--- a/tests/unit/github-workflow-validation.test.ts
+++ b/tests/unit/github-workflow-validation.test.ts
@@ -224,6 +224,14 @@ describe('GitHub Workflow Validation', () => {
       expect(serverJob.needs).toBe('publish-safety');
     });
 
+    it('should scope OIDC write permission to each publishing job', () => {
+      const expectedPermissions = { 'id-token': 'write', contents: 'read' };
+
+      expect(workflow.permissions).toBeUndefined();
+      expect(workflow.jobs['publish-safety'].permissions).toEqual(expectedPermissions);
+      expect(workflow.jobs['publish-npm'].permissions).toEqual(expectedPermissions);
+    });
+
     it('should publish safety only when its version is absent from npm', () => {
       const safetyJob = workflow.jobs['publish-safety'];
       const versionStep = safetyJob.steps.find(step => step.name === 'Check safety package version');


### PR DESCRIPTION
## Summary

- publish a new `@dollhousemcp/safety` workspace version before the MCP server package
- skip safety publication when the workspace version already exists on npm
- require the server dependency floor to match the safety workspace version before the safety package is eligible for publication
- make the MCP server publication job depend on successful safety-package handling
- preserve dry-run behavior for both packages

This is a general monorepo release-order improvement and contains no vulnerability details.

## Validation

- `npm test -- --runInBand tests/unit/github-workflow-validation.test.ts` (118 passed)
- `npx eslint --max-warnings=0 tests/unit/github-workflow-validation.test.ts`
- `npm run security:audit` (0 findings)
- YAML parsed and structurally validated by the workflow test suite

## Operational prerequisite

Configure npm Trusted Publishing for `@dollhousemcp/safety` with organization `DollhouseMCP`, repository `mcp-server`, workflow `publish-npm.yml`, no environment, and direct `npm publish` permission before using the release workflow.