### PR TITLE
ci: tag prerelease npm dry runs

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -118,7 +118,7 @@ jobs:
           # npm 11 rejects --dry-run for a version that already exists. Use a
           # run-local version so the complete publish lifecycle remains testable.
           npm pkg set "version=0.0.0-dry-run.${GITHUB_RUN_ID}"
-          npm publish --dry-run
+          npm publish --dry-run --tag dry-run
 
   publish-npm:
     name: Publish to npm Registry
@@ -211,7 +211,7 @@ jobs:
           # npm 11 rejects --dry-run for a version that already exists. Use a
           # run-local version so the complete publish lifecycle remains testable.
           npm pkg set "version=0.0.0-dry-run.${GITHUB_RUN_ID}"
-          npm publish --dry-run
+          npm publish --dry-run --tag dry-run
 
       - name: Notify success
         if: success() && github.event.inputs.dry_run != 'true'

--- a/tests/unit/github-workflow-validation.test.ts
+++ b/tests/unit/github-workflow-validation.test.ts
@@ -265,7 +265,7 @@ describe('GitHub Workflow Validation', () => {
 
       expect(dryRunStep?.shell).toBe('bash');
       expect(dryRunStep?.run).toContain('version=0.0.0-dry-run.${GITHUB_RUN_ID}');
-      expect(dryRunStep?.run).toContain('npm publish --dry-run');
+      expect(dryRunStep?.run).toContain('npm publish --dry-run --tag dry-run');
     });
 
     it('should avoid published-version conflicts in both dry-run paths', () => {
@@ -278,7 +278,7 @@ describe('GitHub Workflow Validation', () => {
 
       for (const step of [safetyDryRun, serverDryRun]) {
         expect(step?.run).toContain('npm pkg set "version=0.0.0-dry-run.${GITHUB_RUN_ID}"');
-        expect(step?.run).toContain('npm publish --dry-run');
+        expect(step?.run).toContain('npm publish --dry-run --tag dry-run');
       }
     });
   });


### PR DESCRIPTION
## Summary

- add an explicit non-production dist-tag to both npm prerelease dry-run commands
- keep the real safety and server publication commands unchanged
- strengthen workflow contract tests for the npm 11 requirement

## Why

The first post-hotfix dry run stopped safely because npm 11 requires an explicit tag when simulating publication of the synthetic prerelease version.

## Validation

- `tests/unit/github-workflow-validation.test.ts`: 121 passed
- `git diff --check`
- failed dry-run evidence: Actions run 33933095262

## Release sequencing

This PR is required before rerunning the 2.0.42 npm dry run. No package was published by the failed run.